### PR TITLE
Fix canonical report section parsing regression

### DIFF
--- a/src/_tests_/blueprintReport.assert.ts
+++ b/src/_tests_/blueprintReport.assert.ts
@@ -1,0 +1,41 @@
+import {
+  parseBlueprintReport,
+  REPORT_SECTION_NAMES,
+  validateBlueprintReport,
+} from "../lib/blueprintReport";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const representativeMarkdown = REPORT_SECTION_NAMES.map((name, index) => {
+  const analysis = index < 2 ? "\n\n**Analysis**\n\nThis must not survive." : "";
+  const body = name === "This Week Try"
+    ? "- Take a ten-minute walk after lunch.\n- Keep a consistent bedtime."
+    : `Meaningful content for ${name}.${analysis}`;
+  return `## ${name}\n\n${body}`;
+}).join("\n\n");
+
+const report = parseBlueprintReport(representativeMarkdown);
+
+assert(
+  REPORT_SECTION_NAMES.every((name) => report.sections[name].trim().length > 0),
+  "Expected all 12 canonical report sections to be non-empty",
+);
+assert(report.canonicalMarkdown.length > 0, "Expected canonicalMarkdown to be populated");
+assert(report.focusItems.length === 2, "Expected This Week Try bullets to populate focusItems");
+assert(
+  !/^\s*(?:\*\*)?Analysis(?:\*\*)?\s*:?\s*$/im.test(report.canonicalMarkdown),
+  "Expected empty Analysis headings to be removed",
+);
+assert(validateBlueprintReport(report).length === 0, "Expected representative report to validate");
+
+const missingGoals = parseBlueprintReport(
+  representativeMarkdown.replace(/## Goals\r?\n[\s\S]*?(?=\r?\n## Contraindications)/, ""),
+);
+assert(
+  validateBlueprintReport(missingGoals).includes("empty:Goals"),
+  "Expected validation to flag a genuinely missing Goals section",
+);
+
+console.log("blueprintReport assertions passed");

--- a/src/lib/blueprintReport.ts
+++ b/src/lib/blueprintReport.ts
@@ -27,9 +27,20 @@ function cleanText(value: string): string {
 }
 
 function extract(markdown: string, heading: ReportSectionName): string {
-  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = markdown.match(new RegExp(`^##\\s+${escaped}\\s*$([\\s\\S]*?)(?=^##\\s+|$)`, "im"));
-  let body = match?.[1] ?? "";
+  const lines = markdown.split(/\r?\n/);
+  const headingPattern = /^##\s+(.+?)\s*$/;
+  const headingIndex = lines.findIndex((line) => headingPattern.exec(line)?.[1] === heading);
+  if (headingIndex === -1) return "";
+
+  let nextHeadingIndex = lines.length;
+  for (let index = headingIndex + 1; index < lines.length; index++) {
+    if (headingPattern.test(lines[index])) {
+      nextHeadingIndex = index;
+      break;
+    }
+  }
+
+  let body = lines.slice(headingIndex + 1, nextHeadingIndex).join("\n");
   if (["Intro Summary", "Goals", "Evidence & References", "Shopping Links", "Lifestyle Prescriptions", "Longevity Levers", "This Week Try"].includes(heading)) {
     body = body.split(/^\s*\*\*Analysis\*\*\s*:?\s*$/im)[0] ?? body;
   }


### PR DESCRIPTION
## Purpose

Urgently fix the PR #33 canonical report parser regression that caused every H2 section body to parse as empty, blocked stack persistence, and left downstream stack-items requests with no generated stack.

## Root cause

`extract()` used a multiline regular expression where `$` could match the end of the heading line. The non-greedy body capture could therefore remain empty while the lookahead succeeded immediately.

## What changed

- Replaced the fragile dynamic regex with a line/index-based H2 section parser.
- Each canonical H2 body now extends through the line before the next H2, or the true end of the document.
- Preserved PR #33 cleanup and section-specific Analysis behavior.
- Added a representative executable assertion covering all 12 canonical sections.

## Files changed

- `src/lib/blueprintReport.ts`
- `src/_tests_/blueprintReport.assert.ts`

## Verified

- Representative 12-section Markdown report parses with every section non-empty.
- `canonicalMarkdown` is populated.
- `This Week Try` populates `focusItems`.
- Empty Analysis headings are removed.
- `validateBlueprintReport()` passes valid content.
- A genuinely missing Goals section is still reported as `empty:Goals`.
- `npm run typecheck` passed.
- `npm run build` passed with inert placeholder environment values.
- `git diff --check` passed.

The build logged the expected network warning from the placeholder Supabase URL; compilation and page generation completed successfully.

## Not verified locally

Real OpenAI generation, Supabase persistence, production logs, and `/api/stack-items` require the deployed Preview/Production environment and real integrations.

## Production smoke test

1. Deploy this PR with the normal Vercel environment variables.
2. Submit a fresh Tally intake and generate a report.
3. Confirm all 12 sections contain content.
4. Confirm `canonicalMarkdown` is persisted and generation logs do not list `empty:Intro Summary` through `empty:This Week Try`.
5. Confirm a stack row and stack items are persisted.
6. Confirm `/api/stack-items?stack_id=...` returns the generated items rather than failing because no stack was persisted.
7. Confirm the desktop report and PDF still retain PR #33 behavior.

## Risk / rollback

Low-risk parser-only hotfix. No dosing, recommendations, PDF styling, auth, checkout, Tally contract, Supabase schema, or other PR #33 feature behavior changed. Roll back commit `8593b62` if unexpected parsing behavior appears.