### PR TITLE
Canonical intake ledger and repeated Tally group parser

### DIFF
--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -14,6 +14,10 @@ import { applySafetyChecks } from "@/lib/safetyCheck";
 import { enrichAffiliateLinks, buildAmazonSearchLink } from "@/lib/affiliateLinks";
 import { getTopCitationsFor } from "@/lib/evidence";
 import { callOpenAI } from "@/lib/openai";
+import {
+  buildNormalizedCurrentStackLedger,
+  type NormalizedCurrentStackLedgerItem,
+} from "@/lib/normalizedCurrentStackLedger";
 
 // Curated evidence index (JSON)
 // If this path differs in your repo, update the import below.
@@ -306,10 +310,6 @@ function validItemName(raw: unknown): string | null {
   return readableNameText(String(raw ?? ""));
 }
 
-function intakeItemName(item: any): string | null {
-  return extractReadableNames(item)[0] ?? null;
-}
-
 function intakeItems(raw: any): any[] {
   if (!raw) return [];
   if (Array.isArray(raw)) return raw;
@@ -337,36 +337,10 @@ function normalizedItemWithDetails(item: unknown, name: string): string | Record
     : name;
 }
 
-function currentStackEntries(client: any) {
-  const groups = [
-    ["Medication", client?.medications],
-    ["Supplement", client?.supplements],
-    ["Hormone", client?.hormones],
-  ] as const;
-  const seen = new Set<string>();
-  return groups.flatMap(([kind, raw]) => intakeItems(raw).flatMap((item) =>
-    extractReadableNames(item).flatMap((name) => {
-      if (seen.has(name.toLowerCase())) return [];
-      seen.add(name.toLowerCase());
-      const details = typeof item === "object" && item !== null ? item : {};
-      return [{
-        name,
-        kind,
-        purpose: readableDetail(details.purpose ?? details.notes) ?? `${kind} reported in intake`,
-        dose: readableDetail(details.dose ?? details.dosage ?? details.amount) ?? "Not provided",
-        timing: readableDetail(details.timing ?? details.frequency ?? details.schedule) ?? "Not provided",
-      }];
-    })
-  ));
-}
-
-function buildCurrentStackSection(client: any, referencedElsewhere = false): string {
-  const entries = currentStackEntries(client);
-  const body = entries.length
-    ? `| Medication/Supplement/Hormone | Purpose/Notes | Dosage | Timing |\n| --- | --- | --- | --- |\n${entries.map((item) => `| ${item.name} | ${item.kind}: ${item.purpose} | ${item.dose} | ${item.timing} |`).join("\n")}`
-    : referencedElsewhere
-      ? "Current-stack items are referenced elsewhere in this report, but structured intake details could not be recovered. Review the safety and dosing sections with a qualified clinician before making changes."
-      : "No current medications, supplements, or hormones were reported in the intake.";
+function buildCurrentStackSection(ledger: NormalizedCurrentStackLedgerItem[]): string {
+  const body = ledger.length
+    ? `| Medication/Supplement/Hormone | Type | Dosage | Timing |\n| --- | --- | --- | --- |\n${ledger.map((item) => `| ${item.name} | ${item.kind} | ${item.dose ?? "Not provided"} | ${item.timing ?? "Not provided"} |`).join("\n")}`
+    : "No current medications, supplements, or hormones were reported in the intake.";
   return `## Current Stack\n\n${body}\n\n**Analysis**\n\nThis section reflects the current medications, supplements, and hormones reported in the intake. Review it for accuracy and discuss changes or potential interactions with a qualified clinician.`;
 }
 
@@ -384,6 +358,15 @@ function ensureContraCurrentStackCoverage(passB: string, currentNames: string[])
     ? `${body.slice(0, analysisAt).trimEnd()}\n${coverage}\n${body.slice(analysisAt)}`
     : `${body.trimEnd()}\n${coverage}\n`;
   return passB.replace(`${header}${body}`, `${header}${repairedBody}`);
+}
+
+function validateCurrentStackParity(md: string, ledger: NormalizedCurrentStackLedgerItem[]) {
+  const currentBody = sectionChunk(md, "## Current Stack").toLowerCase();
+  const contraBody = sectionChunk(md, "## Contraindications & Med Interactions").toLowerCase();
+  const currentMissing = ledger.filter((item) => !currentBody.includes(item.name.toLowerCase()));
+  const contraMissing = ledger.filter((item) => !contraBody.includes(item.name.toLowerCase()));
+  const mismatch = Array.from(new Set([...currentMissing, ...contraMissing].map((item) => item.name)));
+  return { valid: mismatch.length === 0, mismatch };
 }
 
 function sectionBodyMeaningful(md: string, heading: string): boolean {
@@ -455,10 +438,11 @@ function alignedDosingBody(blueprintTable: string, passB: string): string {
   return `${body}\n${coverage}\n\n**Analysis**\n\nThese notes cover every Blueprint recommendation. Specific dosing should be reviewed with a clinician when it cannot be provided safely from the intake alone.`.trim();
 }
 
-function consistentDosingBody(blueprintTable: string, passB: string, currentNames: string[]): string {
+function consistentDosingBody(blueprintTable: string, passB: string, ledger: NormalizedCurrentStackLedgerItem[]): string {
   const body = sectionChunk(passB, "## Dosing & Notes").trim();
   const blueprint = blueprintNames(blueprintTable);
   const blueprintSet = new Set(blueprint.map((name) => name.toLowerCase()));
+  const currentNames = ledger.map((item) => item.name);
   const currentSet = new Set(currentNames.map((name) => name.toLowerCase()));
   const bulletName = (line: string) => validItemName(
     line.match(/^\s*[-*]\s+(?:\*\*)?(.+?)(?:\*\*)?\s*(?::|-|—)\s+/)?.[1]
@@ -478,8 +462,18 @@ function consistentDosingBody(blueprintTable: string, passB: string, currentName
   const missingLines = blueprint
     .filter((name) => !covered.has(name.toLowerCase()))
     .map((name) => `- **${name}** — Clinician review is recommended before use; a specific dose or timing is not provided.`);
-  const currentBlock = currentLines.length
-    ? `\n\n### Current Stack Notes\n\n${currentLines.join("\n")}`
+  const coveredCurrent = new Set(
+    currentLines.map((line) => bulletName(line)?.toLowerCase()).filter((name): name is string => Boolean(name))
+  );
+  const missingCurrentLines = ledger
+    .filter((item) => !blueprintSet.has(item.name.toLowerCase()) && !coveredCurrent.has(item.name.toLowerCase()))
+    .map((item) => {
+      const details = [item.dose ? `dose: ${item.dose}` : null, item.timing ? `timing: ${item.timing}` : null].filter(Boolean).join("; ");
+      return `- **${item.name}** -- Current ${item.kind} reported${details ? ` (${details})` : ""}. Review interactions and any changes with a qualified clinician or pharmacist.`;
+    });
+  const currentNotes = [...currentLines, ...missingCurrentLines];
+  const currentBlock = currentNotes.length
+    ? `\n\n### Current Stack Notes\n\n${currentNotes.join("\n")}`
     : "";
   const analysisIndex = body.search(/^\*\*Analysis\*\*/im);
   const analysis = analysisIndex >= 0
@@ -488,11 +482,11 @@ function consistentDosingBody(blueprintTable: string, passB: string, currentName
   return `${[...blueprintLines, ...missingLines].join("\n")}${currentBlock}\n\n${analysis}`.trim();
 }
 
-function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: string, currentNames: string[]): string {
+function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: string, ledger: NormalizedCurrentStackLedgerItem[]): string {
   const sources: Record<string, string> = {
     "## Contraindications & Med Interactions": passB,
     "## Your Blueprint Recommendations": `## Your Blueprint Recommendations\n\n${blueprintTable}`,
-    "## Dosing & Notes": `## Dosing & Notes\n\n${consistentDosingBody(blueprintTable, passB, currentNames)}`,
+    "## Dosing & Notes": `## Dosing & Notes\n\n${consistentDosingBody(blueprintTable, passB, ledger)}`,
   };
 
   return CANONICAL_REPORT_HEADINGS.map((heading) => {
@@ -507,9 +501,9 @@ function assembleCanonicalReport(restMd: string, blueprintTable: string, passB: 
     .trim();
 }
 
-function ensureReportDosingAlignment(md: string, currentNames: string[]): string {
+function ensureReportDosingAlignment(md: string, ledger: NormalizedCurrentStackLedgerItem[]): string {
   const blueprint = sectionChunk(md, "## Your Blueprint Recommendations");
-  const dosing = consistentDosingBody(blueprint, md, currentNames);
+  const dosing = consistentDosingBody(blueprint, md, ledger);
   return md.replace(
     /## Dosing & Notes[\s\S]*?(?=\n## |$)/i,
     `## Dosing & Notes\n\n${dosing}`
@@ -1150,11 +1144,26 @@ Output ONLY the section "## Your Blueprint Recommendations" as a Markdown table 
 }
 
 function safetyAndDosingPrompt(fullClient: any, blueprintTable: string) {
+  const {
+    payload_json: _payload,
+    answers: _answers,
+    engine_input_json: _engine,
+    medications_text: _medicationsText,
+    supplements_text: _supplementsText,
+    hormones_text: _hormonesText,
+    ...promptClient
+  } = fullClient;
   return `
 ### CLIENT (Full)
 \`\`\`json
-${JSON.stringify(fullClient, null, 2)}
+${JSON.stringify(promptClient, null, 2)}
 \`\`\`
+
+### CANONICAL NORMALIZED CURRENT STACK LEDGER
+\`\`\`json
+${JSON.stringify(fullClient.normalizedCurrentStackLedger ?? [], null, 2)}
+\`\`\`
+Use this ledger as the only source of truth for current medications, supplements, and hormones.
 
 ### GIVEN BLUEPRINT (exactly as provided)
 \n**Blueprint Table**\n\n${blueprintTable}
@@ -1416,26 +1425,24 @@ const conditionsMerged = mergeReadableValues(normalizationStats,
 );
 const conditionsRaw = conditionsMerged.values;
 
-const medicationsMerged = mergeReadableValues(normalizationStats,
-  engineInput?.medications, engineInput?.meds, (sub as any)?.medications_text, (sub as any)?.medications,
-  getAnswer(readableAns, "question_Ex8YB2", ["medications", "list medication", "do you take any medications"]),
-  getAnswer(ans, "question_Ex8YB2", ["medications", "list medication", "do you take any medications"])
-);
-const medicationsRaw = medicationsMerged.values;
-
-const supplementsMerged = mergeReadableValues(normalizationStats,
-  engineInput?.current_supplements, engineInput?.supplements, (sub as any)?.supplements_text, (sub as any)?.supplements,
-  getAnswer(readableAns, "question_kNO8DM", ["supplements"]),
-  getAnswer(ans, "question_kNO8DM", ["supplements"])
-);
-const supplementsRaw = supplementsMerged.values;
-
-const hormonesMerged = mergeReadableValues(normalizationStats,
-  engineInput?.hormones, (sub as any)?.hormones_text, (sub as any)?.hormones,
-  getAnswer(readableAns, "question_ro2Myv", ["hormones"]),
-  getAnswer(ans, "question_ro2Myv", ["hormones"])
-);
-const hormonesRaw = hormonesMerged.values;
+const normalizedCurrentStackLedger = buildNormalizedCurrentStackLedger(sub);
+if (normalizedCurrentStackLedger.some((item) =>
+  !item.name.trim() || UUID_VALUE_RE.test(item.name) || OBJECT_STRING_RE.test(item.name)
+)) {
+  throw new Error("Invalid current stack ledger item name");
+}
+const ledgerItems = (kind: NormalizedCurrentStackLedgerItem["kind"]) => normalizedCurrentStackLedger
+  .filter((item) => item.kind === kind)
+  .map((item) => ({
+    name: item.name,
+    dose: item.dose,
+    timing: item.timing,
+    source_paths: item.source_paths,
+    raw_labels: item.raw_labels,
+  }));
+const medicationsRaw = ledgerItems("medication");
+const supplementsRaw = ledgerItems("supplement");
+const hormonesRaw = ledgerItems("hormone");
 
 // ONE source of truth for the rest of the file:
 const baseClient = {
@@ -1445,26 +1452,29 @@ const baseClient = {
   medications: medicationsRaw,
   supplements: supplementsRaw,
   hormones: hormonesRaw,
+  normalizedCurrentStackLedger,
 };
 
 const compactClient = summarizeForLLM(baseClient);
 const fullClient = { ...baseClient, age: age((baseClient as any).dob ?? null), today: TODAY };
-const currentStackClient = { medications: medicationsRaw, supplements: supplementsRaw, hormones: hormonesRaw };
-const currentNames = currentStackEntries(currentStackClient).map((item) => item.name);
+const currentNames = normalizedCurrentStackLedger.map((item) => item.name);
 console.info("[gen.intake.check]", {
   normalized_goals: (baseClient as any).goals,
   normalized_conditions: (baseClient as any).conditions,
   normalized_medications: (baseClient as any).medications,
   normalized_supplements: (baseClient as any).supplements,
   normalized_hormones: (baseClient as any).hormones,
-  medications_raw_count: medicationsMerged.rawCount,
   medications_normalized_count: medicationsRaw.length,
-  supplements_raw_count: supplementsMerged.rawCount,
   supplements_normalized_count: supplementsRaw.length,
-  hormones_raw_count: hormonesMerged.rawCount,
   hormones_normalized_count: hormonesRaw.length,
   rejected_object_values_count: normalizationStats.rejectedObjectValues,
-  currentStackEntries_count: currentStackEntries(currentStackClient).length,
+  ledger_total_count: normalizedCurrentStackLedger.length,
+  ledger_medication_count: medicationsRaw.length,
+  ledger_supplement_count: supplementsRaw.length,
+  ledger_hormone_count: hormonesRaw.length,
+  ledger_item_names: currentNames,
+  ledger_source_paths_by_item: Object.fromEntries(normalizedCurrentStackLedger.map((item) => [`${item.kind}:${item.name}`, item.source_paths])),
+  current_stack_rendered_count: normalizedCurrentStackLedger.length,
 });
 // PASS A: Blueprint Table (mini first)
 console.info("[gen.passA:start]", { candidates: candidateModels("mini") });
@@ -1858,15 +1868,14 @@ if (resC?.usage?.completion_tokens) completionTokens = (completionTokens ?? 0) +
 modelUsed = resC?.modelUsed ?? modelUsed;
 
   // ---------- Stitch full Markdown in canonical user-facing order ----------
-const currentItemsReferencedElsewhere = /\b(?:medication|supplement|hormone|metformin|zepbound|armour|testosterone|dhea|pregnenolone|glycine|creatine)\b/i.test(dosingMd);
-restMd = replaceOrAppendSection(restMd, buildCurrentStackSection(currentStackClient, currentItemsReferencedElsewhere));
-let md = assembleCanonicalReport(restMd, tableMd, dosingMd, currentNames);
+restMd = replaceOrAppendSection(restMd, buildCurrentStackSection(normalizedCurrentStackLedger));
+let md = assembleCanonicalReport(restMd, tableMd, dosingMd, normalizedCurrentStackLedger);
 
 
   // Sanity: enforce headings and pad the Blueprint without exposing END.
   md = forceHeadings(md);
   md = hardenBlueprintSection(md, computeValidationTargets(mode, cap).minRows);
-  md = ensureReportDosingAlignment(md, currentNames);
+  md = ensureReportDosingAlignment(md, normalizedCurrentStackLedger);
 
   // ---------- Parse items / safety / enrichment ----------
   const TIMING_ARTIFACT_RE = /^(on\s+waking|am\b.*breakfast|evening\b.*dinner|before\s+bed|pre[- ]?exercise(?:.*)?|hold\/adjust|simplify\s+sleep\s+aids)$/i;
@@ -1929,6 +1938,36 @@ const safetyInput = {
 
   const finalStack: StackItem[] = applyLinkPolicy(enriched, baseClient, mode);
   const withEvidence: StackItem[] = asArray(finalStack).map(attachEvidence);
+  const persistedItemsByName = new Map<string, StackItem>();
+  for (const item of withEvidence) {
+    const key = normalizeSupplementName(item.name).toLowerCase();
+    const ledgerItem = normalizedCurrentStackLedger.find((current) =>
+      normalizeSupplementName(current.name).toLowerCase() === key
+    );
+    persistedItemsByName.set(key, { ...item, is_current: Boolean(ledgerItem) || item.is_current });
+  }
+  for (const item of normalizedCurrentStackLedger) {
+    const key = normalizeSupplementName(item.name).toLowerCase();
+    if (!persistedItemsByName.has(key)) {
+      persistedItemsByName.set(key, {
+        name: item.name,
+        dose: item.dose ?? null,
+        timing: item.timing ?? null,
+        notes: `Current ${item.kind} reported in intake.`,
+        is_current: true,
+      });
+    }
+  }
+  const itemsForPersistence = Array.from(persistedItemsByName.values());
+  if (/\[object Object\]/i.test(JSON.stringify(itemsForPersistence))) {
+    throw new Error("Invalid object string leaked into stack items");
+  }
+  if (itemsForPersistence.some((item) => {
+    const name = validItemName(item.name);
+    return !name || UUID_VALUE_RE.test(name) || OBJECT_STRING_RE.test(name);
+  })) {
+    throw new Error("Invalid current stack item blocked before persistence");
+  }
 
   // Evidence override
   const { section: evidenceSection } = buildEvidenceSection(withEvidence, 8);
@@ -1939,13 +1978,21 @@ const safetyInput = {
   const shoppingRe = /## Shopping Links([\s\S]*?)(?=\n## |\n## END|$)/i;
   md = shoppingRe.test(md) ? md.replace(shoppingRe, shoppingSection) : md.replace(/\n## END/i, `\n\n${shoppingSection}\n\n## END`);
 
-  if (md.includes("[object Object]")) {
+  if (/\[object Object\]/i.test(md)) {
     throw new Error("Invalid object string leaked into report");
   }
 
   // ---------- Final validation ----------
   const targets = computeValidationTargets(mode, cap);
   const emptySections = emptyRequiredSections(md);
+  const parity = validateCurrentStackParity(md, normalizedCurrentStackLedger);
+  if (!parity.valid) console.warn("[validation] contraindication_current_stack_mismatch", parity.mismatch);
+  console.info("[validation] current stack parity", {
+    current_stack_rendered_count: normalizedCurrentStackLedger.filter((item) =>
+      sectionChunk(md, "## Current Stack").toLowerCase().includes(item.name.toLowerCase())
+    ).length,
+    contraindication_current_stack_mismatch: parity.mismatch,
+  });
   const ok = {
     wordCountOK: wc(md) >= targets.minWords,
     headingsValid: headingsOK(md),
@@ -1953,6 +2000,7 @@ const safetyInput = {
     citationsValid: citationsOK(md),
     narrativesValid: narrativesOK(md, targets.minSent),
     sectionBodiesValid: emptySections.length === 0,
+    currentStackParityValid: parity.valid,
     endValid: !/(^|\n)##\s*END\s*(?=\n|$)/i.test(md),
   };
   if (emptySections.length) {
@@ -1963,6 +2011,9 @@ const safetyInput = {
 
   if (!ok.sectionBodiesValid) {
     throw new Error(`Refusing to persist incomplete report sections: ${emptySections.join(", ")}`);
+  }
+  if (!ok.currentStackParityValid) {
+    throw new Error(`Refusing to persist report with Current Stack mismatch: ${parity.mismatch.join(", ")}`);
   }
 
   // ----------------------------------------------------------------------------
@@ -1983,7 +2034,7 @@ const safetyInput = {
           tokens_used: (promptTokens ?? 0) + (completionTokens ?? 0),
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
-          safety_status: (ok.headingsValid && ok.blueprintValid && ok.citationsValid && ok.sectionBodiesValid) ? "safe" : "warning",
+          safety_status: (ok.headingsValid && ok.blueprintValid && ok.citationsValid && ok.sectionBodiesValid && ok.currentStackParityValid) ? "safe" : "warning",
           summary: md,
           sections: { markdown: md, generated_at: new Date().toISOString(), mode, item_cap: cap ?? null },
           notes: null,
@@ -2002,7 +2053,7 @@ const safetyInput = {
   if (parentRows.length > 0 && stackId && user_id) {
     try {
       await supabaseAdmin.from("stacks_items").delete().eq("stack_id", stackId);
-      const rows: StackItemRow[] = (withEvidence || [])
+      const rows: StackItemRow[] = itemsForPersistence
         .map((it) => {
           const readableName = validItemName(it?.name);
           const safeName = readableName ? validItemName(normalizeSupplementName(readableName)) : null;

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -16,6 +16,7 @@ import { getTopCitationsFor } from "@/lib/evidence";
 import { callOpenAI } from "@/lib/openai";
 import {
   buildNormalizedCurrentStackLedger,
+  findMissingRepeatedTallyItems,
   type NormalizedCurrentStackLedgerItem,
 } from "@/lib/normalizedCurrentStackLedger";
 
@@ -339,7 +340,7 @@ function normalizedItemWithDetails(item: unknown, name: string): string | Record
 
 function buildCurrentStackSection(ledger: NormalizedCurrentStackLedgerItem[]): string {
   const body = ledger.length
-    ? `| Medication/Supplement/Hormone | Type | Dosage | Timing |\n| --- | --- | --- | --- |\n${ledger.map((item) => `| ${item.name} | ${item.kind} | ${item.dose ?? "Not provided"} | ${item.timing ?? "Not provided"} |`).join("\n")}`
+    ? `| Medication/Supplement/Hormone | Type | Purpose | Dosage | Timing |\n| --- | --- | --- | --- | --- |\n${ledger.map((item) => `| ${item.name} | ${item.kind} | ${item.purpose ?? "Not provided"} | ${item.dose ?? "Not provided"} | ${item.timing ?? "Not provided"} |`).join("\n")}`
     : "No current medications, supplements, or hormones were reported in the intake.";
   return `## Current Stack\n\n${body}\n\n**Analysis**\n\nThis section reflects the current medications, supplements, and hormones reported in the intake. Review it for accuracy and discuss changes or potential interactions with a qualified clinician.`;
 }
@@ -1426,6 +1427,11 @@ const conditionsMerged = mergeReadableValues(normalizationStats,
 const conditionsRaw = conditionsMerged.values;
 
 const normalizedCurrentStackLedger = buildNormalizedCurrentStackLedger(sub);
+const missingRepeatedTallyItems = findMissingRepeatedTallyItems(sub, normalizedCurrentStackLedger);
+if (missingRepeatedTallyItems.length) {
+  console.warn("[gen.intake] repeated Tally fields missing from ledger", missingRepeatedTallyItems);
+  throw new Error(`Current stack ledger omitted repeated Tally items: ${missingRepeatedTallyItems.join(", ")}`);
+}
 if (normalizedCurrentStackLedger.some((item) =>
   !item.name.trim() || UUID_VALUE_RE.test(item.name) || OBJECT_STRING_RE.test(item.name)
 )) {
@@ -1435,6 +1441,7 @@ const ledgerItems = (kind: NormalizedCurrentStackLedgerItem["kind"]) => normaliz
   .filter((item) => item.kind === kind)
   .map((item) => ({
     name: item.name,
+    purpose: item.purpose,
     dose: item.dose,
     timing: item.timing,
     source_paths: item.source_paths,
@@ -1475,6 +1482,14 @@ console.info("[gen.intake.check]", {
   ledger_item_names: currentNames,
   ledger_source_paths_by_item: Object.fromEntries(normalizedCurrentStackLedger.map((item) => [`${item.kind}:${item.name}`, item.source_paths])),
   current_stack_rendered_count: normalizedCurrentStackLedger.length,
+  current_stack_ledger_total: normalizedCurrentStackLedger.length,
+  current_stack_medication_names: medicationsRaw.map((item) => item.name),
+  current_stack_supplement_names: supplementsRaw.map((item) => item.name),
+  current_stack_hormone_names: hormonesRaw.map((item) => item.name),
+  current_stack_source_fields: Object.fromEntries(normalizedCurrentStackLedger.map((item) => [
+    `${item.kind}:${item.name}`,
+    { labels: item.raw_labels, paths: item.source_paths },
+  ])),
 });
 // PASS A: Blueprint Table (mini first)
 console.info("[gen.passA:start]", { candidates: candidateModels("mini") });
@@ -1953,7 +1968,7 @@ const safetyInput = {
         name: item.name,
         dose: item.dose ?? null,
         timing: item.timing ?? null,
-        notes: `Current ${item.kind} reported in intake.`,
+        notes: item.purpose ?? `Current ${item.kind} reported in intake.`,
         is_current: true,
       });
     }

--- a/src/lib/normalizedCurrentStackLedger.ts
+++ b/src/lib/normalizedCurrentStackLedger.ts
@@ -1,0 +1,184 @@
+export type CurrentStackKind = "medication" | "supplement" | "hormone";
+
+export type NormalizedCurrentStackLedgerItem = {
+  name: string;
+  kind: CurrentStackKind;
+  dose?: string;
+  timing?: string;
+  source_paths: string[];
+  raw_labels: string[];
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const INVALID_NAME_RE = /^(?:\[object Object\]|tbd|none|null|no|n\/?a|blank|no (?:medications?|supplements?|hormones?)|not reported)$/i;
+const KIND_PATTERNS: Array<[CurrentStackKind, RegExp]> = [
+  ["hormone", /\b(?:hormones?|trt|testosterone|dhea|pregnenolone)\b/i],
+  ["medication", /\b(?:medications?|prescriptions?|drugs?|glp(?:[ -]?1)?|thyroid)\b/i],
+  ["supplement", /\b(?:supplements?|vitamins?|current[ _-]?stack)\b/i],
+];
+const DETAIL_KEYS = new Set(["dose", "dosage", "amount", "timing", "frequency", "schedule", "purpose", "notes"]);
+const METADATA_KEYS = new Set(["id", "key", "type", "options", "submission_id", "field_id", "created_at", "updated_at"]);
+
+function parseJson(value: unknown): any {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed || !/^[\[{]/.test(trimmed)) return value;
+  try { return JSON.parse(trimmed); } catch { return value; }
+}
+
+function readableText(value: unknown): string | undefined {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const text = String(value).replace(/\s+/g, " ").trim();
+  return text && !INVALID_NAME_RE.test(text) && !UUID_RE.test(text) ? text : undefined;
+}
+
+export function extractLedgerReadableNames(
+  raw: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0
+): string[] {
+  const value = parseJson(raw);
+  if (value == null || depth > 12) return [];
+  if (typeof value === "string") {
+    return value.split(/,|\n|;|\|/).map(readableText).filter((name): name is string => Boolean(name));
+  }
+  if (typeof value !== "object") return [];
+  if (seen.has(value)) return [];
+  seen.add(value);
+  if (Array.isArray(value)) return value.flatMap((item) => extractLedgerReadableNames(item, seen, depth + 1));
+
+  const object = value as Record<string, any>;
+  const named = [
+    object.med_name, object.medication_name, object.supplement_name, object.hormone_name,
+    object.name, object.label, object.text, object.title,
+  ].filter((candidate) => candidate != null);
+  const nestedAnswers = [
+    object.selectedOptions, object.choices?.labels, object.choices,
+    object.value, object.answer, object.choice,
+  ].filter((candidate) => candidate != null);
+  let names = [...named, ...nestedAnswers].flatMap((candidate) =>
+    extractLedgerReadableNames(candidate, seen, depth + 1)
+  );
+  if (!names.length) {
+    names = Object.entries(object)
+      .filter(([key]) => !DETAIL_KEYS.has(key.toLowerCase()) && !METADATA_KEYS.has(key.toLowerCase()))
+      .flatMap(([, nested]) => extractLedgerReadableNames(nested, seen, depth + 1));
+  }
+  const unique = new Map<string, string>();
+  for (const name of names) if (!unique.has(name.toLowerCase())) unique.set(name.toLowerCase(), name);
+  return Array.from(unique.values());
+}
+
+function inferKind(labelOrKey: string): CurrentStackKind | null {
+  const readable = labelOrKey.replace(/[_-]+/g, " ");
+  for (const [kind, pattern] of KIND_PATTERNS) if (pattern.test(readable)) return kind;
+  return null;
+}
+
+function detailFrom(value: unknown): string | undefined {
+  return readableText(value) ?? extractLedgerReadableNames(value)[0];
+}
+
+function fieldValues(field: Record<string, any>): unknown[] {
+  const options = field.options ?? field.field?.options ?? [];
+  const optionLabels = new Map<string, string>();
+  for (const option of Array.isArray(options) ? options : []) {
+    const id = option?.id ?? option?.value;
+    const label = option?.text ?? option?.label ?? option?.name;
+    if (id != null && readableText(label)) optionLabels.set(String(id), String(label));
+  }
+  const resolve = (value: any): any => {
+    if (Array.isArray(value)) return value.map(resolve);
+    if (typeof value === "string" && optionLabels.has(value)) return optionLabels.get(value);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(Object.entries(value).map(([key, nested]) => [key, resolve(nested)]));
+  };
+  return [
+    field.text, field.choice, field.choices, field.selectedOptions, field.value, field.answer,
+  ].filter((value) => value != null).map(resolve);
+}
+
+export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCurrentStackLedgerItem[] {
+  const ledger = new Map<string, NormalizedCurrentStackLedgerItem>();
+  const addValue = (kind: CurrentStackKind, raw: unknown, sourcePath: string, rawLabel?: string) => {
+    const parsed = parseJson(raw);
+    const parts = Array.isArray(parsed) ? parsed : [parsed];
+    for (const part of parts) {
+      const names = extractLedgerReadableNames(part);
+      for (const name of names) {
+        if (!name || UUID_RE.test(name) || INVALID_NAME_RE.test(name)) continue;
+        const key = `${kind}:${name.toLowerCase()}`;
+        const object = part && typeof part === "object" && !Array.isArray(part) ? part as Record<string, any> : {};
+        const nextDose = detailFrom(object.dose ?? object.dosage ?? object.amount);
+        const nextTiming = detailFrom(object.timing ?? object.frequency ?? object.schedule);
+        const existing = ledger.get(key);
+        if (existing) {
+          if (!existing.dose && nextDose) existing.dose = nextDose;
+          if (!existing.timing && nextTiming) existing.timing = nextTiming;
+          if (!existing.source_paths.includes(sourcePath)) existing.source_paths.push(sourcePath);
+          if (rawLabel && !existing.raw_labels.includes(rawLabel)) existing.raw_labels.push(rawLabel);
+        } else {
+          ledger.set(key, {
+            name,
+            kind,
+            ...(nextDose ? { dose: nextDose } : {}),
+            ...(nextTiming ? { timing: nextTiming } : {}),
+            source_paths: [sourcePath],
+            raw_labels: rawLabel ? [rawLabel] : [],
+          });
+        }
+      }
+    }
+  };
+
+  const engine = parseJson(submission?.engine_input_json) ?? {};
+  const payload = parseJson(submission?.payload_json) ?? {};
+  const answers = parseJson(submission?.answers) ?? [];
+
+  const directSources: Array<[CurrentStackKind, unknown, string, string]> = [
+    ["medication", engine?.medications, "engine_input_json.medications", "medications"],
+    ["medication", engine?.meds, "engine_input_json.meds", "meds"],
+    ["supplement", engine?.current_supplements, "engine_input_json.current_supplements", "current_supplements"],
+    ["supplement", engine?.supplements, "engine_input_json.supplements", "supplements"],
+    ["hormone", engine?.hormones, "engine_input_json.hormones", "hormones"],
+    ["medication", submission?.medications_text, "submissions.medications", "medications"],
+    ["supplement", submission?.supplements_text, "submissions.supplements", "supplements"],
+    ["hormone", submission?.hormones_text, "submissions.hormones", "hormones"],
+  ];
+  for (const [kind, value, path, label] of directSources) addValue(kind, value, path, label);
+  for (const [index, row] of (Array.isArray(submission?.medications) ? submission.medications : []).entries())
+    addValue("medication", row, `submission_medications[${index}]`, "submission_medications");
+  for (const [index, row] of (Array.isArray(submission?.supplements) ? submission.supplements : []).entries())
+    addValue("supplement", row, `submission_supplements[${index}]`, "submission_supplements");
+  for (const [index, row] of (Array.isArray(submission?.hormones) ? submission.hormones : []).entries())
+    addValue("hormone", row, `submission_hormones[${index}]`, "submission_hormones");
+
+  const scan = (raw: unknown, path: string, seen: WeakSet<object> = new WeakSet(), depth = 0) => {
+    const value = parseJson(raw);
+    if (!value || typeof value !== "object" || depth > 12 || seen.has(value)) return;
+    seen.add(value);
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => scan(item, `${path}[${index}]`, seen, depth + 1));
+      return;
+    }
+    const object = value as Record<string, any>;
+    const rawKey = object.key ?? object.field?.key ?? object.field?.id;
+    const rawLabel = object.label ?? object.field?.label ?? object.title;
+    const fieldKind = inferKind(`${rawKey ?? ""} ${rawLabel ?? ""}`);
+    if (fieldKind) {
+      for (const answerValue of fieldValues(object)) addValue(fieldKind, answerValue, path, String(rawLabel ?? rawKey ?? ""));
+    }
+    for (const [key, nested] of Object.entries(object)) {
+      const kind = inferKind(key);
+      if (kind) addValue(kind, nested, `${path}.${key}`, key);
+      scan(nested, `${path}.${key}`, seen, depth + 1);
+    }
+  };
+  scan(engine, "engine_input_json");
+  scan(answers, "answers");
+  scan(payload, "payload_json");
+
+  return Array.from(ledger.values()).sort((a, b) =>
+    a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name)
+  );
+}

--- a/src/lib/normalizedCurrentStackLedger.ts
+++ b/src/lib/normalizedCurrentStackLedger.ts
@@ -3,6 +3,7 @@ export type CurrentStackKind = "medication" | "supplement" | "hormone";
 export type NormalizedCurrentStackLedgerItem = {
   name: string;
   kind: CurrentStackKind;
+  purpose?: string;
   dose?: string;
   timing?: string;
   source_paths: string[];
@@ -18,6 +19,8 @@ const KIND_PATTERNS: Array<[CurrentStackKind, RegExp]> = [
 ];
 const DETAIL_KEYS = new Set(["dose", "dosage", "amount", "timing", "frequency", "schedule", "purpose", "notes"]);
 const METADATA_KEYS = new Set(["id", "key", "type", "options", "submission_id", "field_id", "created_at", "updated_at"]);
+const DETAIL_LABEL_RE = /\b(?:purpose|dose|dosage|frequency|timing|how often|when taken)\b/i;
+const YES_NO_RE = /^(?:yes|no|true|false)$/i;
 
 function parseJson(value: unknown): any {
   if (typeof value !== "string") return value;
@@ -98,6 +101,117 @@ function fieldValues(field: Record<string, any>): unknown[] {
   ].filter((value) => value != null).map(resolve);
 }
 
+function fieldLabel(field: Record<string, any>): string {
+  return String(
+    field.label ?? field.field?.label ?? field.title ?? field.question ??
+    field.key ?? field.field?.key ?? field.field?.id ?? ""
+  ).replace(/\s+/g, " ").trim();
+}
+
+function repeatedItemKind(label: string, activeKind: CurrentStackKind | null): CurrentStackKind | null {
+  const normalized = label.replace(/[–—]/g, "-").replace(/\s+/g, " ").trim();
+  if (/^list medications?$/i.test(normalized) || /^medication\s+(?:[2-6]|others?)(?:\s*\/.*)?$/i.test(normalized))
+    return "medication";
+  if (/^list supplements?$/i.test(normalized) || /^supplement\s+(?:[2-6]|others?)(?:\s*\/.*)?$/i.test(normalized))
+    return "supplement";
+  if (/^list hormones?$/i.test(normalized) || /^hormone\s+(?:[2-6]|others?)(?:\s*\/.*)?$/i.test(normalized))
+    return "hormone";
+  if (/^others?$/i.test(normalized)) return activeKind;
+  return null;
+}
+
+function fieldDetail(field: Record<string, any>): string | undefined {
+  for (const value of fieldValues(field)) {
+    if (typeof value === "string" || typeof value === "number") {
+      const detail = String(value).replace(/\s+/g, " ").trim();
+      if (detail && !UUID_RE.test(detail) && !INVALID_NAME_RE.test(detail)) return detail;
+    }
+    const names = extractLedgerReadableNames(value).filter((name) => !YES_NO_RE.test(name));
+    if (names.length) return names.join(", ");
+  }
+  return undefined;
+}
+
+export function parseTallyCurrentStackFields(
+  fields: unknown,
+  sourcePath = "fields"
+): NormalizedCurrentStackLedgerItem[] {
+  if (!Array.isArray(fields)) return [];
+  const parsed: NormalizedCurrentStackLedgerItem[] = [];
+  let activeKind: CurrentStackKind | null = null;
+  let currentItems: NormalizedCurrentStackLedgerItem[] = [];
+
+  fields.forEach((rawField, index) => {
+    if (!rawField || typeof rawField !== "object") return;
+    const field = rawField as Record<string, any>;
+    const label = fieldLabel(field);
+    if (!label) return;
+
+    if (DETAIL_LABEL_RE.test(label)) {
+      if (!currentItems.length) return;
+      const detail = fieldDetail(field);
+      if (!detail) return;
+      for (const currentItem of currentItems) {
+        if (/\b(?:purpose)\b/i.test(label)) {
+          currentItem.purpose = currentItem.purpose ?? detail;
+        } else if (/\b(?:dose|dosage)\b/i.test(label)) {
+          currentItem.dose = currentItem.dose ?? detail;
+        } else {
+          currentItem.timing = currentItem.timing ?? detail;
+        }
+        currentItem.source_paths.push(`${sourcePath}[${index}]`);
+      }
+      return;
+    }
+
+    const kind = repeatedItemKind(label, activeKind);
+    if (!kind) return;
+    activeKind = kind;
+    const names = fieldValues(field)
+      .flatMap((value) => extractLedgerReadableNames(value))
+      .filter((name) => !YES_NO_RE.test(name) && !UUID_RE.test(name) && !INVALID_NAME_RE.test(name));
+    currentItems = [];
+    for (const name of names) {
+      const item: NormalizedCurrentStackLedgerItem = {
+        name,
+        kind,
+        source_paths: [`${sourcePath}[${index}]`],
+        raw_labels: [label],
+      };
+      parsed.push(item);
+      currentItems.push(item);
+    }
+  });
+
+  return parsed;
+}
+
+function tallyFieldCollections(submission: any): Array<{ fields: unknown; path: string }> {
+  const payload = parseJson(submission?.payload_json) ?? {};
+  const answers = parseJson(submission?.answers) ?? [];
+  return [
+    { fields: payload?.data?.fields, path: "payload_json.data.fields" },
+    { fields: payload?.form_response?.answers, path: "payload_json.form_response.answers" },
+    { fields: answers, path: "answers" },
+    { fields: answers?.data?.fields, path: "answers.data.fields" },
+  ].filter((entry) => Array.isArray(entry.fields));
+}
+
+export function findMissingRepeatedTallyItems(
+  submission: any,
+  ledger: NormalizedCurrentStackLedgerItem[]
+): string[] {
+  const ledgerKeys = new Set(ledger.map((item) => `${item.kind}:${item.name.toLowerCase()}`));
+  const missing = tallyFieldCollections(submission)
+    .flatMap(({ fields, path }) => parseTallyCurrentStackFields(fields, path))
+    .filter((item) => item.raw_labels.some((label) =>
+      /^(?:medication|supplement|hormone)\s+(?:[2-6]|others?)(?:\s*\/.*)?$/i.test(label) || /^others?$/i.test(label)
+    ))
+    .filter((item) => !ledgerKeys.has(`${item.kind}:${item.name.toLowerCase()}`))
+    .map((item) => `${item.kind}:${item.name}`);
+  return Array.from(new Set(missing));
+}
+
 export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCurrentStackLedgerItem[] {
   const ledger = new Map<string, NormalizedCurrentStackLedgerItem>();
   const addValue = (kind: CurrentStackKind, raw: unknown, sourcePath: string, rawLabel?: string) => {
@@ -106,13 +220,15 @@ export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCu
     for (const part of parts) {
       const names = extractLedgerReadableNames(part);
       for (const name of names) {
-        if (!name || UUID_RE.test(name) || INVALID_NAME_RE.test(name)) continue;
+        if (!name || YES_NO_RE.test(name) || UUID_RE.test(name) || INVALID_NAME_RE.test(name)) continue;
         const key = `${kind}:${name.toLowerCase()}`;
         const object = part && typeof part === "object" && !Array.isArray(part) ? part as Record<string, any> : {};
         const nextDose = detailFrom(object.dose ?? object.dosage ?? object.amount);
         const nextTiming = detailFrom(object.timing ?? object.frequency ?? object.schedule);
+        const nextPurpose = detailFrom(object.purpose ?? object.notes);
         const existing = ledger.get(key);
         if (existing) {
+          if (!existing.purpose && nextPurpose) existing.purpose = nextPurpose;
           if (!existing.dose && nextDose) existing.dose = nextDose;
           if (!existing.timing && nextTiming) existing.timing = nextTiming;
           if (!existing.source_paths.includes(sourcePath)) existing.source_paths.push(sourcePath);
@@ -121,6 +237,7 @@ export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCu
           ledger.set(key, {
             name,
             kind,
+            ...(nextPurpose ? { purpose: nextPurpose } : {}),
             ...(nextDose ? { dose: nextDose } : {}),
             ...(nextTiming ? { timing: nextTiming } : {}),
             source_paths: [sourcePath],
@@ -134,6 +251,17 @@ export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCu
   const engine = parseJson(submission?.engine_input_json) ?? {};
   const payload = parseJson(submission?.payload_json) ?? {};
   const answers = parseJson(submission?.answers) ?? [];
+
+  for (const { fields, path } of tallyFieldCollections(submission)) {
+    for (const item of parseTallyCurrentStackFields(fields, path)) {
+      addValue(item.kind, item, item.source_paths[0], item.raw_labels[0]);
+      const stored = ledger.get(`${item.kind}:${item.name.toLowerCase()}`);
+      if (stored) {
+        stored.source_paths = Array.from(new Set([...stored.source_paths, ...item.source_paths]));
+        stored.raw_labels = Array.from(new Set([...stored.raw_labels, ...item.raw_labels]));
+      }
+    }
+  }
 
   const directSources: Array<[CurrentStackKind, unknown, string, string]> = [
     ["medication", engine?.medications, "engine_input_json.medications", "medications"],
@@ -164,13 +292,14 @@ export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCu
     const object = value as Record<string, any>;
     const rawKey = object.key ?? object.field?.key ?? object.field?.id;
     const rawLabel = object.label ?? object.field?.label ?? object.title;
-    const fieldKind = inferKind(`${rawKey ?? ""} ${rawLabel ?? ""}`);
-    if (fieldKind) {
+    const fieldDescriptor = `${rawKey ?? ""} ${rawLabel ?? ""}`;
+    const fieldKind = inferKind(fieldDescriptor);
+    if (fieldKind && !DETAIL_LABEL_RE.test(fieldDescriptor)) {
       for (const answerValue of fieldValues(object)) addValue(fieldKind, answerValue, path, String(rawLabel ?? rawKey ?? ""));
     }
     for (const [key, nested] of Object.entries(object)) {
       const kind = inferKind(key);
-      if (kind) addValue(kind, nested, `${path}.${key}`, key);
+      if (kind && !DETAIL_LABEL_RE.test(key)) addValue(kind, nested, `${path}.${key}`, key);
       scan(nested, `${path}.${key}`, seen, depth + 1);
     }
   };
@@ -178,7 +307,5 @@ export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCu
   scan(answers, "answers");
   scan(payload, "payload_json");
 
-  return Array.from(ledger.values()).sort((a, b) =>
-    a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name)
-  );
+  return Array.from(ledger.values());
 }


### PR DESCRIPTION
## Summary

Creates one canonical normalized Current Stack ledger before any LLM call and now parses ordered repeated Tally medication, supplement, and hormone groups directly from `payload_json.data.fields`, `payload_json.form_response.answers`, and `answers`.

### Repeated Tally group hardening

- recognizes List Medication/Supplements/Hormones, numbered fields 2–6, group-specific Others fields, and order-dependent plain “Others”
- keeps fields in original Tally order
- attaches adjacent purpose, dosage, and frequency/timing fields to the preceding item or multi-select group
- ignores purpose/dosage/frequency values as item names
- ignores Yes/No fields, UUID-only values, placeholders, and `[object Object]`
- validates that populated repeated Medication 2–6, Supplement 2–6, Hormone 2–6, and Others fields are present in the final ledger; generation fails before persistence if any are omitted
- adds the requested ledger totals, category name lists, and source-field diagnostics

### Canonical ledger consumers

The same ledger exclusively drives:

- Current Stack rendering
- Pass B Contraindications context and coverage
- Dosing “Current Stack Notes”
- persisted `stack_items` current items
- existing sidebar data
- Contraindications/Current Stack report parity validation

## Root cause

Normalized submission columns and child tables do not contain the full intake. The missing values are stored in ordered repeated Tally fields inside the raw payload. Generic recursive extraction did not reliably associate repeated item labels with adjacent purpose/dose/frequency fields.

## Checks

- `npm run typecheck` — passed
- `npm run build` — passed with placeholder sandbox environment values
- focused ordered-field fixture — passed with all confirmed medication, supplement, and hormone entries; attached purpose/dose/frequency; no Yes/No, UUID, or object-string names

The build emitted the expected placeholder Supabase fetch warning during static generation. No secrets were requested or committed.

## Scope preserved

No checkout/auth, PDF export, sidebar layout, canonical report ordering, or no-END behavior changes.

## Manual QA

1. Use the existing raw Tally payload or submit a fresh intake.
2. Confirm Current Stack includes Metformin, Zepbound, Armour Thyroid, Melatonin, Omega-3, Vitamin D, Magnesium Glycinate, Creatine Monohydrate, Glycine, Vitamin B-12, Testosterone gel 1%, DHEA, and Pregnenolone.
3. Confirm adjacent purpose, dosage, and frequency values align with the correct item.
4. Confirm Contraindications and Dosing Current Stack Notes use the same items.
5. Confirm all current items are persisted and visible in the sidebar.
6. Confirm no `[object Object]`, UUID-only, empty, or Yes/No item names.
7. Confirm PDF export still works.
