### PR TITLE
PR #31: Current Stack parser cleanup, recommendation mix, and PDF polish

### DIFF
--- a/app/api/export-pdf/route.ts
+++ b/app/api/export-pdf/route.ts
@@ -1,9 +1,6 @@
 // app/api/export-pdf/route.ts
-// -----------------------------------------------------------------------------
 // GET /api/export-pdf?submission_id=<UUID or Tally short id>
-//     OR /api/export-pdf?tally_submission_id=<Tally short id>
-// Generates a styled PDF (Markdown-based) with branding + static disclaimer.
-// -----------------------------------------------------------------------------
+// OR  /api/export-pdf?tally_submission_id=<Tally short id>
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -12,14 +9,12 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+import { renderReportPdf } from "@/lib/reportPdf";
 
-// Helpers
 function isUUID(id: string) {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-    id
-  );
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
 }
+
 function stripFences(md: string) {
   return md
     .replace(/^```[a-z]*\n/i, "")
@@ -28,14 +23,12 @@ function stripFences(md: string) {
     .trim();
 }
 
-// Static disclaimer text (matches Results page)
 const DISCLAIMER_TEXT =
   "This plan from LVE360 (Longevity | Vitality | Energy) is for educational purposes only and is not medical advice. It is not intended to diagnose, treat, cure, or prevent any disease. Always consult with your healthcare provider before starting new supplements or making significant lifestyle changes, especially if you are pregnant, nursing, managing a medical condition, or taking prescriptions. Supplements are regulated under the Dietary Supplement Health and Education Act (DSHEA); results vary and no outcomes are guaranteed. If you experience unexpected effects, discontinue use and seek professional care. By using this report, you agree that decisions about your health remain your responsibility and that LVE360 is not liable for how information is applied.";
 
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = req.nextUrl;
-
     const explicitTally = searchParams.get("tally_submission_id");
     const raw = explicitTally ?? searchParams.get("submission_id");
 
@@ -46,15 +39,12 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    // Fetch stack by UUID or short id
-    let base = supabaseAdmin.from("stacks").select("*").limit(1);
-    let query =
-      explicitTally != null
-        ? base.eq("tally_submission_id", explicitTally)
-        : isUUID(raw!)
-        ? base.eq("submission_id", raw!)
-        : base.eq("tally_submission_id", raw!);
-
+    const base = supabaseAdmin.from("stacks").select("*").limit(1);
+    const query = explicitTally != null
+      ? base.eq("tally_submission_id", explicitTally)
+      : isUUID(raw)
+        ? base.eq("submission_id", raw)
+        : base.eq("tally_submission_id", raw);
     const { data: stackRow, error: stackErr } = await query.maybeSingle();
 
     if (stackErr) {
@@ -62,126 +52,21 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: false, error: "DB error" }, { status: 500 });
     }
     if (!stackRow) {
-      return NextResponse.json(
-        { ok: false, error: "Stack not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ ok: false, error: "Stack not found" }, { status: 404 });
     }
 
-    // Resolve content: prefer sections.markdown, else summary
-    let content: string =
+    const content = stripFences(
       (stackRow?.sections?.markdown as string | undefined) ??
       (stackRow?.summary as string | undefined) ??
-      "No report content available.";
+      "No report content available."
+    );
+    const pdfBytes = await renderReportPdf(content, DISCLAIMER_TEXT);
 
-    content = stripFences(content);
-
-    // --- Create PDF ---
-    const pdfDoc = await PDFDocument.create();
-    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
-    const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
-
-    let page = pdfDoc.addPage([612, 792]); // Letter
-    const margin = 50;
-    const lineGap = 4;
-
-    let cursorY = page.getHeight() - margin;
-
-    function addPage() {
-      page = pdfDoc.addPage([612, 792]);
-      cursorY = page.getHeight() - margin;
-      drawHeader();
-    }
-
-    function drawText(
-      text: string,
-      size = 11,
-      color = rgb(0, 0, 0),
-      bold = false
-    ) {
-      if (cursorY < margin + size + lineGap) addPage();
-      page.drawText(text, {
-        x: margin,
-        y: cursorY,
-        size,
-        font: bold ? boldFont : font,
-        color,
-      });
-      cursorY -= size + lineGap;
-    }
-
-    function drawWrapped(text: string, size = 11, color = rgb(0, 0, 0)) {
-      const maxWidth = page.getWidth() - margin * 2;
-      const words = text.split(/\s+/);
-      let line = "";
-      for (const word of words) {
-        const test = line ? line + " " + word : word;
-        const width = (boldFont ?? font).widthOfTextAtSize(test, size);
-        if (width > maxWidth) {
-          drawText(line, size, color);
-          line = word;
-        } else {
-          line = test;
-        }
-      }
-      if (line) drawText(line, size, color);
-    }
-
-    function drawHeader() {
-      drawText("LVE360 | Longevity • Vitality • Energy", 16, rgb(0.03, 0.76, 0.63), true);
-      cursorY -= 6;
-    }
-
-    // --- Title/header ---
-    drawHeader();
-
-    // --- Render Markdown-ish plain text (simple, durable parser) ---
-    const lines = content.split(/\r?\n/);
-    for (const line of lines) {
-      const l = line.trim();
-      if (!l) {
-        cursorY -= 6;
-        continue;
-      }
-      if (l.startsWith("# ")) {
-        drawText(l.replace(/^#\s+/, ""), 15, rgb(0.1, 0.2, 0.4), true);
-        cursorY -= 6;
-        continue;
-      }
-      if (l.startsWith("## ")) {
-        drawText(l.replace(/^##\s+/, ""), 13, rgb(0.1, 0.2, 0.4), true);
-        continue;
-      }
-      if (l.startsWith("- ")) {
-        drawWrapped("• " + l.slice(2), 11, rgb(0, 0, 0));
-        continue;
-      }
-      // crude table handling: just print lines at smaller size
-      if (l.includes("|")) {
-        if (/^\s*\|?\s*-+\s*\|/.test(l) || l.includes("---")) {
-          // Skip separator rows
-          continue;
-        }
-        drawWrapped(l, 9, rgb(0.25, 0.25, 0.25));
-        continue;
-      }
-      drawWrapped(l, 11, rgb(0, 0, 0));
-    }
-
-    // --- Static Disclaimer (always last) ---
-    cursorY -= 14;
-    drawText("Important Wellness Disclaimer", 12, rgb(0.03, 0.76, 0.63), true);
-    DISCLAIMER_TEXT.split(/(?<=\.)\s+/).forEach((sentence) => {
-      drawWrapped(sentence.trim(), 10, rgb(0.3, 0.3, 0.3));
-    });
-
-    // --- Finalize ---
-    const pdfBytes = await pdfDoc.save();
     return new NextResponse(Buffer.from(pdfBytes), {
       status: 200,
       headers: {
         "Content-Type": "application/pdf",
-        "Content-Disposition": `inline; filename="LVE360_Blueprint.pdf"`,
+        "Content-Disposition": 'inline; filename="LVE360_Blueprint.pdf"',
       },
     });
   } catch (err: any) {

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -18,6 +18,7 @@ import {
   buildNormalizedCurrentStackLedger,
   currentStackKindLabel,
   findMissingRepeatedTallyItems,
+  isMalformedCurrentStackName,
   type NormalizedCurrentStackLedgerItem,
 } from "@/lib/normalizedCurrentStackLedger";
 import {
@@ -363,20 +364,37 @@ function complianceSafeLanguage(text: string): string {
     .replace(/\bno specific conflicts? (?:were )?detected(?: from your intake)?\b/gi, "No specific interaction was flagged by this report");
 }
 
-function ensureContraCurrentStackCoverage(passB: string, ledger: NormalizedCurrentStackLedgerItem[]): string {
+function ensureContraCurrentStackCoverage(
+  passB: string,
+  ledger: NormalizedCurrentStackLedgerItem[],
+  berberineRequiresReview = false
+): string {
   const header = "## Contraindications & Med Interactions";
   const body = sectionChunk(passB, header);
   if (!body || !ledger.length) return complianceSafeLanguage(passB);
   const beforeAnalysis = body.split(/^\*\*Analysis\*\*/im)[0] ?? "";
   const sourceBullets = beforeAnalysis.split(/\r?\n/).filter((line) => /^\s*[-*]\s+/.test(line));
+  const sourceByLabel = new Map(sourceBullets.flatMap((line) => {
+    const bold = line.match(/^\s*[-*]\s+\*\*([^*]+)\*\*/)?.[1];
+    const plain = line.match(/^\s*[-*]\s+([^:]+):/)?.[1];
+    const label = (bold ?? plain ?? "").replace(/:+$/g, "").trim().toLowerCase();
+    return label ? [[label, line] as const] : [];
+  }));
+  const sedationContext = /\b(?:lunesta|eszopiclone|xanax|zanax|alprazolam|melatonin|glycine)\b/i;
   const bullets = ledger.map((item) => {
-    const existing = sourceBullets.find((line) => line.toLowerCase().includes(item.name.toLowerCase()));
-    const detail = existing
+    const existing = sourceByLabel.get(item.name.toLowerCase());
+    let detail = existing
       ? existing
           .replace(/^\s*[-*]\s+/, "")
           .replace(/^\*\*[^*]+\*\*\s*(?::|--|\u2014|-)?\s*/, "")
           .trim()
       : "No specific interaction was flagged by this report.";
+    detail = detail.replace(new RegExp(`^(?:\\*\\*)?${escapeRe(item.name)}(?:\\*\\*)?\\s*:?\\s*`, "i"), "").trim();
+    if (sedationContext.test(item.name)) {
+      detail = "This item may add to drowsiness when combined with other sleep-supporting or sedating items. Review the combined routine with a qualified clinician or pharmacist.";
+    } else if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(item.name)) {
+      detail = "Glucose-lowering medication or blood-sugar context was reported. Coordinate review with a qualified clinician or pharmacist before changing use.";
+    }
     const review = /qualified clinician|pharmacist/i.test(detail)
       ? detail
       : `${detail.replace(/[.\s]+$/, "")}. Review with a qualified clinician or pharmacist before changing use.`;
@@ -440,32 +458,53 @@ function sanitizeBlueprintTable(
   berberineRequiresReview = false
 ): string {
   const rows = blueprintTable.split(/\r?\n/).filter((line) => /^\s*\|\s*\d+\s*\|/.test(line));
-  const seen = new Set<string>();
   const allowed = new Set(allowedNames.map((name) => name.toLowerCase()));
   const currentSupplements = new Set(currentLedger
     .filter((item) => item.kind === "supplement")
     .map((item) => normalizeSupplementName(item.name).toLowerCase()));
-  const items = rows.flatMap((row) => {
+  const parsedItems = rows.flatMap((row) => {
     const cells = row.split("|").slice(1, -1).map((cell) => cell.trim());
     const name = validItemName(cells[1]);
-    if (!name || !isEligibleSupplementName(name) || !allowed.has(name.toLowerCase()) || seen.has(name.toLowerCase())) return [];
-    seen.add(name.toLowerCase());
+    if (!name || isMalformedCurrentStackName(name) || !isEligibleSupplementName(name) || !allowed.has(name.toLowerCase())) return [];
     const whyCell = cells.length >= 4 ? cells[3] : cells[2];
-    return [{ name, why: cleanName(whyCell || "") || "Consider based on intake goals and clinician review" }];
+    return [{ name, why: cleanName(whyCell || "") || "Consider based on intake goals and clinician review", explicit: true }];
   });
+  const candidates = [...parsedItems];
   for (const name of DEFAULT_BLUEPRINT_ITEMS) {
-    if (items.length >= minRows) break;
-    if (seen.has(name.toLowerCase())) continue;
-    seen.add(name.toLowerCase());
-    items.push({ name, why: "Consider based on intake goals and clinician review" });
+    if (!allowed.has(name.toLowerCase())) continue;
+    candidates.push({ name, why: "Consider based on intake goals and clinician review", explicit: false });
   }
+  const candidateNames = new Set<string>();
+  const deduped = candidates.filter((item) => {
+    const key = normalizeSupplementName(item.name).toLowerCase();
+    if (candidateNames.has(key)) return false;
+    candidateNames.add(key);
+    return true;
+  });
+  const classified = deduped.map((item) => ({
+    ...item,
+    status: berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(item.name)
+      ? "Clinician review" as const
+      : currentSupplements.has(normalizeSupplementName(item.name).toLowerCase())
+        ? "Current - optimize" as const
+        : "New - consider" as const,
+  }));
+  const currentPool = classified.filter((item) => item.status === "Current - optimize").slice(0, 5);
+  const clinicianPool = classified.filter((item) => item.status === "Clinician review" && item.explicit).slice(0, 1);
+  const newPool = classified.filter((item) => item.status === "New - consider");
+  const selected = [...currentPool];
+  const reservedClinician = clinicianPool.length;
+  const requiredNew = Math.max(4, minRows - selected.length - reservedClinician);
+  selected.push(...newPool.slice(0, requiredNew));
+  selected.push(...clinicianPool);
+  if (selected.length < minRows) {
+    const selectedNames = new Set(selected.map((item) => normalizeSupplementName(item.name).toLowerCase()));
+    selected.push(...newPool.filter((item) => !selectedNames.has(normalizeSupplementName(item.name).toLowerCase())).slice(0, minRows - selected.length));
+  }
+  const items = selected.slice(0, minRows);
   const header = "| Rank | Supplement | Status | Why it Matters |\n| --- | --- | --- | --- |";
   return `${header}\n${items.map((item, index) => {
-    const status = berberineRequiresReview && /^berberine$/i.test(item.name)
-      ? "Clinician review"
-      : currentSupplements.has(normalizeSupplementName(item.name).toLowerCase())
-        ? "Current - optimize"
-        : "New - consider";
+    const status = item.status;
     const why = status === "Clinician review"
       ? `${item.why.replace(/[.\s]+$/, "")}. Coordinate with a qualified clinician before considering use.`
       : item.why;
@@ -515,8 +554,12 @@ function consistentDosingBody(
   });
   const currentLines = bullets.filter((line) => {
     const name = bulletName(line);
-    return Boolean(name && !blueprintSet.has(normalizeSupplementName(name).toLowerCase()) && currentSet.has(normalizeSupplementName(name).toLowerCase()));
+    return Boolean(name && !isMalformedCurrentStackName(name) && !blueprintSet.has(normalizeSupplementName(name).toLowerCase()) && currentSet.has(normalizeSupplementName(name).toLowerCase()));
   });
+  const uniqueCurrentLines = Array.from(new Map(currentLines.flatMap((line) => {
+    const name = bulletName(line);
+    return name ? [[normalizeSupplementName(name).toLowerCase(), line] as const] : [];
+  })).values());
   const covered = new Set(
     modelBlueprintLines.map((line) => bulletName(line)?.toLowerCase()).filter((name): name is string => Boolean(name))
   );
@@ -531,22 +574,25 @@ function consistentDosingBody(
       normalizeSupplementName(item.name).toLowerCase() === normalizeSupplementName(name).toLowerCase());
     const reported = [current?.dose, current?.timing].filter(Boolean).join(", ");
     if (current && reported) return `- **${name}** -- Currently reported: ${reported}. Review before changing.`;
-    if (berberineRequiresReview && /^berberine$/i.test(name)) {
+    if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(name)) {
       return `- **${name}** -- Clinician review is required before considering use because glucose-lowering medication or blood-sugar context was reported. Do not start without coordinated review.`;
     }
     return modelLineByName.get(name.toLowerCase()) ??
       `- **${name}** -- Clinician review is recommended before use; a specific dose or timing is not provided.`;
   }).map(complianceSafeLanguage);
   const coveredCurrent = new Set(
-    currentLines.map((line) => bulletName(line)?.toLowerCase()).filter((name): name is string => Boolean(name))
+    uniqueCurrentLines.map((line) => {
+      const name = bulletName(line);
+      return name ? normalizeSupplementName(name).toLowerCase() : null;
+    }).filter((name): name is string => Boolean(name))
   );
   const missingCurrentLines = ledger
-    .filter((item) => !blueprintSet.has(normalizeSupplementName(item.name).toLowerCase()) && !coveredCurrent.has(item.name.toLowerCase()))
+    .filter((item) => !blueprintSet.has(normalizeSupplementName(item.name).toLowerCase()) && !coveredCurrent.has(normalizeSupplementName(item.name).toLowerCase()))
     .map((item) => {
       const details = [item.dose ? `dose: ${item.dose}` : null, item.timing ? `timing: ${item.timing}` : null].filter(Boolean).join("; ");
       return `- **${item.name}** -- Current ${currentStackKindLabel(item.kind).toLowerCase()} reported${details ? ` (${details})` : ""}. Review interactions and any changes with a qualified clinician or pharmacist.`;
     });
-  const currentNotes = [...currentLines, ...missingCurrentLines];
+  const currentNotes = [...uniqueCurrentLines, ...missingCurrentLines];
   const currentBlock = currentNotes.length
     ? `\n\n### Current Stack Notes\n\n${currentNotes.join("\n")}`
     : "";
@@ -636,6 +682,33 @@ function blueprintOK(md: string, minRows: number) {
   const dataStart = sepIdx >= 0 ? sepIdx + 1 : 1;
   const data = tableLines.slice(dataStart).filter((l) => /\S/.test(l));
   return data.length >= minRows;
+}
+
+function validateBlueprintMix(md: string) {
+  const rows = sectionChunk(md, "## Your Blueprint Recommendations")
+    .split(/\r?\n/)
+    .filter((line) => /^\s*\|\s*\d+\s*\|/.test(line))
+    .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()));
+  const statuses = rows.map((cells) => cells[2]);
+  const counts = {
+    total: rows.length,
+    current: statuses.filter((status) => status === "Current - optimize").length,
+    new: statuses.filter((status) => status === "New - consider").length,
+    clinicianReview: statuses.filter((status) => status === "Clinician review").length,
+  };
+  return {
+    valid: counts.total === 10 && counts.current <= 5 && counts.new >= 4 && counts.clinicianReview <= 1 &&
+      statuses.every((status) => ["Current - optimize", "New - consider", "Clinician review"].includes(status)),
+    counts,
+  };
+}
+
+function malformedCurrentStackRows(md: string): string[] {
+  return sectionChunk(md, "## Current Stack")
+    .split(/\r?\n/)
+    .filter((line) => /^\s*\|/.test(line) && !/^\s*\|\s*(?:Current Item|-+)/i.test(line))
+    .map((line) => line.split("|")[1]?.trim() ?? "")
+    .filter(isMalformedCurrentStackName);
 }
 
 function citationsOK(md: string) {
@@ -975,6 +1048,7 @@ function normalizeSupplementName(name: string): string {
   if (collapsed.startsWith("creatine")) return "Creatine Monohydrate";
   if (collapsed.startsWith("curcumin") || collapsed.startsWith("turmeric")) return "Curcumin";
   if (collapsed.startsWith("probiotic")) return "Probiotic";
+  if (collapsed.startsWith("collagen")) return "Collagen peptides";
   if (collapsed.includes("psyllium") || collapsed.startsWith("soluble fiber") || collapsed.startsWith("fiber (")) return "Soluble fiber (psyllium)";
   if (collapsed.startsWith("rhodiola")) return "Rhodiola Rosea";
   if (collapsed.startsWith("ginkgo")) return "Ginkgo Biloba";
@@ -993,6 +1067,7 @@ const ALIAS_MAP: Record<string, string> = {
   "Creatine Monohydrate": "creatine (monohydrate)",
   "Curcumin": "curcumin (95% curcuminoids + piperine)",
   "Probiotic": "probiotic (lacto/bifido blend)",
+  "Collagen peptides": "collagen peptides",
   "Soluble fiber (psyllium)": "fiber (psyllium husk)",
   "Rhodiola Rosea": "rhodiola rosea (3% rosavins)",
   "Ginkgo Biloba": "ginkgo biloba (24/6)",
@@ -1024,6 +1099,7 @@ function buildEvidenceCandidates(normName: string): string[] {
     "Creatine Monohydrate": ["creatine (monohydrate)", "creatine monohydrate", "creatine"],
     "Curcumin": ["curcumin (95% curcuminoids + piperine)", "curcumin", "turmeric"],
     "Probiotic": ["probiotic (lacto/bifido blend)", "probiotic", "probiotics"],
+    "Collagen peptides": ["collagen peptides", "collagen peptide", "hydrolyzed collagen"],
     "Soluble fiber (psyllium)": ["fiber (psyllium husk)", "psyllium husk", "psyllium", "soluble fiber"],
     "Rhodiola Rosea": ["rhodiola rosea (3% rosavins)", "rhodiola rosea"],
     "Ginkgo Biloba": ["ginkgo biloba (24/6)", "ginkgo biloba"],
@@ -1245,6 +1321,7 @@ Output ONLY the section "## Your Blueprint Recommendations" as a Markdown table 
 | Rank | Supplement | Status | Why it Matters |
 
 - Provide exactly **10** data rows (Rank 1..10).
+- Include at least 4 "New - consider" rows, no more than 5 "Current - optimize" rows, and no more than 1 "Clinician review" row.
 - Recommend goal-aligned supplement options only. Never recommend medications, prescription drugs, or hormones.
 - Never recommend endocrine-active supplements such as DHEA or Pregnenolone by default.
 - Select from the recommendable supplement ledger. Do not simply copy the Current Stack unless a legitimate current supplement has a clear optimization reason.
@@ -1561,7 +1638,7 @@ if (missingRepeatedTallyItems.length) {
   throw new Error(`Current stack ledger omitted repeated Tally items: ${missingRepeatedTallyItems.join(", ")}`);
 }
 if (currentStackLedger.some((item) =>
-  !item.name.trim() || UUID_VALUE_RE.test(item.name) || OBJECT_STRING_RE.test(item.name)
+  isMalformedCurrentStackName(item.name) || UUID_VALUE_RE.test(item.name) || OBJECT_STRING_RE.test(item.name)
 )) {
   throw new Error("Invalid current stack ledger item name");
 }
@@ -1643,6 +1720,7 @@ Convert the text below into a single Markdown table ONLY with header exactly:
 | Rank | Supplement | Status | Why it Matters |
 
 - Provide exactly 10 data rows (Rank 1..10).
+- Include at least 4 "New - consider" rows, no more than 5 "Current - optimize" rows, and no more than 1 "Clinician review" row.
 - Short, plain-English "Why it Matters".
 - If dose/timing is relevant, write "See Dosing & Notes".
 - No other text. No code fences.
@@ -1859,7 +1937,7 @@ if (!hasContra || !hasDosing || !passBHasBodies()) {
   hasContra = _hasContra(dosingMd);
   hasDosing = _hasDosing(dosingMd);
 }
-dosingMd = ensureContraCurrentStackCoverage(dosingMd, currentStackLedger);
+dosingMd = ensureContraCurrentStackCoverage(dosingMd, currentStackLedger, berberineRequiresReview);
 
 
 // token accounting (wrapper exposes usage.*)
@@ -2101,7 +2179,7 @@ const safetyInput = {
   const isShoppableItem = (item: StackItem) => {
     const key = itemKey(item.name);
     const currentKind = currentKindByName.get(key);
-    if (berberineRequiresReview && /^berberine$/i.test(item.name)) return false;
+    if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(item.name)) return false;
     return shoppableNames.has(key) && isEligibleSupplementName(item.name) && (!currentKind || currentKind === "supplement");
   };
   const isEvidenceItem = (item: StackItem) => {
@@ -2175,7 +2253,7 @@ const safetyInput = {
   }
   if (itemsForPersistence.some((item) => {
     const name = validItemName(item.name);
-    return !name || UUID_VALUE_RE.test(name) || OBJECT_STRING_RE.test(name);
+    return !name || isMalformedCurrentStackName(name) || UUID_VALUE_RE.test(name) || OBJECT_STRING_RE.test(name);
   })) {
     throw new Error("Invalid current stack item blocked before persistence");
   }
@@ -2223,6 +2301,8 @@ const safetyInput = {
   const targets = computeValidationTargets(mode, cap);
   const emptySections = emptyRequiredSections(md);
   const parity = validateCurrentStackParity(md, currentStackLedger);
+  const blueprintMix = validateBlueprintMix(md);
+  const malformedCurrentRows = malformedCurrentStackRows(md);
   if (!parity.valid) console.warn("[validation] contraindication_current_stack_mismatch", parity.mismatch);
   console.info("[validation] current stack parity", {
     current_stack_rendered_count: currentStackLedger.filter((item) =>
@@ -2234,15 +2314,19 @@ const safetyInput = {
     wordCountOK: wc(md) >= targets.minWords,
     headingsValid: headingsOK(md),
     blueprintValid: blueprintOK(md, targets.minRows),
+    blueprintMixValid: blueprintMix.valid,
     citationsValid: citationsOK(md),
     narrativesValid: narrativesOK(md, targets.minSent),
     sectionBodiesValid: emptySections.length === 0,
     currentStackParityValid: parity.valid,
+    currentStackNamesValid: malformedCurrentRows.length === 0,
     endValid: !/(^|\n)##\s*END\s*(?=\n|$)/i.test(md),
   };
   if (emptySections.length) {
     console.warn("[validation] empty required section bodies:", emptySections);
   }
+  if (!blueprintMix.valid) console.warn("[validation] invalid Blueprint recommendation mix", blueprintMix.counts);
+  if (malformedCurrentRows.length) console.warn("[validation] malformed Current Stack rows", malformedCurrentRows);
   console.info("validation.targets", targets);
   console.info("validation.debug", { ...ok, actualWordCount: wc(md) });
 
@@ -2251,6 +2335,12 @@ const safetyInput = {
   }
   if (!ok.currentStackParityValid) {
     throw new Error(`Refusing to persist report with Current Stack mismatch: ${parity.mismatch.join(", ")}`);
+  }
+  if (!ok.blueprintMixValid) {
+    throw new Error(`Refusing to persist invalid Blueprint recommendation mix: ${JSON.stringify(blueprintMix.counts)}`);
+  }
+  if (!ok.currentStackNamesValid) {
+    throw new Error(`Refusing to persist malformed Current Stack rows: ${malformedCurrentRows.join(", ")}`);
   }
 
   // ----------------------------------------------------------------------------
@@ -2271,7 +2361,7 @@ const safetyInput = {
           tokens_used: (promptTokens ?? 0) + (completionTokens ?? 0),
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
-          safety_status: (ok.headingsValid && ok.blueprintValid && ok.citationsValid && ok.sectionBodiesValid && ok.currentStackParityValid) ? "safe" : "warning",
+          safety_status: (ok.headingsValid && ok.blueprintValid && ok.blueprintMixValid && ok.citationsValid && ok.sectionBodiesValid && ok.currentStackParityValid && ok.currentStackNamesValid) ? "safe" : "warning",
           summary: md,
           sections: { markdown: md, generated_at: new Date().toISOString(), mode, item_cap: cap ?? null },
           notes: null,

--- a/src/lib/normalizedCurrentStackLedger.ts
+++ b/src/lib/normalizedCurrentStackLedger.ts
@@ -13,7 +13,7 @@ export type NormalizedCurrentStackLedgerItem = {
 };
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const INVALID_NAME_RE = /^(?:\[object Object\]|tbd|none|null|no|n\/?a|blank|no (?:medications?|supplements?|hormones?)|not reported)$/i;
+const INVALID_NAME_RE = /^(?:\[object Object\]|tbd|none|null|no|n\/?a|blank|each|no (?:medications?|supplements?|hormones?)|not reported)$/i;
 const KIND_PATTERNS: Array<[CurrentStackKind, RegExp]> = [
   ["hormone", /\b(?:hormones?|trt|testosterone|dhea|pregnenolone)\b/i],
   ["medication", /\b(?:medications?|prescriptions?|drugs?|glp(?:[ -]?1)?|thyroid)\b/i],
@@ -25,7 +25,31 @@ const DETAIL_LABEL_RE = /\b(?:purpose|dose|dosage|frequency|timing|how often|whe
 const YES_NO_RE = /^(?:yes|no|true|false)$/i;
 const ENDOCRINE_ACTIVE_RE = /^(?:dhea|pregnenolone)\b/i;
 const INLINE_DOSE_RE = /\b\d+(?:\.\d+)?\s*(?:mcg|\u00b5g|ug|mg|g|iu|ml)\b|\b\d+(?:\.\d+)?\s*%/i;
-const INLINE_FREQUENCY_RE = /\b(?:(?:once|twice|three times|\d+\s*x)\s*(?:(?:a|per)\s+)?(?:day|daily)?|daily|weekly|monthly|every other day)\b/i;
+const INLINE_FREQUENCY_RE = /\b(?:(?:once|twice|three times|\d+\s*x)\s*(?:(?:a|per)\s+)?(?:day|daily)?|daily|nightly|weekly|monthly|every other day)\b/i;
+const DOSE_ONLY_RE = /^\d+(?:\.\d+)?\s*(?:mcg|\u00b5g|ug|mg|g|iu|ml|%)(?:\s*(?:daily|nightly|morning|evening|night|am|pm|weekly|monthly|twice daily))?$/i;
+const DANGLING_DASH_RE = /(?:\u2014|\u2013|â€”|â€“|-|\?)\s*$/;
+
+function normalizeNumericCommas(value: string): string {
+  return value.replace(/(\d),(?=\d{3}\b)/g, "$1");
+}
+
+function cleanParsedName(value: string): string {
+  const cleaned = value
+    .replace(/\s*(?:\u2014|\u2013|â€”|â€“|-)\s*$/g, "")
+    .replace(/\s*\?\s*$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (/^(?:alcar|acetyl[- ]l[- ]carnitine(?:\s*\(alcar\))?)$/i.test(cleaned)) {
+    return "Acetyl-L-carnitine (ALCAR)";
+  }
+  return cleaned;
+}
+
+export function isMalformedCurrentStackName(value: unknown): boolean {
+  const name = String(value ?? "").replace(/\s+/g, " ").trim();
+  return !name || INVALID_NAME_RE.test(name) || UUID_RE.test(name) || DANGLING_DASH_RE.test(name) ||
+    /^\d+$/.test(name) || /^0{2,}\s*(?:mg|mcg|g|iu|ml)\b/i.test(name) || DOSE_ONLY_RE.test(name);
+}
 
 export function classifyCurrentStackKind(name: string, fallback: CurrentStackKind): CurrentStackKind {
   return ENDOCRINE_ACTIVE_RE.test(name.trim()) ? "endocrine_active_supplement" : fallback;
@@ -42,12 +66,12 @@ export function parseCurrentStackFreeText(raw: string): {
   timing?: string;
   purpose?: string;
 } {
-  const original = raw.replace(/\s+/g, " ").trim();
+  const original = normalizeNumericCommas(raw).replace(/\s+/g, " ").trim();
   const dose = original.match(INLINE_DOSE_RE)?.[0]?.trim();
   const purposeMatch = original.match(/\bfor\s+([^,;]+)$/i);
   const purpose = purposeMatch?.[1]?.trim();
   const timingParts: string[] = [];
-  const timeOfDay = original.match(/\b(?:morning|evening|night|bedtime|am|pm)\b/i)?.[0];
+  const timeOfDay = original.match(/\b(?:morning|evening|night|nightly|bedtime|am|pm)\b/i)?.[0];
   const frequency = original.match(INLINE_FREQUENCY_RE)?.[0];
   const withFood = original.match(/\bwith\s+(?:breakfast|lunch|dinner|meals?|food)\b/i)?.[0];
   const asNeeded = /\bas needed\b/i.test(original) ? "As needed" : undefined;
@@ -59,14 +83,15 @@ export function parseCurrentStackFreeText(raw: string): {
   if (purposeMatch) name = name.replace(purposeMatch[0], " ");
   if (dose) name = name.replace(dose, " ");
   name = name
-    .replace(/\bat\s+(?:morning|evening|night|bedtime)\b/gi, " ")
-    .replace(/\b(?:morning|evening|night|bedtime|am|pm)\b/gi, " ")
+    .replace(/\bat\s+(?:morning|evening|night|nightly|bedtime)\b/gi, " ")
+    .replace(/\b(?:morning|evening|night|nightly|bedtime|am|pm)\b/gi, " ")
     .replace(new RegExp(INLINE_FREQUENCY_RE.source, "gi"), " ")
     .replace(/\bwith\s+(?:breakfast|lunch|dinner|meals?|food)\b/gi, " ")
     .replace(/\bas needed\b/gi, " ")
     .replace(/\s+/g, " ")
-    .replace(/[,:;-]+$/g, "")
+    .replace(/[,:;]+$/g, "")
     .trim();
+  name = cleanParsedName(name);
 
   return {
     name: name || original,
@@ -85,8 +110,8 @@ function parseJson(value: unknown): any {
 
 function readableText(value: unknown): string | undefined {
   if (typeof value !== "string" && typeof value !== "number") return undefined;
-  const text = String(value).replace(/\s+/g, " ").trim();
-  return text && !INVALID_NAME_RE.test(text) && !UUID_RE.test(text) ? text : undefined;
+  const text = normalizeNumericCommas(String(value)).replace(/\s+/g, " ").trim();
+  return text && !isMalformedCurrentStackName(text) ? text : undefined;
 }
 
 export function extractLedgerReadableNames(
@@ -97,7 +122,7 @@ export function extractLedgerReadableNames(
   const value = parseJson(raw);
   if (value == null || depth > 12) return [];
   if (typeof value === "string") {
-    return value.split(/,|\n|;|\|/).map(readableText).filter((name): name is string => Boolean(name));
+    return normalizeNumericCommas(value).split(/,|\n|;|\|/).map(readableText).filter((name): name is string => Boolean(name));
   }
   if (typeof value !== "object") return [];
   if (seen.has(value)) return [];
@@ -223,10 +248,11 @@ export function parseTallyCurrentStackFields(
     activeKind = kind;
     const names = fieldValues(field)
       .flatMap((value) => extractLedgerReadableNames(value))
-      .filter((name) => !isPreferenceFieldOrValue(name) && !YES_NO_RE.test(name) && !UUID_RE.test(name) && !INVALID_NAME_RE.test(name));
+      .filter((name) => !isPreferenceFieldOrValue(name) && !YES_NO_RE.test(name) && !isMalformedCurrentStackName(name));
     currentItems = [];
     for (const rawName of names) {
       const parsedValue = parseCurrentStackFreeText(rawName);
+      if (isMalformedCurrentStackName(parsedValue.name)) continue;
       const item: NormalizedCurrentStackLedgerItem = {
         name: parsedValue.name,
         kind: classifyCurrentStackKind(parsedValue.name, kind),
@@ -278,8 +304,9 @@ export function buildNormalizedCurrentStackLedger(submission: any): NormalizedCu
     for (const part of parts) {
       const names = extractLedgerReadableNames(part);
       for (const rawName of names) {
-        if (!rawName || isPreferenceFieldOrValue(rawLabel) || isPreferenceFieldOrValue(rawName) || YES_NO_RE.test(rawName) || UUID_RE.test(rawName) || INVALID_NAME_RE.test(rawName)) continue;
+        if (!rawName || isPreferenceFieldOrValue(rawLabel) || isPreferenceFieldOrValue(rawName) || YES_NO_RE.test(rawName) || isMalformedCurrentStackName(rawName)) continue;
         const parsedValue = parseCurrentStackFreeText(rawName);
+        if (isMalformedCurrentStackName(parsedValue.name)) continue;
         const resolvedKind = classifyCurrentStackKind(parsedValue.name, kind);
         const key = `${resolvedKind}:${parsedValue.name.toLowerCase()}`;
         const object = part && typeof part === "object" && !Array.isArray(part) ? part as Record<string, any> : {};

--- a/src/lib/reportPdf.ts
+++ b/src/lib/reportPdf.ts
@@ -1,0 +1,337 @@
+import { PDFDocument, PDFFont, PDFPage, StandardFonts, rgb, type RGB } from "pdf-lib";
+
+const PAGE_WIDTH = 612;
+const PAGE_HEIGHT = 792;
+const MARGIN = 42;
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+const FOOTER_Y = 25;
+const CONTENT_BOTTOM = 48;
+
+const NAVY = rgb(0.07, 0.16, 0.27);
+const TEAL = rgb(0.03, 0.62, 0.53);
+const PALE_TEAL = rgb(0.9, 0.97, 0.95);
+const PALE_BLUE = rgb(0.94, 0.96, 0.98);
+const PALE_AMBER = rgb(1, 0.96, 0.86);
+const PALE_RED = rgb(1, 0.93, 0.91);
+const TEXT = rgb(0.14, 0.17, 0.2);
+const MUTED = rgb(0.38, 0.43, 0.48);
+const BORDER = rgb(0.82, 0.86, 0.88);
+const WHITE = rgb(1, 1, 1);
+
+function pdfText(value: string): string {
+  return String(value ?? "")
+    .replace(/â€”|â€“|\u2014|\u2013/g, "-")
+    .replace(/â€¢|\u2022/g, "-")
+    .replace(/â‰¥|\u2265/g, ">=")
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/\u2026/g, "...")
+    .replace(/\u00a0/g, " ")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, "$1: $2")
+    .replace(/[*_`]/g, "")
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function wrap(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
+  const clean = pdfText(text);
+  if (!clean) return [];
+  const lines: string[] = [];
+  let line = "";
+  const words = clean.split(/\s+/).flatMap((word) => {
+    if (font.widthOfTextAtSize(word, size) <= maxWidth) return [word];
+    const chunks: string[] = [];
+    let chunk = "";
+    for (const character of word) {
+      if (chunk && font.widthOfTextAtSize(`${chunk}${character}`, size) > maxWidth) {
+        chunks.push(chunk);
+        chunk = character;
+      } else {
+        chunk += character;
+      }
+    }
+    if (chunk) chunks.push(chunk);
+    return chunks;
+  });
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (line && font.widthOfTextAtSize(candidate, size) > maxWidth) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = candidate;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}
+
+function sectionBody(markdown: string, heading: string): string {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return markdown.match(new RegExp(`## ${escaped}([\\s\\S]*?)(?=\\n## |$)`, "i"))?.[1] ?? "";
+}
+
+function focusItems(markdown: string): string[] {
+  return sectionBody(markdown, "This Week Try")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\s*[-*]\s+/, "").trim())
+    .filter((line) => line && !/^\*\*Analysis\*\*/i.test(line) && !/^Analysis\b/i.test(pdfText(line)))
+    .map(pdfText)
+    .filter(Boolean)
+    .slice(0, 5);
+}
+
+export async function renderReportPdf(markdown: string, disclaimer: string): Promise<Uint8Array> {
+  const pdfDoc = await PDFDocument.create();
+  pdfDoc.setTitle("LVE360 Blueprint");
+  pdfDoc.setAuthor("LVE360");
+  pdfDoc.setSubject("Personalized wellness blueprint");
+  const regular = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+  let page!: PDFPage;
+  let cursorY = 0;
+
+  const drawBrandHeader = (targetPage: PDFPage = page) => {
+    targetPage.drawRectangle({ x: 0, y: PAGE_HEIGHT - 62, width: PAGE_WIDTH, height: 62, color: NAVY });
+    targetPage.drawText("LVE360", { x: MARGIN, y: PAGE_HEIGHT - 34, size: 19, font: bold, color: WHITE });
+    targetPage.drawText("LONGEVITY  |  VITALITY  |  ENERGY", { x: MARGIN + 92, y: PAGE_HEIGHT - 32, size: 8.5, font: regular, color: rgb(0.55, 0.91, 0.84) });
+    targetPage.drawRectangle({ x: MARGIN, y: PAGE_HEIGHT - 64, width: 78, height: 3, color: TEAL });
+  };
+
+  const addPage = () => {
+    page = pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    drawBrandHeader();
+    cursorY = PAGE_HEIGHT - 86;
+  };
+
+  const ensureSpace = (height: number) => {
+    if (cursorY - height < CONTENT_BOTTOM) addPage();
+  };
+
+  const drawLines = (
+    lines: string[],
+    options: { x?: number; size?: number; leading?: number; font?: PDFFont; color?: RGB } = {}
+  ) => {
+    const x = options.x ?? MARGIN;
+    const size = options.size ?? 10.5;
+    const leading = options.leading ?? size + 3.2;
+    const usedFont = options.font ?? regular;
+    const color = options.color ?? TEXT;
+    ensureSpace(lines.length * leading + 2);
+    for (const line of lines) {
+      page.drawText(line, { x, y: cursorY, size, font: usedFont, color });
+      cursorY -= leading;
+    }
+  };
+
+  const drawParagraph = (text: string, options: { indent?: number; color?: RGB; size?: number; font?: PDFFont } = {}) => {
+    const indent = options.indent ?? 0;
+    const size = options.size ?? 10.5;
+    const usedFont = options.font ?? regular;
+    drawLines(wrap(text, usedFont, size, CONTENT_WIDTH - indent), {
+      x: MARGIN + indent,
+      size,
+      font: usedFont,
+      color: options.color ?? TEXT,
+    });
+    cursorY -= 4;
+  };
+
+  const drawSectionHeader = (title: string) => {
+    ensureSpace(38);
+    const safety = /Contraindications/i.test(title);
+    page.drawRectangle({
+      x: MARGIN,
+      y: cursorY - 22,
+      width: CONTENT_WIDTH,
+      height: 28,
+      color: safety ? PALE_RED : PALE_TEAL,
+      borderColor: safety ? rgb(0.86, 0.48, 0.42) : rgb(0.58, 0.82, 0.77),
+      borderWidth: 0.7,
+    });
+    page.drawText(pdfText(title), { x: MARGIN + 11, y: cursorY - 13, size: 12.5, font: bold, color: NAVY });
+    cursorY -= 37;
+    if (safety) {
+      ensureSpace(42);
+      page.drawRectangle({ x: MARGIN, y: cursorY - 32, width: CONTENT_WIDTH, height: 34, color: PALE_AMBER, borderColor: rgb(0.88, 0.7, 0.32), borderWidth: 0.8 });
+      page.drawText("SAFETY REVIEW", { x: MARGIN + 10, y: cursorY - 12, size: 8, font: bold, color: NAVY });
+      page.drawText("Review the combined Current Stack with a qualified clinician or pharmacist before making changes.", {
+        x: MARGIN + 10, y: cursorY - 25, size: 8.5, font: regular, color: TEXT,
+      });
+      cursorY -= 43;
+    }
+  };
+
+  const drawStatusPill = (status: string, x: number, y: number, maxWidth: number) => {
+    const label = pdfText(status);
+    const color = status === "Current - optimize" ? rgb(0.78, 0.92, 0.88) : status === "Clinician review" ? rgb(1, 0.88, 0.7) : rgb(0.82, 0.9, 0.98);
+    const textWidth = Math.min(bold.widthOfTextAtSize(label, 7.2), maxWidth - 12);
+    const width = Math.min(textWidth + 14, maxWidth - 4);
+    const centerY = y + 7;
+    page.drawRectangle({ x: x + 5, y: centerY - 5, width: Math.max(1, width - 10), height: 10, color });
+    page.drawCircle({ x: x + 5, y: centerY, size: 5, color });
+    page.drawCircle({ x: x + width - 5, y: centerY, size: 5, color });
+    page.drawText(label, { x: x + 7, y: centerY - 2.5, size: 7.2, font: bold, color: NAVY, maxWidth: width - 12 });
+  };
+
+  const drawTable = (rawLines: string[]) => {
+    const rows = rawLines
+      .filter((line) => !/^\s*\|?\s*:?-{3,}/.test(line))
+      .map((line) => line.split("|").slice(1, -1).map(pdfText));
+    if (!rows.length) return;
+    const columnCount = Math.max(...rows.map((row) => row.length));
+    const header = rows[0];
+    const isBlueprint = header.some((cell) => /status/i.test(cell));
+    const statusColumn = header.findIndex((cell) => /status/i.test(cell));
+    const isCurrent = header.some((cell) => /current item/i.test(cell));
+    const proportions = isBlueprint && columnCount === 4
+      ? [0.08, 0.25, 0.2, 0.47]
+      : isCurrent && columnCount === 5
+        ? [0.24, 0.16, 0.2, 0.18, 0.22]
+        : Array.from({ length: columnCount }, () => 1 / columnCount);
+    const widths = proportions.map((part) => CONTENT_WIDTH * part);
+
+    rows.forEach((row, rowIndex) => {
+      const cellFont = rowIndex === 0 ? bold : regular;
+      const cellSize = rowIndex === 0 ? 8.2 : 8;
+      const wrapped = row.map((cell, index) => wrap(cell, cellFont, cellSize, Math.max(28, widths[index] - 12)));
+      const rowHeight = Math.max(22, ...wrapped.map((lines) => lines.length * 10 + 8));
+      ensureSpace(rowHeight + 2);
+      const y = cursorY - rowHeight;
+      page.drawRectangle({
+        x: MARGIN,
+        y,
+        width: CONTENT_WIDTH,
+        height: rowHeight,
+        color: rowIndex === 0 ? NAVY : rowIndex % 2 === 0 ? PALE_BLUE : WHITE,
+        borderColor: BORDER,
+        borderWidth: 0.45,
+      });
+      let x = MARGIN;
+      row.forEach((cell, index) => {
+        if (index > 0) page.drawLine({ start: { x, y }, end: { x, y: y + rowHeight }, color: BORDER, thickness: 0.4 });
+        if (isBlueprint && index === statusColumn && rowIndex > 0) {
+          drawStatusPill(cell, x + 3, y + rowHeight / 2 - 7, widths[index] - 6);
+        } else {
+          wrapped[index].forEach((line, lineIndex) => {
+            page.drawText(line, {
+              x: x + 6,
+              y: y + rowHeight - 11 - lineIndex * 10,
+              size: cellSize,
+              font: cellFont,
+              color: rowIndex === 0 ? WHITE : TEXT,
+              maxWidth: widths[index] - 12,
+            });
+          });
+        }
+        x += widths[index];
+      });
+      cursorY = y;
+    });
+    cursorY -= 9;
+  };
+
+  const drawFocusCard = (items: string[]) => {
+    if (!items.length) return;
+    const itemLines = items.map((item, index) => wrap(`${index + 1}. ${item}`, regular, 9.2, CONTENT_WIDTH - 30));
+    const height = 32 + itemLines.reduce((sum, lines) => sum + Math.max(13, lines.length * 11), 0);
+    ensureSpace(height + 10);
+    page.drawRectangle({ x: MARGIN, y: cursorY - height, width: CONTENT_WIDTH, height, color: PALE_BLUE, borderColor: rgb(0.45, 0.65, 0.82), borderWidth: 0.9 });
+    page.drawText("THIS WEEK FOCUS", { x: MARGIN + 13, y: cursorY - 20, size: 10, font: bold, color: NAVY });
+    let y = cursorY - 37;
+    itemLines.forEach((lines) => {
+      lines.forEach((line) => {
+        page.drawText(line, { x: MARGIN + 15, y, size: 9.2, font: regular, color: TEXT });
+        y -= 11;
+      });
+      y -= 2;
+    });
+    cursorY -= height + 13;
+  };
+
+  addPage();
+  drawFocusCard(focusItems(markdown));
+
+  const lines = markdown.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const raw = lines[index];
+    const line = raw.trim();
+    if (!line || /^##\s*END$/i.test(line)) {
+      cursorY -= 4;
+      continue;
+    }
+    if (line.startsWith("|")) {
+      const table: string[] = [];
+      while (index < lines.length && lines[index].trim().startsWith("|")) {
+        table.push(lines[index].trim());
+        index++;
+      }
+      index--;
+      drawTable(table);
+      continue;
+    }
+    if (/^##\s+/.test(line)) {
+      const heading = line.replace(/^##\s+/, "");
+      if (/^Important Wellness Disclaimer$/i.test(heading)) {
+        while (index + 1 < lines.length && !/^##\s+/.test(lines[index + 1].trim())) index++;
+        continue;
+      }
+      drawSectionHeader(heading);
+      continue;
+    }
+    if (/^###\s+/.test(line)) {
+      ensureSpace(24);
+      drawParagraph(line.replace(/^###\s+/, ""), { font: bold, size: 10.5, color: NAVY });
+      continue;
+    }
+    if (/^#\s+/.test(line)) {
+      drawParagraph(line.replace(/^#\s+/, ""), { font: bold, size: 15, color: NAVY });
+      continue;
+    }
+    if (/^[-*]\s+/.test(line)) {
+      const bullet = line.replace(/^[-*]\s+/, "");
+      ensureSpace(18);
+      page.drawCircle({ x: MARGIN + 4, y: cursorY + 3, size: 2.2, color: TEAL });
+      drawParagraph(bullet, { indent: 13 });
+      continue;
+    }
+    if (/^\*\*Analysis\*\*/i.test(line)) {
+      ensureSpace(20);
+      drawParagraph("Analysis", { font: bold, size: 9.5, color: TEAL });
+      continue;
+    }
+    drawParagraph(line);
+  }
+
+  const disclaimerLines = wrap(disclaimer, regular, 8.5, CONTENT_WIDTH - 20);
+  const disclaimerHeight = disclaimerLines.length * 11 + 18;
+  ensureSpace(disclaimerHeight + 53);
+  cursorY -= 8;
+  drawSectionHeader("Important Wellness Disclaimer");
+  page.drawRectangle({ x: MARGIN, y: cursorY - disclaimerHeight, width: CONTENT_WIDTH, height: disclaimerHeight, color: PALE_BLUE, borderColor: BORDER, borderWidth: 0.7 });
+  disclaimerLines.forEach((line, index) => {
+    page.drawText(line, { x: MARGIN + 10, y: cursorY - 14 - index * 11, size: 8.5, font: regular, color: MUTED });
+  });
+  cursorY -= disclaimerHeight;
+
+  const pages = pdfDoc.getPages();
+  pages.forEach((pdfPage, index) => {
+    drawBrandHeader(pdfPage);
+    pdfPage.drawLine({ start: { x: MARGIN, y: 41 }, end: { x: PAGE_WIDTH - MARGIN, y: 41 }, color: BORDER, thickness: 0.5 });
+    pdfPage.drawText("Educational wellness information - review changes with a qualified clinician.", {
+      x: MARGIN, y: FOOTER_Y, size: 7.2, font: regular, color: MUTED,
+    });
+    const pageLabel = `Page ${index + 1} of ${pages.length}`;
+    pdfPage.drawText(pageLabel, {
+      x: PAGE_WIDTH - MARGIN - regular.widthOfTextAtSize(pageLabel, 7.2),
+      y: FOOTER_Y,
+      size: 7.2,
+      font: regular,
+      color: MUTED,
+    });
+  });
+
+  return pdfDoc.save();
+}

--- a/src/lib/supplementEligibility.ts
+++ b/src/lib/supplementEligibility.ts
@@ -27,6 +27,7 @@ const PREFERENCE_VALUES = [
 
 const ENDOCRINE_ACTIVE_SUPPLEMENT_RE = /^(?:dhea|pregnenolone)\b/i;
 const NON_SHOPPABLE_MEDICATION_OR_HORMONE_RE = /\b(?:metformin|zepbound|tirzepatide|mounjaro|armour\s+thyroid|levothyroxine|synthroid|testosterone(?:\s+gel)?|dhea|pregnenolone|lunesta|eszopiclone|xanax|zanax|alprazolam)\b/i;
+const MALFORMED_ITEM_NAME_RE = /^(?:each|\d+|0{2,}\s*(?:mg|mcg|g|iu|ml)\b.*|\d+(?:\.\d+)?\s*(?:mg|mcg|g|iu|ml|%)(?:\s+(?:daily|nightly|morning|evening|night|am|pm))?)$/i;
 
 export const RECOMMENDABLE_SUPPLEMENT_CANDIDATES = [
   "Omega-3",
@@ -38,6 +39,7 @@ export const RECOMMENDABLE_SUPPLEMENT_CANDIDATES = [
   "Soluble fiber (psyllium)",
   "Probiotic",
   "Curcumin",
+  "Collagen peptides",
   "L-Theanine",
   "Vitamin B12",
   "Berberine",
@@ -74,6 +76,8 @@ export function isEligibleSupplementName(value: unknown): boolean {
     text &&
     !isPreferenceFieldOrValue(text) &&
     !isMedicationOrHormoneName(text) &&
+    !MALFORMED_ITEM_NAME_RE.test(text) &&
+    !/(?:\u2014|\u2013|â€”|â€“|-)\s*$/.test(text) &&
     !/^\[object object\]$/.test(text) &&
     !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(text)
   );


### PR DESCRIPTION
## Purpose

Clean up malformed Current Stack parsing, enforce a balanced 10-item recommendation mix, improve contraindication/dosing/evidence/shopping parity, and polish the generated PDF without changing the export route contract.

## Files changed

- `src/lib/normalizedCurrentStackLedger.ts` — numeric-comma normalization, dose-fragment rejection, dangling-dash cleanup, ALCAR canonicalization.
- `src/lib/generateStack.ts` — Current Stack hard guards, one-bullet contraindication coverage, recommendation mix validation, dosing-note dedupe, evidence/shopping alignment.
- `src/lib/supplementEligibility.ts` — malformed-name filtering and Collagen peptide eligibility.
- `src/lib/reportPdf.ts` — branded, structured PDF renderer with safety callouts, tables, status pills, focus card, footer, and one final disclaimer.
- `app/api/export-pdf/route.ts` — delegates rendering while preserving request lookup, response type, inline filename, and disclaimer behavior.

## What was verified

- `npm run typecheck` — passed.
- `npm run build` — passed with inert placeholders for the documented required launch variables; no secrets were written or committed.
- Parser helper assertions — passed for numeric commas, dangling separators, ALCAR canonicalization, nightly timing, and rejection of dose-only fragments.
- Rendered a representative Letter PDF with Poppler and visually inspected all pages — passed; canonical sections remain ordered and no user-facing END marker is introduced.
- `git diff --check` — passed.

## What was not verified

- `npm run qa:env` correctly failed because this sandbox has no real Supabase, OpenAI, Tally, Stripe, or app URL variables.
- No live Tally submission, Supabase persistence, production PDF route, or Vercel Preview was exercised locally.

## Risks / rollback notes

- Recommendation generation now fails closed if it cannot produce exactly 10 valid rows with at least 4 New, at most 5 Current, and at most 1 Clinician Review.
- Report persistence now fails closed on malformed Current Stack names.
- Rollback is the single commit `7f0b83d`; no schema or environment changes are included.

## Manual QA

1. Submit current items using: `Citrus bergamot — 600 mg twice daily`, `Berberine HCl — 200 mg twice daily`, `ALCAR — 1,000 mg morning`, `Vitamin C — 1,000 mg daily`, and `Apigenin — 50 mg nightly`.
2. Confirm clean names, doses, and timing; confirm no `each`, `000 mg`, dangling dash, dose-only row, UUID, or `[object Object]`.
3. Confirm Current Stack, contraindications, Current Stack dosing notes, persisted current items, and sidebar items agree.
4. Confirm contraindications contain one item-specific bullet per current item, followed by Analysis; verify sedation and Berberine/glucose cautions are non-diagnostic.
5. Confirm Blueprint has exactly 10 rows, at least 4 New, at most 5 Current, and at most 1 Clinician Review.
6. Confirm Evidence covers Blueprint items without unrelated padding, and Shopping excludes medications, hormones, endocrine-active items, malformed items, and risk-flagged Berberine.
7. Export the PDF and verify branding, section order, top focus card, safety box, table striping/status pills, page numbers/footer, final disclaimer, and no END marker.
