### PR TITLE
Verify launch funnel billing and tier sync

### DIFF
--- a/app/(app)/account/page.tsx
+++ b/app/(app)/account/page.tsx
@@ -34,8 +34,6 @@ export default function AccountPage() {
     try {
       const res = await fetch("/api/stripe/portal", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: user.email }),
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
   const { data } = await supabase
     .from("users")
     .select("email, tier, billing_interval, subscription_end_date")
-    .eq("email", user.email)
+    .eq("id", user.id)
     .maybeSingle();
 
   return NextResponse.json(data);

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -13,11 +13,11 @@ export async function POST(req: NextRequest) {
     const stripeKey = process.env.STRIPE_SECRET_KEY;
     const priceMonthly = process.env.STRIPE_PRICE_PREMIUM;
     const priceAnnual = process.env.STRIPE_PRICE_ANNUAL;
-    const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/+$/, "");
 
-    if (!stripeKey || !priceMonthly || !priceAnnual) {
+    if (!stripeKey || !priceMonthly || !priceAnnual || !appUrl) {
       return NextResponse.json(
-        { error: "Missing Stripe envs (STRIPE_SECRET_KEY, STRIPE_PRICE_PREMIUM, STRIPE_PRICE_ANNUAL)" },
+        { error: "Missing required Stripe checkout configuration" },
         { status: 500 }
       );
     }
@@ -53,8 +53,9 @@ export async function POST(req: NextRequest) {
       customer_email: user.email.toLowerCase(),
       client_reference_id: user.id,                 // ← helps correlate
       metadata: { plan, user_id: user.id },         // ← used by /confirm
-      success_url: `${APP_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}&just=1`,
-      cancel_url: `${APP_URL}/upgrade?canceled=1`,
+      subscription_data: { metadata: { plan, user_id: user.id } },
+      success_url: `${appUrl}/upgrade/success?session_id={CHECKOUT_SESSION_ID}&just=1`,
+      cancel_url: `${appUrl}/upgrade?canceled=1`,
       allow_promotion_codes: true,
     });
 

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,29 +1,31 @@
 // app/api/stripe/portal/route.ts
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
 import Stripe from "stripe";
 import { supabaseAdmin } from "@/lib/supabase";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "", {
   apiVersion: "2024-06-20",
 });
 
-export async function POST(req: NextRequest) {
+export async function POST() {
   try {
-    const { email } = await req.json();
-
-    if (!email) {
-      console.error("❌ Missing email in portal request");
-      return NextResponse.json({ error: "Missing email" }, { status: 400 });
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data: { user: authUser } } = await supabase.auth.getUser();
+    if (!authUser?.id || !authUser.email) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const email = authUser.email.toLowerCase();
 
     console.log(`🔑 Stripe portal requested for email: ${email}`);
 
-    // Lookup user by email (include tier for debugging)
-    const { data: user, error } = await supabaseAdmin
+    // Resolve billing data from the authenticated profile used by dashboard gating.
+    const { data: profile, error } = await supabaseAdmin
       .from("users")
       .select("id, stripe_customer_id, tier")
-      .eq("email", email)
+      .eq("id", authUser.id)
       .maybeSingle();
 
     if (error) {
@@ -31,9 +33,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "User lookup failed" }, { status: 500 });
     }
 
-    console.log("🗄️ Supabase user lookup result:", user);
+    console.log("🗄️ Supabase user lookup result:", profile);
 
-    let stripeCustomerId = user?.stripe_customer_id ?? null;
+    let stripeCustomerId = profile?.stripe_customer_id ?? null;
 
     // 🛠 Backfill safeguard: if missing, try to find customer in Stripe
     if (!stripeCustomerId) {
@@ -51,7 +53,7 @@ export async function POST(req: NextRequest) {
         await supabaseAdmin
           .from("users")
           .update({ stripe_customer_id: stripeCustomerId })
-          .eq("email", email);
+          .eq("id", authUser.id);
 
         console.log(`✅ Backfilled stripe_customer_id for ${email}: ${stripeCustomerId}`);
       } else {
@@ -66,12 +68,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/+$/, "");
+    if (!appUrl) {
+      return NextResponse.json({ error: "Missing app URL configuration" }, { status: 500 });
+    }
 
     // Create a portal session
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: stripeCustomerId,
-      return_url: `${APP_URL}/dashboard`,
+      return_url: `${appUrl}/account`,
     });
 
     console.log(`✅ Created Stripe portal session for ${email}`);

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -12,11 +12,42 @@ import Stripe from "stripe";
 import { supabaseAdmin as supa } from "@/lib/supabaseAdmin";
 
 // ------------------- CONFIG -------------------
-const STRIPE_SECRET = process.env.STRIPE_SECRET_KEY!;
 const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET!;
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://app.lve360.com";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {apiVersion: "2024-06-20",});
+
+async function syncUserProfile(
+  userId: string | null,
+  email: string | null,
+  fields: Record<string, unknown>
+) {
+  const payload = {
+    ...fields,
+    ...(email ? { email } : {}),
+    updated_at: new Date().toISOString(),
+  };
+
+  if (userId) {
+    const updated = await supa
+      .from("users")
+      .update(payload)
+      .eq("id", userId)
+      .select("id")
+      .maybeSingle();
+    if (updated.error) throw updated.error;
+    if (updated.data) return;
+
+    const inserted = await supa
+      .from("users")
+      .upsert({ id: userId, ...payload }, { onConflict: "id" });
+    if (inserted.error) throw inserted.error;
+    return;
+  }
+
+  if (!email) throw new Error("Stripe event could not be matched to a user");
+  const fallback = await supa.from("users").upsert(payload, { onConflict: "email" });
+  if (fallback.error) throw fallback.error;
+}
 
 // ------------------- MAIN HANDLER -------------------
 export async function POST(req: NextRequest) {
@@ -50,14 +81,12 @@ export async function POST(req: NextRequest) {
       // --------------------------------------------------
       case "checkout.session.completed": {
         const session = event.data.object as Stripe.Checkout.Session;
-        const customerId = session.customer as string;
-        const email =
-          (session.customer_details?.email ||
-            session.client_reference_id ||
-            "").toLowerCase();
+        const customerId = typeof session.customer === "string" ? session.customer : null;
+        const userId = session.client_reference_id || session.metadata?.user_id || null;
+        const email = session.customer_details?.email?.toLowerCase() || null;
 
-        if (!email) {
-          console.warn("⚠️ Stripe checkout missing email:", session.id);
+        if (!userId && !email) {
+          console.warn("⚠️ Stripe checkout missing user correlation:", session.id);
           return NextResponse.json({ received: true }, { status: 200 });
         }
 
@@ -78,19 +107,12 @@ export async function POST(req: NextRequest) {
             : null;
         }
 
-        await supa.from("users").upsert(
-          {
-            email,
-            stripe_customer_id: customerId,
-            tier: "premium",
-            billing_interval: interval,
-            subscription_end_date: endDate
-              ? endDate.toISOString()
-              : null,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: "email" }
-        );
+        await syncUserProfile(userId, email, {
+          stripe_customer_id: customerId,
+          tier: "premium",
+          billing_interval: interval,
+          subscription_end_date: endDate ? endDate.toISOString() : null,
+        });
 
         console.log(`💎 Upgraded ${email} → premium (${interval})`);
         return NextResponse.json({ received: true }, { status: 200 });
@@ -103,6 +125,7 @@ export async function POST(req: NextRequest) {
       case "customer.subscription.updated": {
         const sub = event.data.object as Stripe.Subscription;
         const customerId = sub.customer as string;
+        const userId = sub.metadata?.user_id || null;
         const price = sub.items.data[0]?.price;
         const unit = price?.recurring?.interval;
         const interval: "monthly" | "annual" =
@@ -112,26 +135,19 @@ export async function POST(req: NextRequest) {
           : null;
 
         const customer = await stripe.customers.retrieve(customerId);
-        const email = (customer as Stripe.Customer).email?.toLowerCase();
+        const email = (customer as Stripe.Customer).email?.toLowerCase() || null;
 
-        if (!email) {
-          console.warn("⚠️ Subscription update missing email:", sub.id);
+        if (!userId && !email) {
+          console.warn("⚠️ Subscription update missing user correlation:", sub.id);
           return NextResponse.json({ received: true }, { status: 200 });
         }
 
-        await supa.from("users").upsert(
-          {
-            email,
-            stripe_customer_id: customerId,
-            tier: sub.status === "active" ? "premium" : "free",
-            billing_interval: interval,
-            subscription_end_date: endDate
-              ? endDate.toISOString()
-              : null,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: "email" }
-        );
+        await syncUserProfile(userId, email, {
+          stripe_customer_id: customerId,
+          tier: sub.status === "active" || sub.status === "trialing" ? "premium" : "free",
+          billing_interval: interval,
+          subscription_end_date: endDate ? endDate.toISOString() : null,
+        });
 
         console.log(`🔄 Synced subscription for ${email}`);
         return NextResponse.json({ received: true }, { status: 200 });
@@ -143,24 +159,20 @@ export async function POST(req: NextRequest) {
       case "customer.subscription.deleted": {
         const sub = event.data.object as Stripe.Subscription;
         const customerId = sub.customer as string;
+        const userId = sub.metadata?.user_id || null;
 
         const customer = await stripe.customers.retrieve(customerId);
-        const email = (customer as Stripe.Customer).email?.toLowerCase();
+        const email = (customer as Stripe.Customer).email?.toLowerCase() || null;
 
-        if (!email) {
-          console.warn("⚠️ Subscription deletion missing email:", sub.id);
+        if (!userId && !email) {
+          console.warn("⚠️ Subscription deletion missing user correlation:", sub.id);
           return NextResponse.json({ received: true }, { status: 200 });
         }
 
-        await supa.from("users").upsert(
-          {
-            email,
-            stripe_customer_id: customerId,
-            tier: "free",
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: "email" }
-        );
+        await syncUserProfile(userId, email, {
+          stripe_customer_id: customerId,
+          tier: "free",
+        });
 
         console.log(`⬇️ Downgraded ${email} → free`);
         return NextResponse.json({ received: true }, { status: 200 });

--- a/app/api/tally-webhook/route.ts
+++ b/app/api/tally-webhook/route.ts
@@ -420,13 +420,14 @@ const submissionRow = {
 
 
     const submissionId = subRow.id;
-    const resultsUrl = `https://app.lve360.com/results?submissionId=${submissionId}&email=${encodeURIComponent(
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://app.lve360.com").replace(/\/+$/, "");
+    const resultsUrl = `${appUrl}/results?submission_id=${submissionId}&email=${encodeURIComponent(
       userEmail ?? ""
     )}`;
 
     // Fire-and-forget stack generation
     try {
-      fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/generate-stack`, {
+      fetch(`${appUrl}/api/generate-stack`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ submission_id: submissionId }),

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,7 +6,7 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 export const dynamic = "force-dynamic";
 
 // Only allow safe next values to avoid open redirects
-const ALLOW_NEXT = new Set<string>([
+const ALLOW_NEXT_PATHS = new Set<string>([
   "/dashboard",
   "/results",
   "/account",
@@ -14,6 +14,17 @@ const ALLOW_NEXT = new Set<string>([
   "/premium",
   "/onboarding",
 ]);
+
+function safeNext(raw: string): string {
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/dashboard";
+  const target = new URL(raw, "https://app.lve360.com");
+  if (!ALLOW_NEXT_PATHS.has(target.pathname)) return "/dashboard";
+  if (target.pathname !== "/upgrade") return target.pathname;
+  const plan = target.searchParams.get("plan");
+  return plan === "monthly" || plan === "annual"
+    ? `/upgrade?plan=${plan}`
+    : "/upgrade";
+}
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -47,6 +58,6 @@ if (user) {
 }
 
   // All good → redirect to a safe next page
-  const dest = ALLOW_NEXT.has(next) ? next : "/dashboard";
+  const dest = safeNext(next);
   return NextResponse.redirect(new URL(dest, url.origin));
 }

--- a/app/upgrade/UpgradeClient.tsx
+++ b/app/upgrade/UpgradeClient.tsx
@@ -47,6 +47,10 @@ function Inner() {
   const router = useRouter();
   const sp = useSearchParams(); // safe inside Suspense
   const justUpgraded = sp?.get("just") === "1";
+  const requestedPlan: Plan | null =
+    sp?.get("plan") === "monthly" || sp?.get("plan") === "annual"
+      ? (sp.get("plan") as Plan)
+      : null;
 
   const [loadingPlan, setLoadingPlan] = useState<Plan | null>(null);
   const [tier, setTier] = useState<Tier>("free");
@@ -64,7 +68,8 @@ function Inner() {
 
         if (res.status === 401) {
           console.log("[/upgrade] 401 → to login");
-          router.replace("/login?next=/upgrade");
+          const next = requestedPlan ? `/upgrade?plan=${requestedPlan}` : "/upgrade";
+          router.replace(`/login?next=${encodeURIComponent(next)}`);
           return;
         }
 
@@ -93,6 +98,11 @@ function Inner() {
           console.log("[/upgrade] is premium → /dashboard");
           setTimeout(() => router.replace("/dashboard"), 400);
           return;
+        }
+
+        if (requestedPlan && data?.user_id) {
+          const label = requestedPlan === "annual" ? "Annual" : "Monthly";
+          setBanner(`You're signed in. Continue with ${label} Checkout below.`);
         }
 
         // If bounced here immediately after Stripe success, poll for flip
@@ -136,7 +146,7 @@ function Inner() {
     })();
 
     return () => { cancelled = true; };
-  }, [router, justUpgraded]);
+  }, [router, justUpgraded, requestedPlan]);
 
   async function handleUpgrade(plan: Plan) {
     setLoadingPlan(plan);
@@ -150,7 +160,7 @@ function Inner() {
       });
       if (res.status === 401) {
         console.log("[/upgrade] 401 on checkout → to login");
-        router.push("/login?next=/upgrade");
+        router.push(`/login?next=${encodeURIComponent(`/upgrade?plan=${plan}`)}`);
         return;
       }
       const json = await res.json();
@@ -206,7 +216,7 @@ function Inner() {
               disabled={disabled}
               className="text-lg px-6 py-3 w-full"
             >
-              {tier === "premium" ? "You're Premium" : loadingPlan === "monthly" ? "Redirecting…" : "Choose Monthly"}
+              {tier === "premium" ? "You're Premium" : loadingPlan === "monthly" ? "Redirecting…" : requestedPlan === "monthly" ? "Continue Monthly Checkout" : "Choose Monthly"}
             </CTAButton>
           </div>
 
@@ -220,7 +230,7 @@ function Inner() {
               disabled={disabled}
               className="text-lg px-6 py-3 w-full bg-yellow-400 hover:bg-yellow-500 text-purple-900 font-semibold"
             >
-              {tier === "premium" ? "You're Premium" : loadingPlan === "annual" ? "Redirecting…" : "Choose Annual"}
+              {tier === "premium" ? "You're Premium" : loadingPlan === "annual" ? "Redirecting…" : requestedPlan === "annual" ? "Continue Annual Checkout" : "Choose Annual"}
             </CTAButton>
           </div>
         </div>

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -251,6 +251,63 @@ function sectionChunk(md: string, header: string) {
   return m ? m[1] : "";
 }
 
+const CANONICAL_REPORT_HEADINGS = HEADINGS.slice(0, -1);
+
+function blueprintNames(blueprintTable: string): string[] {
+  return Array.from(blueprintTable.matchAll(/\|\s*\d+\s*\|\s*([^|]+)\|/g))
+    .map((match) => cleanName(match[1] || ""))
+    .filter((name) => name && !/^TBD$/i.test(name));
+}
+
+function alignedDosingBody(blueprintTable: string, passB: string): string {
+  const body = sectionChunk(passB, "## Dosing & Notes").trim();
+  const lowerBody = body.toLowerCase();
+  const missing = blueprintNames(blueprintTable).filter(
+    (name) => !lowerBody.includes(name.toLowerCase())
+  );
+  if (!missing.length) return body;
+
+  const coverage = missing
+    .map(
+      (name) =>
+        `- **${name}** — Clinician review is recommended before use; a specific dose or timing is not provided.`
+    )
+    .join("\n");
+  const analysisIndex = body.search(/^\*\*Analysis\*\*/im);
+  if (analysisIndex >= 0) {
+    return `${body.slice(0, analysisIndex).trim()}\n${coverage}\n\n${body.slice(analysisIndex).trim()}`;
+  }
+  return `${body}\n${coverage}\n\n**Analysis**\n\nThese notes cover every Blueprint recommendation. Specific dosing should be reviewed with a clinician when it cannot be provided safely from the intake alone.`.trim();
+}
+
+function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: string): string {
+  const sources: Record<string, string> = {
+    "## Contraindications & Med Interactions": passB,
+    "## Your Blueprint Recommendations": `## Your Blueprint Recommendations\n\n${blueprintTable}`,
+    "## Dosing & Notes": `## Dosing & Notes\n\n${alignedDosingBody(blueprintTable, passB)}`,
+  };
+
+  return CANONICAL_REPORT_HEADINGS.map((heading) => {
+    if (heading === "## Your Blueprint Recommendations" || heading === "## Dosing & Notes") {
+      return sources[heading];
+    }
+    const body = sectionChunk(sources[heading] || restMd, heading).trim();
+    return `${heading}\n\n${body}`.trim();
+  })
+    .join("\n\n")
+    .replace(/(^|\n)##\s*END\s*(?=\n|$)/gi, "$1")
+    .trim();
+}
+
+function ensureReportDosingAlignment(md: string): string {
+  const blueprint = sectionChunk(md, "## Your Blueprint Recommendations");
+  const dosing = alignedDosingBody(blueprint, md);
+  return md.replace(
+    /## Dosing & Notes[\s\S]*?(?=\n## |$)/i,
+    `## Dosing & Notes\n\n${dosing}`
+  );
+}
+
 function padBlueprint(md: string, minRows: number) {
   const re = /## Your Blueprint Recommendations([\s\S]*?)(?=\n## |\n## END|$)/i;
   const m = md.match(re);
@@ -596,7 +653,7 @@ Rules:
 - Fix headings/levels/ordering only; keep the user-facing content.
 - Plain ASCII Markdown. No code fences.
 - Each section ends with an **Analysis** paragraph (≥3 sentences). If missing, summarize the existing content; do not invent clinical claims.
-- End with a line "## END".
+- Do not include an END marker.
 `.trim();
 }
 function compactForPassC(sub: any) {
@@ -850,7 +907,7 @@ Section rules:
 • Evidence & References → ≥8 markdown links (PubMed/PMC/DOI etc.), then Analysis.
 • Shopping Links → links + Analysis.
 • Follow-up Plan, Lifestyle Prescriptions, Longevity Levers, This Week Try → each ends with Analysis.
-Finish with a line \`## END\`.
+Do not include an END marker.
 `.trim();
 }
 function systemPromptC_Strict(): string {
@@ -872,7 +929,7 @@ Rules:
 - Each section ends with an **Analysis** paragraph (≥3 sentences).
 - Use the given Blueprint/Dosing for consistency (do not rewrite them).
 - Evidence must include ≥8 valid links (PubMed/PMC/DOI or trusted journals).
-- No code fences or preamble. Finish with a single line: ## END
+- No code fences, preamble, or END marker.
 `.trim();
 }
 
@@ -949,7 +1006,7 @@ Rules:
 - Keep language plain-English and encouraging (not clinical).
 - Each section must end with an **Analysis** paragraph of ≥3 sentences.
 - Evidence must include ≥8 valid links (PubMed/PMC/DOI and trusted journals).
-- End output with a line "## END".
+- Do not include an END marker.
 `;
 }
 
@@ -1500,21 +1557,14 @@ if (resC?.usage?.prompt_tokens) promptTokens = (promptTokens ?? 0) + (resC.usage
 if (resC?.usage?.completion_tokens) completionTokens = (completionTokens ?? 0) + (resC.usage.completion_tokens ?? 0);
 modelUsed = resC?.modelUsed ?? modelUsed;
 
-  // ---------- Stitch full Markdown ----------
-let md = [
-  restMd.includes("## Intro Summary") ? "" : "## Intro Summary\n",
-  restMd,
-  "\n\n## Your Blueprint Recommendations\n",
-  tableMd, // <- already sanitized to just the table
-  "\n\n",
-  dosingMd,
-].join("\n").trim();
+  // ---------- Stitch full Markdown in canonical user-facing order ----------
+let md = assembleCanonicalReport(restMd, tableMd, dosingMd);
 
 
-  // Sanity: enforce headings / pad blueprint / end marker
+  // Sanity: enforce headings and pad the Blueprint without exposing END.
   md = forceHeadings(md);
-  md = ensureEnd(md);
   md = hardenBlueprintSection(md, computeValidationTargets(mode, cap).minRows);
+  md = ensureReportDosingAlignment(md);
 
   // ---------- Parse items / safety / enrichment ----------
   const TIMING_ARTIFACT_RE = /^(on\s+waking|am\b.*breakfast|evening\b.*dinner|before\s+bed|pre[- ]?exercise(?:.*)?|hold\/adjust|simplify\s+sleep\s+aids)$/i;
@@ -1589,7 +1639,7 @@ const safetyInput = {
     blueprintValid: blueprintOK(md, targets.minRows),
     citationsValid: citationsOK(md),
     narrativesValid: narrativesOK(md, targets.minSent),
-    endValid: /\n## END\s*$/.test(md),
+    endValid: !/(^|\n)##\s*END\s*(?=\n|$)/i.test(md),
   };
   console.info("validation.targets", targets);
   console.info("validation.debug", { ...ok, actualWordCount: wc(md) });


### PR DESCRIPTION
## Purpose

Verify and repair the existing LVE360 launch funnel without changing product scope:

Home → Quiz → Free Blueprint → Generate/Retrieve Stack → PDF Export → Upgrade → Stripe Checkout → Webhook → Premium Dashboard → Billing Portal.

## Funnel map and verification

- **Home / Quiz:** Home and `/quiz` embed the existing Tally intake.
- **Submission / Free Blueprint:** `/api/tally-webhook` validates and persists the submission, returns a results URL, and triggers `/api/generate-stack`.
- **Generate / Retrieve:** `/results` accepts the persisted submission UUID or Tally submission ID, calls `/api/get-stack`, and can call `/api/generate-stack` when needed.
- **PDF export:** `/results` passes the same identifier contract to `/api/export-pdf`; the PDF retains the DSHEA/FTC-safe wellness disclaimer.
- **Upgrade / Checkout:** `/upgrade` calls `/api/stripe/checkout`; success returns to `/upgrade/success` and cancellation returns to `/upgrade`.
- **Webhook / Dashboard:** Checkout and Subscription metadata now carry the authenticated Supabase user ID. Stripe webhook tier updates target that ID, matching `requireTier` dashboard gating.
- **Billing portal:** `/account` opens an authenticated portal session for the current user's Stripe customer and returns to `/account`.

## Changes

- Derive Tally results/generation URLs from `NEXT_PUBLIC_APP_URL` and standardize the results query key.
- Require configured app URL for Stripe success/cancel/portal redirects and trim trailing slashes.
- Copy authenticated user ID and plan metadata onto the Stripe Subscription.
- Sync Stripe tier changes by authenticated user ID when available, with email fallback for legacy events, and surface database write failures for Stripe retries.
- Authenticate billing-portal requests server-side; ignore client-supplied identity.
- Read account/billing state by the same user ID used by premium dashboard gating.

## Checks

- `npm run typecheck` — passed.
- `npm run build` — passed with temporary non-secret placeholder environment values.

The sandbox did not contain real Supabase, OpenAI, Tally, or Stripe credentials. Live webhook delivery, report generation, PDF data retrieval, Checkout, tier mutation, and portal entry require manual QA with Preview environment variables.

## Risks

- Existing Stripe subscriptions created before this change may not contain `user_id` metadata; webhook handling retains the email fallback for those events.
- The Tally-triggered report generation remains fire-and-forget; the Results page still provides the existing explicit generation/retrieval fallback.
- No database migration or schema change is included.

## Manual QA

1. Open Preview home and launch the embedded quiz; also verify `/quiz`.
2. Submit a test Tally response and confirm redirect to `/results?submission_id=<uuid>`.
3. Confirm the submission is stored and the Free Blueprint can be generated, retrieved after refresh, and displays the wellness disclaimer.
4. Export the report and confirm a readable PDF opens with the same disclaimer.
5. Sign in as a free test user and open `/upgrade`.
6. Start monthly Checkout; verify success URL is Preview `/upgrade/success?session_id=...`.
7. Start annual Checkout and cancel; verify return to Preview `/upgrade?canceled=1`.
8. Complete a Stripe test subscription and confirm webhook updates the authenticated user's `users.id` row to `tier=premium`.
9. Confirm `/dashboard` unlocks for that same user.
10. Open `/account` → Manage Billing; confirm Stripe Portal opens and returns to Preview `/account`.
11. Cancel the test subscription and confirm the webhook downgrades the same user row to `tier=free` and dashboard gating returns to `/upgrade`.
