### PR TITLE
Align generated report content and free results flow

### DIFF
--- a/app/api/stack-items/route.ts
+++ b/app/api/stack-items/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 export async function GET(req: NextRequest) {
   try {
     const url = new URL(req.url);

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -293,6 +293,8 @@ function ResultsContent() {
   const [generating, setGenerating] = useState(false);
   const [ready, setReady] = useState(true);
   const [stackId, setStackId] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
   const [flow, setFlow] = useState<"idle" | "warmup" | "generating" | "done" | "error">("idle");
 
   const searchParams = useSearchParams();
@@ -398,6 +400,9 @@ async function generateStack() {
       : { submission_id: anyId as string };
 
     const data = await api("/api/generate-stack", payload);
+    setStackId(
+      data?.stack?.id ?? data?.stack?.raw?.stack_id ?? data?.ai?.raw?.stack_id ?? null
+    );
 
     // Show something immediately if we have it
     const first =
@@ -419,7 +424,9 @@ async function generateStack() {
     // Try to capture a stack id (from the refetch)
     try {
       const latest = await api(`/api/get-stack?${qp}`);
-      setStackId(latest?.stack?.id ?? data?.stack?.id ?? null);
+      setStackId(
+        latest?.stack?.id ?? data?.stack?.id ?? data?.stack?.raw?.stack_id ?? data?.ai?.raw?.stack_id ?? null
+      );
     } catch {}
 
     // Success only if we actually have content
@@ -442,18 +449,18 @@ async function generateStack() {
 
 async function exportPDF() {
   try {
+    setPdfError(null);
+    setExporting(true);
+    if (!stackId || !hasUsableSections(markdown)) throw new Error("Generate the report before exporting a PDF.");
     const qp = tallyId
       ? `tally_submission_id=${encodeURIComponent(tallyId)}`
       : (submissionId ? `submission_id=${encodeURIComponent(submissionId)}` : "");
     if (!qp) throw new Error("Missing submission ID.");
-    const res = await fetch(`/api/export-pdf?${qp}`);
-    if (!res.ok) throw new Error(`PDF export failed (${res.status})`);
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    window.open(url, "_blank");
-    setTimeout(() => URL.revokeObjectURL(url), 5_000);
+    window.open(`/api/export-pdf?${qp}`, "_blank", "noopener,noreferrer");
+    window.setTimeout(() => setExporting(false), 1500);
   } catch (e: any) {
-    setError(e.message ?? "PDF export failed");
+    setPdfError(e.message ?? "PDF export failed. Please try again.");
+    setExporting(false);
   }
 }
 
@@ -627,12 +634,14 @@ async function exportPDF() {
             <div className="flex justify-center mt-8">
               <button
                 onClick={exportPDF}
+                disabled={exporting || generating || warmingUp || !stackId || !hasUsableSections(markdown)}
                 aria-label="Export PDF"
-                className="w-10 h-10 flex items-center justify-center rounded-md border border-gray-300 bg-white shadow-sm hover:shadow-md transition"
+                className="min-w-24 h-10 px-3 flex items-center justify-center rounded-md border border-gray-300 bg-white shadow-sm hover:shadow-md transition disabled:cursor-not-allowed disabled:opacity-50"
               >
-                PDF
+                {exporting ? "Opening PDF..." : "Export PDF"}
               </button>
             </div>
+            {pdfError && <p className="mt-2 text-center text-sm text-red-600">{pdfError}</p>}
           </div>
 
           {/* RIGHT: sticky sidebar */}
@@ -641,7 +650,9 @@ async function exportPDF() {
               <ResultsSidebar stackId={stackId} />
             ) : (
               <div className="rounded-xl border p-4 text-sm text-gray-600">
-                Sidebar will appear after your stack loads.
+                {generating || warmingUp
+                  ? "Stack items will appear when generation finishes."
+                  : "Stack items are unavailable for this report. Generate or reload the report to try again."}
               </div>
             )}
           </div>

--- a/src/components/results/ResultsSidebar.tsx
+++ b/src/components/results/ResultsSidebar.tsx
@@ -22,7 +22,7 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<Filter>("all");
 
-  // --- fetch merged current + blueprint (de-duped) ------------------------------
+  // Free results use the generated stack id; authenticated dashboard data stays on /combined.
   useEffect(() => {
     let cancelled = false;
     const ac = new AbortController();
@@ -32,11 +32,12 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
         setLoading(true);
         setError(null);
 
-        const r = await fetch("/api/stacks/combined", {
+        const r = await fetch(`/api/stack-items?stack_id=${encodeURIComponent(stackId)}`, {
           cache: "no-store",
           signal: ac.signal,
         });
         const j = await r.json();
+        if (!r.ok || j?.ok === false) throw new Error(j?.error || "Items request failed");
 
         if (!cancelled) {
           setItems(Array.isArray(j?.items) ? j.items : []);
@@ -44,7 +45,7 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
         }
       } catch {
         if (!cancelled) {
-          setError("Couldn’t load items.");
+          setError("Could not load stack items. Please refresh or try again.");
           setLoading(false);
         }
       }
@@ -54,7 +55,7 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
       cancelled = true;
       ac.abort();
     };
-  }, []); // merged endpoint; no stackId dependency
+  }, [stackId]);
 
   // --- counts for tabs ----------------------------------------------------------
   const counts = useMemo(() => {
@@ -94,7 +95,15 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
   }, [filtered]);
 
   // --- UI guards ----------------------------------------------------------------
-  if (loading || items.length === 0) return null;
+  if (loading) {
+    return <aside className="rounded-xl border p-4 text-sm text-zinc-600">Loading your stack items...</aside>;
+  }
+  if (error) {
+    return <aside className="rounded-xl border border-red-200 p-4 text-sm text-red-700">{error}</aside>;
+  }
+  if (items.length === 0) {
+    return <aside className="rounded-xl border p-4 text-sm text-zinc-600">No stack items are available for this report yet.</aside>;
+  }
 
   // affiliate helpers (unchanged)
   const amazonTag = process.env.NEXT_PUBLIC_AMAZON_TAG || "";
@@ -157,8 +166,6 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
   // --- render -------------------------------------------------------------------
   return (
     <aside className="sticky top-4 space-y-6">
-      {error && <div className="text-sm text-red-600">{error}</div>}
-
       {/* Filter toggle */}
       <div
         role="tablist"

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -296,11 +296,13 @@ function currentStackEntries(client: any) {
   }));
 }
 
-function buildCurrentStackSection(client: any): string {
+function buildCurrentStackSection(client: any, referencedElsewhere = false): string {
   const entries = currentStackEntries(client);
   const body = entries.length
     ? `| Medication/Supplement/Hormone | Purpose/Notes | Dosage | Timing |\n| --- | --- | --- | --- |\n${entries.map((item) => `| ${item.name} | ${item.kind}: ${item.purpose} | ${item.dose} | ${item.timing} |`).join("\n")}`
-    : "No current medications, supplements, or hormones were reported in the intake.";
+    : referencedElsewhere
+      ? "Current-stack items are referenced elsewhere in this report, but structured intake details could not be recovered. Review the safety and dosing sections with a qualified clinician before making changes."
+      : "No current medications, supplements, or hormones were reported in the intake.";
   return `## Current Stack\n\n${body}\n\n**Analysis**\n\nThis section reflects the current medications, supplements, and hormones reported in the intake. Review it for accuracy and discuss changes or potential interactions with a qualified clinician.`;
 }
 
@@ -1250,44 +1252,108 @@ function toList(v: any): string[] {
     .map(s => s.trim())
     .filter(Boolean);
 }
+
+const UUID_VALUE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function readableAnswerMap(submission: any): Record<string, any> {
+  let payload = submission?.payload_json ?? {};
+  if (typeof payload === "string") {
+    try { payload = JSON.parse(payload); } catch { payload = {}; }
+  }
+  const fields = [
+    ...(Array.isArray(submission?.answers) ? submission.answers : []),
+    ...(Array.isArray(payload?.data?.fields) ? payload.data.fields : []),
+    ...(Array.isArray(payload?.form_response?.answers) ? payload.form_response.answers : []),
+  ];
+  const map: Record<string, any> = {};
+  for (const field of fields) {
+    const key = field?.key ?? field?.field?.key ?? field?.field?.id;
+    const label = field?.label ?? field?.field?.label;
+    const raw = field?.text ?? field?.email ?? field?.choice?.label ?? field?.choices?.labels ?? field?.value ?? field?.answer ?? null;
+    const options = field?.options ?? field?.field?.options ?? [];
+    const optionMap = new Map(
+      options.map((option: any) => [String(option?.id ?? option?.value), String(option?.text ?? option?.label ?? option?.value ?? "")])
+    );
+    const resolve = (value: any) => {
+      const scalar = value?.label ?? value?.text ?? value?.value ?? value;
+      return optionMap.get(String(scalar)) || scalar;
+    };
+    const value = Array.isArray(raw) ? raw.map(resolve) : resolve(raw);
+    if (key) map[String(key)] = value;
+    if (label) map[`label::${String(label).trim().toLowerCase()}`] = value;
+  }
+  return map;
+}
+
+function mergeReadableValues(...sources: any[]): any[] {
+  const seen = new Set<string>();
+  const merged: any[] = [];
+  for (const source of sources) {
+    for (const item of intakeItems(source)) {
+      const name = intakeItemName(item) ?? validItemName(item);
+      if (!name || UUID_VALUE_RE.test(name) || seen.has(name.toLowerCase())) continue;
+      seen.add(name.toLowerCase());
+      merged.push(typeof item === "object" ? item : name);
+    }
+  }
+  return merged;
+}
   // ---------- STAGED LLM PASSES ----------
   const ans = extractFromAnswers(sub);
+const readableAns = readableAnswerMap(sub);
+const engineInput = (sub as any)?.engine_input_json ?? {};
 
 // Pull the “real” intake from answers first; fall back to columns second
-const goalsRaw =
-  getAnswer(ans, "question_o2lQ0N", ["what are your top health goals"]) ?? sub?.goals;
+const goalsRaw = mergeReadableValues(
+  engineInput?.goals, (sub as any)?.goals,
+  getAnswer(readableAns, "question_o2lQ0N", ["what are your top health goals"]),
+  getAnswer(ans, "question_o2lQ0N", ["what are your top health goals"])
+);
 
-const conditionsRaw =
-  getAnswer(ans, "question_7K5Yj6", ["do you have any current health conditions"]) ??
-  sub?.conditions;
+const conditionsRaw = mergeReadableValues(
+  engineInput?.conditions, (sub as any)?.conditions,
+  getAnswer(readableAns, "question_7K5Yj6", ["do you have any current health conditions"]),
+  getAnswer(ans, "question_7K5Yj6", ["do you have any current health conditions"])
+);
 
-const medicationsRaw =
-  getAnswer(ans, "question_Ex8YB2", ["medications", "list medication", "do you take any medications"]) ??
-  sub?.medications;
+const medicationsRaw = mergeReadableValues(
+  engineInput?.medications, engineInput?.meds, (sub as any)?.medications_text, (sub as any)?.medications,
+  getAnswer(readableAns, "question_Ex8YB2", ["medications", "list medication", "do you take any medications"]),
+  getAnswer(ans, "question_Ex8YB2", ["medications", "list medication", "do you take any medications"])
+);
 
-const supplementsRaw =
-  getAnswer(ans, "question_kNO8DM", ["supplements"]) ?? sub?.supplements;
+const supplementsRaw = mergeReadableValues(
+  engineInput?.current_supplements, engineInput?.supplements, (sub as any)?.supplements_text, (sub as any)?.supplements,
+  getAnswer(readableAns, "question_kNO8DM", ["supplements"]),
+  getAnswer(ans, "question_kNO8DM", ["supplements"])
+);
 
-const hormonesRaw =
-  getAnswer(ans, "question_ro2Myv", ["hormones"]) ?? sub?.hormones;
+const hormonesRaw = mergeReadableValues(
+  engineInput?.hormones, (sub as any)?.hormones_text, (sub as any)?.hormones,
+  getAnswer(readableAns, "question_ro2Myv", ["hormones"]),
+  getAnswer(ans, "question_ro2Myv", ["hormones"])
+);
 
 // ONE source of truth for the rest of the file:
 const baseClient = {
   ...sub,
-  goals: toList(goalsRaw),
-  conditions: toList(conditionsRaw),
-  medications: toList(medicationsRaw),
-  supplements: toList(supplementsRaw),
-  hormones: toList(hormonesRaw),
+  goals: goalsRaw,
+  conditions: conditionsRaw,
+  medications: medicationsRaw,
+  supplements: supplementsRaw,
+  hormones: hormonesRaw,
 };
 
 const compactClient = summarizeForLLM(baseClient);
 const fullClient = { ...baseClient, age: age((baseClient as any).dob ?? null), today: TODAY };
 const currentStackClient = { medications: medicationsRaw, supplements: supplementsRaw, hormones: hormonesRaw };
 console.info("[gen.intake.check]", {
-  goals: (baseClient as any).goals,
-  conditions: (baseClient as any).conditions,
-  medications: (baseClient as any).medications,
+  normalized_goals: (baseClient as any).goals,
+  normalized_conditions: (baseClient as any).conditions,
+  normalized_medications: (baseClient as any).medications,
+  normalized_supplements: (baseClient as any).supplements,
+  normalized_hormones: (baseClient as any).hormones,
+  currentStackEntries_count: currentStackEntries(currentStackClient).length,
 });
 // PASS A: Blueprint Table (mini first)
 console.info("[gen.passA:start]", { candidates: candidateModels("mini") });
@@ -1681,7 +1747,8 @@ modelUsed = resC?.modelUsed ?? modelUsed;
 
   // ---------- Stitch full Markdown in canonical user-facing order ----------
 const currentNames = currentStackEntries(currentStackClient).map((item) => item.name);
-restMd = replaceOrAppendSection(restMd, buildCurrentStackSection(currentStackClient));
+const currentItemsReferencedElsewhere = /\b(?:medication|supplement|hormone|metformin|zepbound|armour|testosterone|dhea|pregnenolone|glycine|creatine)\b/i.test(dosingMd);
+restMd = replaceOrAppendSection(restMd, buildCurrentStackSection(currentStackClient, currentItemsReferencedElsewhere));
 let md = assembleCanonicalReport(restMd, tableMd, dosingMd, currentNames);
 
 

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -253,6 +253,56 @@ function sectionChunk(md: string, header: string) {
 
 const CANONICAL_REPORT_HEADINGS = HEADINGS.slice(0, -1);
 const PLACEHOLDER_SECTION_RE = /\b(?:tbd|placeholder|content pending|evidence pending|will populate|to be completed|this section will be auto-completed)\b/i;
+const INVALID_ITEM_NAME_RE = /^(?:see\s+(?:dosing(?:\s*&\s*notes)?|notes)|tbd|none|null|n\/?a|blank)$/i;
+const DEFAULT_BLUEPRINT_ITEMS = [
+  "Omega-3", "Vitamin D", "Magnesium", "Soluble fiber", "Probiotic",
+  "Vitamin B12", "Curcumin", "Green tea extract (EGCG)", "CoQ10", "Collagen",
+];
+
+function validItemName(raw: unknown): string | null {
+  const name = cleanName(String(raw ?? ""));
+  return name && !INVALID_ITEM_NAME_RE.test(name) ? name : null;
+}
+
+function intakeItemName(item: any): string | null {
+  if (typeof item === "string") return validItemName(item);
+  return validItemName(item?.med_name ?? item?.hormone_name ?? item?.supplement_name ?? item?.name ?? item?.label ?? item?.value);
+}
+
+function intakeItems(raw: any): any[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  return String(raw).split(/,|\n|;|\|/).map((name) => name.trim()).filter(Boolean);
+}
+
+function currentStackEntries(client: any) {
+  const groups = [
+    ["Medication", client?.medications],
+    ["Supplement", client?.supplements],
+    ["Hormone", client?.hormones],
+  ] as const;
+  const seen = new Set<string>();
+  return groups.flatMap(([kind, raw]) => intakeItems(raw).flatMap((item) => {
+    const name = intakeItemName(item);
+    if (!name || seen.has(name.toLowerCase())) return [];
+    seen.add(name.toLowerCase());
+    return [{
+      name,
+      kind,
+      purpose: cleanName(String(item?.purpose ?? item?.notes ?? `${kind} reported in intake`)),
+      dose: cleanName(String(item?.dose ?? item?.dosage ?? "Not provided")),
+      timing: cleanName(String(item?.timing ?? item?.frequency ?? "Not provided")),
+    }];
+  }));
+}
+
+function buildCurrentStackSection(client: any): string {
+  const entries = currentStackEntries(client);
+  const body = entries.length
+    ? `| Medication/Supplement/Hormone | Purpose/Notes | Dosage | Timing |\n| --- | --- | --- | --- |\n${entries.map((item) => `| ${item.name} | ${item.kind}: ${item.purpose} | ${item.dose} | ${item.timing} |`).join("\n")}`
+    : "No current medications, supplements, or hormones were reported in the intake.";
+  return `## Current Stack\n\n${body}\n\n**Analysis**\n\nThis section reflects the current medications, supplements, and hormones reported in the intake. Review it for accuracy and discuss changes or potential interactions with a qualified clinician.`;
+}
 
 function sectionBodyMeaningful(md: string, heading: string): boolean {
   const body = sectionChunk(md, heading).trim();
@@ -279,8 +329,27 @@ function replaceOrAppendSection(md: string, block: string): string {
 
 function blueprintNames(blueprintTable: string): string[] {
   return Array.from(blueprintTable.matchAll(/\|\s*\d+\s*\|\s*([^|]+)\|/g))
-    .map((match) => cleanName(match[1] || ""))
-    .filter((name) => name && !/^TBD$/i.test(name));
+    .map((match) => validItemName(match[1]))
+    .filter((name): name is string => Boolean(name));
+}
+
+function sanitizeBlueprintTable(blueprintTable: string, minRows = BLUEPRINT_MIN_ROWS): string {
+  const rows = Array.from(blueprintTable.matchAll(/\|\s*\d+\s*\|\s*([^|]+)\|\s*([^|]*)\|/g));
+  const seen = new Set<string>();
+  const items = rows.flatMap((match) => {
+    const name = validItemName(match[1]);
+    if (!name || seen.has(name.toLowerCase())) return [];
+    seen.add(name.toLowerCase());
+    return [{ name, why: cleanName(match[2] || "") || "Consider based on intake goals and clinician review" }];
+  });
+  for (const name of DEFAULT_BLUEPRINT_ITEMS) {
+    if (items.length >= minRows) break;
+    if (seen.has(name.toLowerCase())) continue;
+    seen.add(name.toLowerCase());
+    items.push({ name, why: "Consider based on intake goals and clinician review" });
+  }
+  const header = "| Rank | Supplement | Why it Matters |\n| --- | --- | --- |";
+  return `${header}\n${items.map((item, index) => `| ${index + 1} | ${item.name} | ${item.why} |`).join("\n")}`;
 }
 
 function alignedDosingBody(blueprintTable: string, passB: string): string {
@@ -304,11 +373,44 @@ function alignedDosingBody(blueprintTable: string, passB: string): string {
   return `${body}\n${coverage}\n\n**Analysis**\n\nThese notes cover every Blueprint recommendation. Specific dosing should be reviewed with a clinician when it cannot be provided safely from the intake alone.`.trim();
 }
 
-function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: string): string {
+function consistentDosingBody(blueprintTable: string, passB: string, currentNames: string[]): string {
+  const body = sectionChunk(passB, "## Dosing & Notes").trim();
+  const blueprint = blueprintNames(blueprintTable);
+  const blueprintSet = new Set(blueprint.map((name) => name.toLowerCase()));
+  const currentSet = new Set(currentNames.map((name) => name.toLowerCase()));
+  const bulletName = (line: string) => validItemName(
+    line.match(/^\s*[-*]\s+(?:\*\*)?(.+?)(?:\*\*)?\s*(?::|-|—)\s+/)?.[1]
+  );
+  const bullets = body.split(/\r?\n/).filter((line) => /^\s*[-*]\s+/.test(line));
+  const blueprintLines = bullets.filter((line) => {
+    const name = bulletName(line);
+    return Boolean(name && blueprintSet.has(name.toLowerCase()));
+  });
+  const currentLines = bullets.filter((line) => {
+    const name = bulletName(line);
+    return Boolean(name && !blueprintSet.has(name.toLowerCase()) && currentSet.has(name.toLowerCase()));
+  });
+  const covered = new Set(
+    blueprintLines.map((line) => bulletName(line)?.toLowerCase()).filter((name): name is string => Boolean(name))
+  );
+  const missingLines = blueprint
+    .filter((name) => !covered.has(name.toLowerCase()))
+    .map((name) => `- **${name}** — Clinician review is recommended before use; a specific dose or timing is not provided.`);
+  const currentBlock = currentLines.length
+    ? `\n\n### Current Stack Notes\n\n${currentLines.join("\n")}`
+    : "";
+  const analysisIndex = body.search(/^\*\*Analysis\*\*/im);
+  const analysis = analysisIndex >= 0
+    ? body.slice(analysisIndex).trim()
+    : "**Analysis**\n\nThese notes cover every Blueprint recommendation. Specific dosing should be reviewed with a clinician when it cannot be provided safely from the intake alone.";
+  return `${[...blueprintLines, ...missingLines].join("\n")}${currentBlock}\n\n${analysis}`.trim();
+}
+
+function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: string, currentNames: string[]): string {
   const sources: Record<string, string> = {
     "## Contraindications & Med Interactions": passB,
     "## Your Blueprint Recommendations": `## Your Blueprint Recommendations\n\n${blueprintTable}`,
-    "## Dosing & Notes": `## Dosing & Notes\n\n${alignedDosingBody(blueprintTable, passB)}`,
+    "## Dosing & Notes": `## Dosing & Notes\n\n${consistentDosingBody(blueprintTable, passB, currentNames)}`,
   };
 
   return CANONICAL_REPORT_HEADINGS.map((heading) => {
@@ -323,9 +425,9 @@ function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: 
     .trim();
 }
 
-function ensureReportDosingAlignment(md: string): string {
+function ensureReportDosingAlignment(md: string, currentNames: string[]): string {
   const blueprint = sectionChunk(md, "## Your Blueprint Recommendations");
-  const dosing = alignedDosingBody(blueprint, md);
+  const dosing = consistentDosingBody(blueprint, md, currentNames);
   return md.replace(
     /## Dosing & Notes[\s\S]*?(?=\n## |$)/i,
     `## Dosing & Notes\n\n${dosing}`
@@ -433,14 +535,8 @@ function stripCodeFences(s: string): string {
 
 function hardenBlueprintSection(md: string, requiredRows: number) {
   const body = sectionChunk(md, "## Your Blueprint Recommendations");
-  const header = "| Rank | Supplement | Why it Matters |\n| --- | --- | --- |\n";
   if (!body) return md;
-  const rows = body.split(/\r?\n/).filter(l => l.trim().startsWith("|") && !/^\|\s*-+\s*\|/.test(l));
-  const data = rows.filter(Boolean);
-  const need = Math.max(0, requiredRows - data.length);
-  if (need <= 0) return md;
-  const pad = Array.from({ length: need }).map((_, i) => `| ${data.length + i + 1} | TBD | See Dosing & Notes |`);
-  const rebuilt = `## Your Blueprint Recommendations\n\n${header}${[...data, ...pad].join("\n")}\n`;
+  const rebuilt = `## Your Blueprint Recommendations\n\n${sanitizeBlueprintTable(body, requiredRows)}\n`;
   return md.replace(/## Your Blueprint Recommendations([\s\S]*?)(?=\n## |\n## END|$)/i, rebuilt);
 }
 
@@ -517,7 +613,6 @@ function synthesizeBlueprintFromIntake(sub: any): string {
   const header = "| Rank | Supplement | Why it Matters |\n| --- | --- | --- |\n";
   const fromIntake = ([] as string[])
     .concat((sub?.supplements ?? []).map((x:any) => cleanName(x?.name ?? x)))
-    .concat((sub?.medications ?? []).map((x:any) => cleanName(x?.name ?? x)))
     .filter(Boolean);
 
   const defaults = [
@@ -852,22 +947,18 @@ function buildEvidenceSection(items: StackItem[], minCount = 8): {
       const url = (rawUrl || "").trim();
       const normalized = url.endsWith("/") ? url : url + "/";
       if (CURATED_CITE_RE.test(normalized) || MODEL_CITE_RE.test(normalized)) {
-        bullets.push({ name: cleanName(it.name), url: normalized });
+        const label = `${cleanName(it.name)}${it.is_current ? " (Current Stack)" : ""}`;
+        bullets.push({ name: label, url: normalized });
       }
     }
   }
   const seen = new Set<string>();
   let unique = bullets.filter(b => (seen.has(b.url) ? false : (seen.add(b.url), true)));
 
-  if (unique.length < minCount) {
-    const extras = topUpCitations(minCount, unique);
-    unique = unique.concat(extras);
-  }
-
   const bulletsText = unique.map(b => `- ${b.name}: [${labelForUrl(b.url)}](${b.url})`).join("\n");
   const section =
     `## Evidence & References\n\n${bulletsText}\n\n` +
-    `**Analysis**\n\nLinks prioritize PubMed/PMC/DOI and major journals. We deduplicate sources and top up from LVE360’s curated index when per-item citations provide fewer than ${minCount} unique links, ensuring a reliable evidence floor.`;
+    `**Analysis**\n\nLinks prioritize PubMed/PMC/DOI and major journals and are limited to Blueprint recommendations plus clearly identified current-stack items. Sources are deduplicated; reports with fewer than ${minCount} aligned citations remain flagged for review rather than adding unrelated items.`;
   return { section, bullets: unique };
 }
 
@@ -883,7 +974,7 @@ function buildShoppingLinksSection(items: StackItem[]): string {
     return "## Shopping Links\n\n- No links available yet.\n\n**Analysis**\n\nLinks will be provided once products are mapped.";
   }
   const bullets = items.map((it) => {
-    const name = cleanName(it.name);
+    const name = `${cleanName(it.name)}${it.is_current ? " (Current Stack)" : ""}`;
     const links: string[] = [];
     if (it.link_amazon) links.push(`[Amazon](${it.link_amazon})`);
     if (it.link_fullscript) links.push(`[Fullscript](${it.link_fullscript})`);
@@ -1192,6 +1283,7 @@ const baseClient = {
 
 const compactClient = summarizeForLLM(baseClient);
 const fullClient = { ...baseClient, age: age((baseClient as any).dob ?? null), today: TODAY };
+const currentStackClient = { medications: medicationsRaw, supplements: supplementsRaw, hormones: hormonesRaw };
 console.info("[gen.intake.check]", {
   goals: (baseClient as any).goals,
   conditions: (baseClient as any).conditions,
@@ -1237,6 +1329,7 @@ if (!tableMd) {
   console.warn("[passA] falling back to synthesized table from intake/defaults");
   tableMd = synthesizeBlueprintFromIntake(fullClient);
 }
+tableMd = sanitizeBlueprintTable(tableMd);
 
 
 // token accounting (if available)
@@ -1587,13 +1680,15 @@ if (resC?.usage?.completion_tokens) completionTokens = (completionTokens ?? 0) +
 modelUsed = resC?.modelUsed ?? modelUsed;
 
   // ---------- Stitch full Markdown in canonical user-facing order ----------
-let md = assembleCanonicalReport(restMd, tableMd, dosingMd);
+const currentNames = currentStackEntries(currentStackClient).map((item) => item.name);
+restMd = replaceOrAppendSection(restMd, buildCurrentStackSection(currentStackClient));
+let md = assembleCanonicalReport(restMd, tableMd, dosingMd, currentNames);
 
 
   // Sanity: enforce headings and pad the Blueprint without exposing END.
   md = forceHeadings(md);
   md = hardenBlueprintSection(md, computeValidationTargets(mode, cap).minRows);
-  md = ensureReportDosingAlignment(md);
+  md = ensureReportDosingAlignment(md, currentNames);
 
   // ---------- Parse items / safety / enrichment ----------
   const TIMING_ARTIFACT_RE = /^(on\s+waking|am\b.*breakfast|evening\b.*dinner|before\s+bed|pre[- ]?exercise(?:.*)?|hold\/adjust|simplify\s+sleep\s+aids)$/i;
@@ -1604,7 +1699,12 @@ let md = assembleCanonicalReport(restMd, tableMd, dosingMd);
     return TIMING_ARTIFACT_RE.test(s);
   }
 
-  const parsedItemsRaw = parseMarkdownToItems(md) as any[];
+  const allowedItemNames = new Set(
+    [...blueprintNames(tableMd), ...currentNames].map((name) => normalizeSupplementName(name).toLowerCase())
+  );
+  const parsedItemsRaw = (parseMarkdownToItems(md) as any[]).filter((item) =>
+    allowedItemNames.has(normalizeSupplementName(String(item?.name ?? "")).toLowerCase())
+  );
   const rawCapped = typeof cap === "number" ? asArray(parsedItemsRaw).slice(0, cap) : asArray(parsedItemsRaw);
   const baseItems: StackItem[] = rawCapped.map((i: any) => ({ ...i, is_current: i?.is_current === true }));
   const filteredItems: StackItem[] = baseItems.filter((it) => {

--- a/src/lib/getSubmissionWithChildren.ts
+++ b/src/lib/getSubmissionWithChildren.ts
@@ -52,6 +52,9 @@ export async function getSubmissionWithChildren(submissionId: string): Promise<S
 
   return {
     ...submission,
+    medications_text: submission.medications ?? null,
+    supplements_text: submission.supplements ?? null,
+    hormones_text: submission.hormones ?? null,
     medications: medResp.data ?? [],
     supplements: supResp.data ?? [],
     hormones: horResp.data ?? [],


### PR DESCRIPTION
## Purpose

Resolve the report consistency cleanup plus three blocking Preview/QA findings: normalized intake recovery, free-results sidebar loading, and reliable first-attempt PDF export.

## Exact fixes

### Normalized intake and Current Stack
- Merges readable values from `engine_input_json`, submission text columns, `payload_json`/`answers`, and medication/supplement/hormone child tables.
- Resolves Tally choice IDs through option labels and filters unresolved UUIDs.
- Builds Current Stack deterministically from normalized intake.
- Logs normalized goals, conditions, medications, supplements, hormones, and Current Stack count.
- Preserves Blueprint placeholder rejection and the separate `Current Stack Notes` dosing subsection.

### Free-results sidebar
- Uses the supplied `stackId` with public `/api/stack-items?stack_id=...`.
- Keeps `/api/stacks/combined` for authenticated dashboard use.
- Sets `stackId` immediately after generate/get-stack responses.
- Adds explicit loading, empty, unavailable, and request-error states.

### PDF export
- Opens the real `/api/export-pdf?...` URL with `noopener,noreferrer`.
- Removes blob URL creation/revocation.
- Adds exporting state, readiness disabling, and user-facing error text.

## Changed files
- `src/lib/generateStack.ts`
- `src/lib/getSubmissionWithChildren.ts`
- `src/components/results/ResultsSidebar.tsx`
- `app/results/page.tsx`
- `app/api/stack-items/route.ts`

Canonical order, no user-facing END, PR #25 `sectionBodiesValid`, safe wellness language, and checkout/auth behavior remain unchanged.

## Verification
- `npm run typecheck` — passed
- `npm run build` — passed using non-secret placeholder environment values

## Manual QA
1. Generate an intake containing choice-ID goals/conditions and Metformin, testosterone gel, DHEA, Pregnenolone, Glycine, and Creatine across the supported sources.
2. Confirm logs contain readable normalized lists and a nonzero Current Stack count.
3. Confirm Current Stack lists all reported items.
4. Confirm Blueprint contains no placeholder item names.
5. Confirm non-Blueprint dosing appears only under `Current Stack Notes`.
6. While logged out, confirm the free report sidebar loads items for the generated stack.
7. Confirm clear sidebar empty/error states.
8. Export immediately after generation and confirm one PDF tab opens reliably; repeat export.
9. Confirm canonical PDF order, complete bodies, and no END marker.
10. Confirm checkout/auth flows are unchanged.

## Risk / rollback
The public sidebar endpoint exposes only item data for a supplied stack ID and remains separate from authenticated combined/dashboard data. Roll back commit `2452801` if a legacy Tally payload shape exposes another normalization variant.