### PR TITLE
PR #32: Lazy Supabase admin client and build-safe API routes

### DIFF
--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -2,14 +2,12 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { createClient } from "@supabase/supabase-js";
 import { OpenAI } from "openai";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 // If you already have a helper in src/lib/openai.ts, you can import it instead.
 // import { openai } from "@/lib/openai";
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
 
 // Small helper to compute a % (0–100) safely
@@ -21,9 +19,7 @@ function pct(numerator: number, denominator: number) {
 export async function POST() {
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
-  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    auth: { persistSession: false },
-  });
+  const admin = getSupabaseAdmin();
 
   try {
     // 1) Auth

--- a/app/api/fullscript/add/route.ts
+++ b/app/api/fullscript/add/route.ts
@@ -2,13 +2,10 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { createClient } from "@supabase/supabase-js";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 // NEW: import timing helpers (you added src/lib/timing.ts earlier)
 import { bucketsForItem, collapseBucketsToString } from "@/src/lib/timing";
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 export async function POST(req: Request) {
   const cookieStore = cookies();
@@ -39,7 +36,7 @@ export async function POST(req: Request) {
     }
 
     // admin client to upsert (safer for creating stack if none exists)
-    const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+    const admin = getSupabaseAdmin();
 
     // 1) ensure latest stack for user
     const { data: stacksRows, error: stacksErr } = await admin

--- a/app/api/fullscript/search/route.ts
+++ b/app/api/fullscript/search/route.ts
@@ -2,17 +2,15 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { createClient } from "@supabase/supabase-js";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 // --- Env ---
 const FULLSCRIPT_BASE = process.env.FULLSCRIPT_BASE_URL || "https://api.fullscript.com";
 const FULLSCRIPT_API_KEY = process.env.FULLSCRIPT_API_KEY || "";
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 // Fallback query against your own supplements table when Fullscript keys are missing
 async function fallbackSearch(q: string) {
-  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false }});
+  const admin = getSupabaseAdmin();
   const { data, error } = await admin
     .from("supplements")
     .select("id, ingredient, product_name, link_fullscript, link_amazon, notes")

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,6 +1,8 @@
 // app/api/goals/route.ts
 import { NextResponse } from "next/server";
-import { supabaseAdmin } from "@/lib/supabase";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
 
 type Body = {
   userId: string;
@@ -13,6 +15,7 @@ export async function GET(req: Request) {
   const userId = url.searchParams.get("userId");
   if (!userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
 
+  const supabaseAdmin = getSupabaseAdmin();
   const { data, error } = await supabaseAdmin
     .from("goals")
     .select("goals, custom_goal, target_weight, target_sleep, target_energy")
@@ -27,6 +30,7 @@ export async function POST(req: Request) {
   const body = (await req.json()) as Body;
   if (!body?.userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
 
+  const supabaseAdmin = getSupabaseAdmin();
   const payload = {
     user_id: body.userId,
     goals: body.goals ?? [],

--- a/app/api/goals/upsert/route.ts
+++ b/app/api/goals/upsert/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { createClient } from "@supabase/supabase-js";
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -39,7 +36,7 @@ export async function POST(req: Request) {
     };
 
     // Use service role so we don't depend on RLS being perfect
-    const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+    const admin = getSupabaseAdmin();
 
     const { error: upsertErr } = await admin
       .from("goals")

--- a/app/api/intake/set/route.ts
+++ b/app/api/intake/set/route.ts
@@ -2,16 +2,13 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { createClient } from "@supabase/supabase-js";
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 // Upsert today's intake event for (user, item)
 export async function POST(req: Request) {
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
-  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+  const admin = getSupabaseAdmin();
 
   try {
     const { data: userWrap, error: userErr } = await supabase.auth.getUser();

--- a/app/api/stacks/route.ts
+++ b/app/api/stacks/route.ts
@@ -4,7 +4,8 @@ import { supabaseAdmin } from "@/lib/supabase";
 
 export async function GET() {
   try {
-    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+    if (!supabaseUrl || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
       console.error("[API] Supabase env vars missing");
       return NextResponse.json({ error: "Supabase envs not configured." }, { status: 500 });
     }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,8 +4,8 @@
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 
-// Re-export admin client so existing imports keep working
-export { supabaseAdmin } from './supabaseAdmin';
+// Re-export the lazy admin getter and compatibility client for existing callers.
+export { getSupabaseAdmin, supabaseAdmin } from './supabaseAdmin';
 
 export function supabaseServer() {
   const cookieStore = cookies();

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,11 +1,35 @@
 // lib/supabaseAdmin.ts
 // Admin client with Service Role. Server-only, never import in client code.
 import 'server-only';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-// Create ONE singleton client so callers can do: supabaseAdmin.from('table')...
-export const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!, // DO NOT expose to browser
-  { auth: { persistSession: false } }
-);
+const MISSING_ADMIN_ENV_ERROR =
+  "Missing Supabase admin environment variables: SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY";
+
+let adminClient: SupabaseClient | null = null;
+
+export function getSupabaseAdmin(): SupabaseClient {
+  if (adminClient) return adminClient;
+
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(MISSING_ADMIN_ENV_ERROR);
+  }
+
+  adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+  return adminClient;
+}
+
+// Build-safe compatibility wrapper for existing server-only imports. The real
+// client is created only when a route or server function first uses it.
+export const supabaseAdmin = new Proxy({} as SupabaseClient, {
+  get(_target, property) {
+    const client = getSupabaseAdmin();
+    const value = Reflect.get(client, property, client);
+    return typeof value === "function" ? value.bind(client) : value;
+  },
+});


### PR DESCRIPTION
## Purpose

Prevent Next.js route collection from constructing the Supabase service-role client at module import time, while preserving existing route behavior and admin-client imports.

## Root cause

`src/lib/supabaseAdmin.ts` called `createClient()` as soon as the module was imported. During Next.js page-data collection, an unavailable Supabase URL caused `/api/goals` to crash the build before any request handler ran.

## What changed

- Added a cached `getSupabaseAdmin()` lazy getter.
- The getter resolves `SUPABASE_URL ?? NEXT_PUBLIC_SUPABASE_URL` and requires `SUPABASE_SERVICE_ROLE_KEY`.
- Missing runtime configuration now throws:
  `Missing Supabase admin environment variables: SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY`
- Preserved existing `supabaseAdmin.from(...)` callers through a build-safe lazy compatibility proxy.
- Updated `/api/goals` to be `force-dynamic` and create the client inside GET/POST.
- Routed the remaining direct service-role client construction in goals upsert, intake set, AI insights, and Fullscript routes through the same lazy getter.
- Updated the stacks route guard to accept the server-only `SUPABASE_URL` fallback.

## Auth-helper deprecation audit

- Found 32 active imports from `@supabase/auth-helpers-nextjs` across login, callback, dashboard, and authenticated API flows.
- Found no direct imports from `@supabase/auth-helpers-shared`; it remains a transitive dependency.
- Kept both packages because removing or broadly migrating them would change existing auth flows and exceed PR #32's scope.
- `npm install` made no package or lockfile changes.

## Verification

- `npm install` — passed; dependency tree unchanged.
- `npm run typecheck` — passed.
- `npm run build` — passed with inert placeholders for required build variables; no secrets were written.
- Lazy-client assertion — passed:
  - module import made zero Supabase client creations;
  - missing env failed only when the getter was called, with the exact required message;
  - `SUPABASE_URL` fallback and singleton compatibility proxy worked.
- A deliberate build without Supabase variables progressed beyond `/api/goals` and all admin-client imports. It later stopped in the existing login/account auth-helper paths because those require public Supabase URL/anon variables.
- `git diff --check` — passed.
- `npm run qa:env` — expected failure because this sandbox has no real launch environment variables.

## Risks / rollback

- Existing `supabaseAdmin` imports now use a proxy that binds methods to the lazily created singleton.
- Runtime requests still fail clearly when service-role configuration is absent.
- No auth, checkout, report generation, PDF, Tally webhook, or schema behavior was changed.
- Roll back commit `36268be` if needed.

## Manual QA

1. Deploy Preview with the normal Supabase variables and confirm the build completes.
2. Exercise GET and POST `/api/goals`.
3. Exercise goals upsert, intake set, AI insights, Fullscript fallback search/add, and stacks list.
4. Confirm missing service-role configuration produces the clear runtime error rather than a module-import/build crash.
5. Smoke-test login, auth callback, dashboard session, and logout to confirm the untouched auth-helper flows remain stable.
