### PR TITLE
Canonical report dosage and desktop/PDF parity

### DIFF
--- a/app/api/export-pdf/route.ts
+++ b/app/api/export-pdf/route.ts
@@ -10,6 +10,7 @@ export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { renderReportPdf } from "@/lib/reportPdf";
+import { parseBlueprintReport } from "@/lib/blueprintReport";
 
 function isUUID(id: string) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
@@ -61,12 +62,14 @@ export async function GET(req: NextRequest) {
       "No report content available."
     );
     const pdfBytes = await renderReportPdf(content, DISCLAIMER_TEXT);
+    const reportHash = parseBlueprintReport(content).contentHash;
 
     return new NextResponse(Buffer.from(pdfBytes), {
       status: 200,
       headers: {
         "Content-Type": "application/pdf",
         "Content-Disposition": 'inline; filename="LVE360_Blueprint.pdf"',
+        "X-LVE360-Report-Hash": reportHash,
       },
     });
   } catch (err: any) {

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -8,6 +8,7 @@ import remarkGfm from "remark-gfm";
 
 import CTAButton from "@/components/CTAButton";
 import ResultsSidebar from "@/components/results/ResultsSidebar";
+import { parseBlueprintReport } from "@/lib/blueprintReport";
 
 /* ───────── helpers ───────── */
 function sanitizeMarkdown(md: string): string {
@@ -184,10 +185,12 @@ function LinksTable({ raw, type }: { raw: string; type: "evidence" | "shopping" 
 /* Section card wrapper */
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="bg-white rounded-2xl shadow-md p-6 mb-8">
-      <h2 className="text-xl font-semibold text-[#06C1A0] mb-4">{title}</h2>
-      {children}
-    </div>
+    <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-md mb-8">
+      <div className={title.includes("Contraindications") ? "border-b border-amber-200 bg-amber-50 px-6 py-4" : "bg-gradient-to-r from-[#041B2D] to-[#0B4B57] px-6 py-4"}>
+        <h2 className={title.includes("Contraindications") ? "text-xl font-semibold text-amber-900" : "text-xl font-semibold text-white"}>{title}</h2>
+      </div>
+      <div className="p-6">{children}</div>
+    </section>
   );
 }
 
@@ -466,29 +469,22 @@ async function exportPDF() {
 
 
   const sec = useMemo(() => {
-    const md = markdown ?? "";
+    const report = parseBlueprintReport(markdown ?? "");
     return {
-      intro: extractSection(md, ["Intro Summary", "Summary"]),
-      goals: extractSection(md, ["Goals"]),
-      contra: extractSection(md, ["Contraindications & Med Interactions", "Contraindications"]),
-      current: extractSection(md, ["Current Stack"]),
-      blueprint: extractSection(md, [
-        "Your Blueprint Recommendations",
-        'High-Impact "Bang-for-Buck" Additions',
-        "High-Impact Bang-for-Buck Additions",
-      ]),
-      dosing: extractSection(md, ["Dosing & Notes", "Dosing"]),
-      evidence: extractSection(md, ["Evidence & References"]),
-      shopping: extractSection(md, ["Shopping Links"]),
-      follow: extractSection(md, ["Follow-up Plan"]),
-      lifestyle: extractSection(md, ["Lifestyle Prescriptions"]),
-      longevity: extractSection(md, ["Longevity Levers"]),
-      weekTry: extractSection(md, ["This Week Try", "Weekly Experiment"]),
+      intro: report.sections["Intro Summary"], goals: report.sections.Goals,
+      contra: report.sections["Contraindications & Med Interactions"], current: report.sections["Current Stack"],
+      blueprint: report.sections["Your Blueprint Recommendations"], dosing: report.sections["Dosing & Notes"],
+      evidence: report.sections["Evidence & References"], shopping: report.sections["Shopping Links"],
+      follow: report.sections["Follow-up Plan"], lifestyle: report.sections["Lifestyle Prescriptions"],
+      longevity: report.sections["Longevity Levers"], weekTry: report.sections["This Week Try"],
+      focusItems: report.focusItems,
+      contentHash: report.contentHash,
     };
   }, [markdown]);
 
   return (
     <motion.main
+      data-report-hash={sec.contentHash}
       className="relative isolate overflow-hidden min-h-screen bg-gradient-to-br from-[#F8F5FB] via-white to-[#EAFBF8]"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -553,6 +549,15 @@ async function exportPDF() {
             </SectionCard>
 
             {error && <div className="text-center text-red-600 mb-6">{error}</div>}
+
+            {sec.focusItems.length > 0 && (
+              <div className="mb-8 rounded-2xl border border-sky-200 bg-gradient-to-r from-sky-50 to-teal-50 p-6 shadow-sm">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-sky-700">This Week Focus</p>
+                <ol className="mt-3 grid gap-2 text-sm text-slate-800 sm:grid-cols-2">
+                  {sec.focusItems.map((item, index) => <li key={item} className="rounded-xl bg-white/80 px-4 py-3"><strong>{index + 1}.</strong> {item}</li>)}
+                </ol>
+              </div>
+            )}
 
             {/* sections */}
             {sec.intro && (

--- a/src/lib/blueprintReport.ts
+++ b/src/lib/blueprintReport.ts
@@ -1,0 +1,77 @@
+export const REPORT_SECTION_NAMES = [
+  "Intro Summary", "Goals", "Contraindications & Med Interactions", "Current Stack",
+  "Your Blueprint Recommendations", "Dosing & Notes", "Evidence & References", "Shopping Links",
+  "Follow-up Plan", "Lifestyle Prescriptions", "Longevity Levers", "This Week Try",
+] as const;
+
+export type ReportSectionName = typeof REPORT_SECTION_NAMES[number];
+export type BlueprintReport = {
+  sections: Record<ReportSectionName, string>;
+  focusItems: string[];
+  canonicalMarkdown: string;
+  contentHash: string;
+};
+
+function cleanText(value: string): string {
+  return value
+    .replace(/^```[a-z]*\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .replace(/(^|\n)##\s*END\s*(?=\n|$)/gi, "$1")
+    .replace(/^\s*\*\*Analysis\*\*\s*:?\s*$/gim, "")
+    .replace(/^\s*Analysis\s*:?\s*$/gim, "")
+    .replace(/(^|\n)(\s*[-*]\s+)?\s*:\s+/g, "$1$2")
+    .replace(/\*\*([^*]+)\*\*\s*:\s*\1\s*:/gi, "**$1**:")
+    .replace(/([^\n.!?]+[.!?])\s+\1/gi, "$1")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function extract(markdown: string, heading: ReportSectionName): string {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = markdown.match(new RegExp(`^##\\s+${escaped}\\s*$([\\s\\S]*?)(?=^##\\s+|$)`, "im"));
+  let body = match?.[1] ?? "";
+  if (["Intro Summary", "Goals", "Evidence & References", "Shopping Links", "Lifestyle Prescriptions", "Longevity Levers", "This Week Try"].includes(heading)) {
+    body = body.split(/^\s*\*\*Analysis\*\*\s*:?\s*$/im)[0] ?? body;
+  }
+  const labels: Partial<Record<ReportSectionName, string>> = {
+    "Contraindications & Med Interactions": "Safety Takeaway",
+    "Current Stack": "What We Noticed",
+    "Your Blueprint Recommendations": "Why These Recommendations",
+    "Follow-up Plan": "Follow-up Priorities",
+  };
+  if (labels[heading]) body = body.replace(/^\s*\*\*Analysis\*\*\s*:?\s*$/im, `### ${labels[heading]}`);
+  return cleanText(body);
+}
+
+function hash(value: string): string {
+  let result = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    result ^= value.charCodeAt(index);
+    result = Math.imul(result, 16777619);
+  }
+  return (result >>> 0).toString(16).padStart(8, "0");
+}
+
+export function parseBlueprintReport(markdown: string): BlueprintReport {
+  const cleaned = cleanText(markdown);
+  const sections = Object.fromEntries(REPORT_SECTION_NAMES.map((name) => [name, extract(cleaned, name)])) as Record<ReportSectionName, string>;
+  const focusItems = sections["This Week Try"].split(/\r?\n/)
+    .map((line) => cleanText(line.replace(/^\s*[-*]\s+/, "")))
+    .filter(Boolean)
+    .slice(0, 5);
+  const canonicalMarkdown = REPORT_SECTION_NAMES
+    .filter((name) => sections[name])
+    .map((name) => `## ${name}\n\n${sections[name]}`)
+    .join("\n\n");
+  return { sections, focusItems, canonicalMarkdown, contentHash: hash(canonicalMarkdown) };
+}
+
+export function validateBlueprintReport(report: BlueprintReport): string[] {
+  const issues: string[] = [];
+  for (const name of REPORT_SECTION_NAMES) {
+    if (!report.sections[name].trim()) issues.push(`empty:${name}`);
+  }
+  if (/^\s*(?:Analysis)?\s*:\s*$/m.test(report.canonicalMarkdown)) issues.push("hanging-colon");
+  if (/\[object Object\]|##\s*END/i.test(report.canonicalMarkdown)) issues.push("invalid-marker");
+  return issues;
+}

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -10,6 +10,8 @@
 import getSubmissionWithChildren from "@/lib/getSubmissionWithChildren";
 import { supabaseAdmin } from "@/lib/supabase";
 import parseMarkdownToItems from "@/lib/parseMarkdownToItems";
+import { formatStartingGuidance } from "@/lib/supplementDosingRegistry";
+import { parseBlueprintReport, validateBlueprintReport } from "@/lib/blueprintReport";
 import { applySafetyChecks } from "@/lib/safetyCheck";
 import { enrichAffiliateLinks, buildAmazonSearchLink } from "@/lib/affiliateLinks";
 import { getTopCitationsFor } from "@/lib/evidence";
@@ -577,6 +579,8 @@ function consistentDosingBody(
     if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(name)) {
       return `- **${name}** -- Clinician review is required before considering use because glucose-lowering medication or blood-sugar context was reported. Do not start without coordinated review.`;
     }
+    const startingGuidance = formatStartingGuidance(name);
+    if (startingGuidance) return `- **${name}** -- ${startingGuidance}`;
     return modelLineByName.get(name.toLowerCase()) ??
       `- **${name}** -- Clinician review is recommended before use; a specific dose or timing is not provided.`;
   }).map(complianceSafeLanguage);
@@ -2267,6 +2271,13 @@ const safetyInput = {
   const shoppingRe = /## Shopping Links([\s\S]*?)(?=\n## |\n## END|$)/i;
   md = shoppingRe.test(md) ? md.replace(shoppingRe, shoppingSection) : md.replace(/\n## END/i, `\n\n${shoppingSection}\n\n## END`);
   md = complianceSafeLanguage(md);
+  const canonicalReport = parseBlueprintReport(md);
+  const canonicalIssues = validateBlueprintReport(canonicalReport);
+  if (canonicalIssues.length) {
+    console.warn("[validation] canonical report issues", canonicalIssues);
+    throw new Error(`Refusing to persist invalid canonical report: ${canonicalIssues.join(", ")}`);
+  }
+  md = canonicalReport.canonicalMarkdown;
 
   if (/\[object Object\]/i.test(md)) {
     throw new Error("Invalid object string leaked into report");

--- a/src/lib/reportPdf.ts
+++ b/src/lib/reportPdf.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, PDFFont, PDFPage, StandardFonts, rgb, type RGB } from "pdf-lib";
+import { parseBlueprintReport } from "@/lib/blueprintReport";
 
 const PAGE_WIDTH = 612;
 const PAGE_HEIGHT = 792;
@@ -83,10 +84,13 @@ function focusItems(markdown: string): string[] {
 }
 
 export async function renderReportPdf(markdown: string, disclaimer: string): Promise<Uint8Array> {
+  const report = parseBlueprintReport(markdown);
+  markdown = report.canonicalMarkdown;
   const pdfDoc = await PDFDocument.create();
   pdfDoc.setTitle("LVE360 Blueprint");
   pdfDoc.setAuthor("LVE360");
   pdfDoc.setSubject("Personalized wellness blueprint");
+  pdfDoc.setKeywords(["LVE360", "wellness", `report-${report.contentHash}`]);
   const regular = await pdfDoc.embedFont(StandardFonts.Helvetica);
   const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
 
@@ -252,7 +256,7 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
   };
 
   addPage();
-  drawFocusCard(focusItems(markdown));
+  drawFocusCard(report.focusItems);
 
   const lines = markdown.split(/\r?\n/);
   for (let index = 0; index < lines.length; index++) {
@@ -297,11 +301,7 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
       drawParagraph(bullet, { indent: 13 });
       continue;
     }
-    if (/^\*\*Analysis\*\*/i.test(line)) {
-      ensureSpace(20);
-      drawParagraph("Analysis", { font: bold, size: 9.5, color: TEAL });
-      continue;
-    }
+    if (/^\*\*Analysis\*\*/i.test(line) || /^Analysis\s*:?$/i.test(line)) continue;
     drawParagraph(line);
   }
 

--- a/src/lib/supplementDosingRegistry.ts
+++ b/src/lib/supplementDosingRegistry.ts
@@ -1,0 +1,56 @@
+export type SupplementDoseGuidance = {
+  name: string;
+  startingDose: string;
+  typicalRange: string;
+  timing: string;
+  food: string;
+  adjustment?: string;
+  guardrail?: string;
+  caution?: string;
+  evidenceLabel: string;
+  lastReviewed: string;
+};
+
+const REGISTRY: Record<string, SupplementDoseGuidance> = {
+  "omega-3": { name: "Omega-3", startingDose: "1,000 mg combined EPA+DHA daily", typicalRange: "1,000-2,000 mg EPA+DHA daily", timing: "With a meal, morning or evening", food: "Take with food", guardrail: "Do not exceed label directions; higher amounts require clinician review", caution: "Review first if using anticoagulants or before a procedure", evidenceLabel: "NIH ODS Omega-3", lastReviewed: "2026-07-18" },
+  "vitamin d": { name: "Vitamin D", startingDose: "1,000 IU daily", typicalRange: "1,000-2,000 IU daily", timing: "Morning or midday", food: "Take with a fat-containing meal", guardrail: "Do not exceed 4,000 IU/day from all sources without clinician guidance and lab monitoring", caution: "Lab-guided dosing is preferred", evidenceLabel: "NIH ODS Vitamin D", lastReviewed: "2026-07-18" },
+  "magnesium glycinate": { name: "Magnesium Glycinate", startingDose: "100-200 mg elemental magnesium daily", typicalRange: "100-350 mg supplemental elemental magnesium daily", timing: "Evening", food: "With or without food", adjustment: "Begin at the low end and increase only if well tolerated", guardrail: "The adult upper limit for supplemental magnesium is 350 mg/day unless a clinician recommends otherwise", caution: "Separate from thyroid medication and certain antibiotics by at least 2-4 hours", evidenceLabel: "NIH ODS Magnesium", lastReviewed: "2026-07-18" },
+  "creatine monohydrate": { name: "Creatine Monohydrate", startingDose: "3 g daily", typicalRange: "3-5 g daily", timing: "Any consistent time", food: "With water or a meal", adjustment: "A loading phase is not required", caution: "Review first with known kidney disease", evidenceLabel: "ISSN Creatine Position Stand", lastReviewed: "2026-07-18" },
+  glycine: { name: "Glycine", startingDose: "3 g daily", typicalRange: "3 g daily", timing: "30-60 minutes before bed", food: "With or without food", caution: "Use extra caution alongside sedating medicines", evidenceLabel: "PubMed Glycine Sleep", lastReviewed: "2026-07-18" },
+  coq10: { name: "CoQ10", startingDose: "100 mg daily", typicalRange: "100-200 mg daily", timing: "Morning or midday", food: "Take with a fat-containing meal", caution: "Review if using warfarin or blood-pressure medication", evidenceLabel: "PubMed CoQ10", lastReviewed: "2026-07-18" },
+  "soluble fiber (psyllium)": { name: "Soluble fiber (psyllium)", startingDose: "3-5 g once daily", typicalRange: "5-10 g daily in divided servings", timing: "Before or with a meal", food: "Take with at least 8 oz of water", adjustment: "Increase gradually over 1-2 weeks", caution: "Separate from medicines and supplements by at least 2 hours", evidenceLabel: "PubMed 30239559", lastReviewed: "2026-07-18" },
+  psyllium: { name: "Soluble fiber (psyllium)", startingDose: "3-5 g once daily", typicalRange: "5-10 g daily in divided servings", timing: "Before or with a meal", food: "Take with at least 8 oz of water", adjustment: "Increase gradually over 1-2 weeks", caution: "Separate from medicines and supplements by at least 2 hours", evidenceLabel: "PubMed 30239559", lastReviewed: "2026-07-18" },
+  curcumin: { name: "Curcumin", startingDose: "500 mg daily", typicalRange: "500-1,000 mg daily", timing: "With a meal", food: "Take with food; use a standardized product", caution: "Review first with anticoagulants, gallbladder concerns, or before procedures", evidenceLabel: "PubMed Curcumin Review", lastReviewed: "2026-07-18" },
+  probiotic: { name: "Probiotic", startingDose: "Use one label-directed serving daily", typicalRange: "Product- and strain-specific", timing: "At the same time daily", food: "Follow the product label", adjustment: "Start with the lowest label serving", caution: "Avoid without clinician review if significantly immunocompromised", evidenceLabel: "NIH ODS Probiotics", lastReviewed: "2026-07-18" },
+  "collagen peptides": { name: "Collagen peptides", startingDose: "5 g daily", typicalRange: "5-10 g daily", timing: "Any consistent time", food: "Mix with food or a beverage", adjustment: "Increase toward 10 g if well tolerated", evidenceLabel: "PubMed Collagen Peptides", lastReviewed: "2026-07-18" },
+  "l-theanine": { name: "L-Theanine", startingDose: "100 mg", typicalRange: "100-200 mg once or twice daily", timing: "Daytime for calm or 30-60 minutes before bed", food: "With or without food", adjustment: "Increase to 200 mg only if well tolerated", caution: "Use extra caution with sedating medicines", evidenceLabel: "PubMed L-Theanine", lastReviewed: "2026-07-18" },
+};
+
+function key(value: string): string {
+  return value.toLowerCase().replace(/[®™]/g, "").replace(/\s+/g, " ").trim();
+}
+
+export function getSupplementDoseGuidance(name: string): SupplementDoseGuidance | null {
+  const normalized = key(name)
+    .replace(/^omega\s*3.*$/, "omega-3")
+    .replace(/^magnesium(?:\s+bis)?glycinate.*$/, "magnesium glycinate")
+    .replace(/^creatine.*$/, "creatine monohydrate")
+    .replace(/^coenzyme q10.*$/, "coq10")
+    .replace(/^psyllium.*$/, "psyllium")
+    .replace(/^collagen.*$/, "collagen peptides");
+  return REGISTRY[normalized] ?? null;
+}
+
+export function formatStartingGuidance(name: string): string | null {
+  const entry = getSupplementDoseGuidance(name);
+  if (!entry) return null;
+  return [
+    `An evidence-informed starting point is ${entry.startingDose}.`,
+    `Typical range: ${entry.typicalRange}.`,
+    `Timing: ${entry.timing}; ${entry.food.toLowerCase()}.`,
+    entry.adjustment ? `Adjustment: ${entry.adjustment}.` : null,
+    entry.guardrail ? `Guardrail: ${entry.guardrail}.` : null,
+    entry.caution ? `Safety note: ${entry.caution}.` : null,
+    "This is general wellness guidance, not a prescription.",
+  ].filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Purpose
Unify desktop and PDF report content, restore useful evidence-informed supplement starting guidance, and remove report formatting drift without changing checkout, auth, Stripe, Tally webhook behavior, or prescription medication dosing.

## What changed
- Added a canonical `BlueprintReport` parser shared by desktop and PDF rendering.
- Added deterministic supplement starting-dose/timing guidance with ranges, ramp-up notes, guardrails, cautions, evidence labels, and review dates.
- Preserved reported intake dose/timing separately from new recommendation guidance in report output.
- Removed unnecessary Analysis blocks and renamed useful interpretation blocks.
- Sanitized hanging colons, duplicate sentences, raw markers, and user-facing END markers.
- Added matching report hashes to desktop markup, PDF metadata, and the PDF response header.
- Brought desktop cards and the This Week Focus presentation closer to the polished PDF.
- Kept Berberine's existing glucose-lowering clinician-review block and all existing commerce eligibility controls.

## Files changed
- `src/lib/blueprintReport.ts`
- `src/lib/supplementDosingRegistry.ts`
- `src/lib/generateStack.ts`
- `src/lib/reportPdf.ts`
- `app/results/page.tsx`
- `app/api/export-pdf/route.ts`

## Verified
- `npm run typecheck`
- `npm run build` with inert build-time placeholders
- `git diff --check`

## Not verified / manual QA
- Fresh live report generation using Preview/Production Supabase, Tally, and OpenAI credentials.
- Side-by-side browser/PDF comparison using the real submitted intake.
- Confirm every reported intake dose/timing survives the Tally payload and normalized ledger.
- Confirm every eligible new recommendation receives registry guidance and aligned evidence.
- Confirm Berberine remains non-shoppable with Metformin/Zepbound or other glucose-lowering context.
- Inspect PDF pagination for long Current Stack and Evidence tables.

## Risks / rollback
The stricter canonical validator refuses to persist reports with missing required sections or invalid markers. Roll back commit `7d3a48d` if live generation reveals an unsupported legacy report shape.