### PR TITLE
Preserve Tally dosage details and improve report PDF continuity

### DIFF
--- a/src/_tests_/blueprintReport.assert.ts
+++ b/src/_tests_/blueprintReport.assert.ts
@@ -11,7 +11,7 @@ function assert(condition: unknown, message: string): asserts condition {
 const representativeMarkdown = REPORT_SECTION_NAMES.map((name, index) => {
   const analysis = index < 2 ? "\n\n**Analysis**\n\nThis must not survive." : "";
   const body = name === "This Week Try"
-    ? "- Take a ten-minute walk after lunch.\n- Keep a consistent bedtime."
+    ? "- Take a ten-minute walk after lunch.\n- Keep a consistent bedtime.\n\n**Analysis**\n\nInternal reasoning must not become a focus item."
     : `Meaningful content for ${name}.${analysis}`;
   return `## ${name}\n\n${body}`;
 }).join("\n\n");
@@ -24,6 +24,10 @@ assert(
 );
 assert(report.canonicalMarkdown.length > 0, "Expected canonicalMarkdown to be populated");
 assert(report.focusItems.length === 2, "Expected This Week Try bullets to populate focusItems");
+assert(
+  report.focusItems.every((item) => !/analysis|internal reasoning/i.test(item)),
+  "Expected analysis prose to be excluded from focusItems",
+);
 assert(
   !/^\s*(?:\*\*)?Analysis(?:\*\*)?\s*:?\s*$/im.test(report.canonicalMarkdown),
   "Expected empty Analysis headings to be removed",

--- a/src/_tests_/normalizedCurrentStackLedger.assert.ts
+++ b/src/_tests_/normalizedCurrentStackLedger.assert.ts
@@ -1,0 +1,39 @@
+import { buildNormalizedCurrentStackLedger } from "../lib/normalizedCurrentStackLedger";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const fields = [
+  { label: "List Medication", value: "Metformin" },
+  { label: "e.g., Blood Sugar", value: "Blood sugar" },
+  { label: "500mg", value: "500 mg" },
+  { label: "2 x Daily", value: "2 x Daily" },
+  { label: "Medication 2", value: "Zepbound" },
+  { label: "Purpose e.g., for blood pressure", value: "Weight loss" },
+  { label: "Dosage e.g., 50mg", value: "7.5 mg" },
+  { label: "Frequency e.g., Daily, AM, PM, Both", value: "Weekly" },
+  { label: "List Supplements", value: "Omega" },
+  { label: "e.g., Heart Health", value: "Heart health" },
+  { label: "100mg", value: "1000 mg" },
+  { label: "Daily, AM", value: "Daily AM" },
+  { label: "Supplement 2", value: "Creatine Monohydrate" },
+  { label: "Purpose", value: "Muscle and cognition" },
+  { label: "Dosage", value: "5 g" },
+  { label: "Frequency", value: "Daily PM" },
+];
+
+const ledger = buildNormalizedCurrentStackLedger({ payload_json: { data: { fields } } });
+const byName = new Map(ledger.map((item) => [item.name, item]));
+
+assert(byName.get("Metformin")?.dose === "500 mg", "Expected example-labeled medication dose to be retained");
+assert(byName.get("Metformin")?.timing === "2 x Daily", "Expected example-labeled medication frequency to be retained");
+assert(byName.get("Zepbound")?.dose === "7.5 mg", "Expected explicit medication dosage to be retained");
+assert(byName.get("Zepbound")?.timing === "Weekly", "Expected explicit medication frequency to be retained");
+assert(byName.get("Omega-3")?.dose === "1000 mg", "Expected Omega alias and example-labeled dose to normalize");
+assert(byName.get("Omega-3")?.timing === "Daily AM", "Expected example-labeled supplement timing to be retained");
+assert(byName.get("Creatine Monohydrate")?.dose === "5 g", "Expected repeated supplement dose to be retained");
+assert(byName.get("Creatine Monohydrate")?.timing === "Daily PM", "Expected repeated supplement timing to be retained");
+assert(ledger.filter((item) => item.name === "Omega-3").length === 1, "Expected Omega aliases to deduplicate");
+
+console.log("normalizedCurrentStackLedger assertions passed");

--- a/src/lib/blueprintReport.ts
+++ b/src/lib/blueprintReport.ts
@@ -64,7 +64,11 @@ function hash(value: string): string {
 }
 
 export function parseBlueprintReport(markdown: string): BlueprintReport {
-  const cleaned = cleanText(markdown);
+  const cleaned = String(markdown ?? "")
+    .replace(/^```[a-z]*\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .replace(/(^|\n)##\s*END\s*(?=\n|$)/gi, "$1")
+    .trim();
   const sections = Object.fromEntries(REPORT_SECTION_NAMES.map((name) => [name, extract(cleaned, name)])) as Record<ReportSectionName, string>;
   const focusItems = sections["This Week Try"].split(/\r?\n/)
     .map((line) => cleanText(line.replace(/^\s*[-*]\s+/, "")))

--- a/src/lib/normalizedCurrentStackLedger.ts
+++ b/src/lib/normalizedCurrentStackLedger.ts
@@ -1,4 +1,4 @@
-import { isPreferenceFieldOrValue } from "@/lib/supplementEligibility";
+import { isPreferenceFieldOrValue } from "./supplementEligibility";
 
 export type CurrentStackKind = "medication" | "supplement" | "hormone" | "endocrine_active_supplement";
 
@@ -42,6 +42,7 @@ function cleanParsedName(value: string): string {
   if (/^(?:alcar|acetyl[- ]l[- ]carnitine(?:\s*\(alcar\))?)$/i.test(cleaned)) {
     return "Acetyl-L-carnitine (ALCAR)";
   }
+  if (/^(?:omega(?:[- ]?3)?|fish oil)$/i.test(cleaned)) return "Omega-3";
   return cleaned;
 }
 
@@ -158,7 +159,12 @@ function inferKind(labelOrKey: string): CurrentStackKind | null {
 }
 
 function detailFrom(value: unknown): string | undefined {
-  return readableText(value) ?? extractLedgerReadableNames(value)[0];
+  const parsed = parseJson(value);
+  if (typeof parsed === "string" || typeof parsed === "number") {
+    const detail = normalizeNumericCommas(String(parsed)).replace(/\s+/g, " ").trim();
+    return detail && !UUID_RE.test(detail) && !INVALID_NAME_RE.test(detail) ? detail : undefined;
+  }
+  return extractLedgerReadableNames(parsed)[0];
 }
 
 function fieldValues(field: Record<string, any>): unknown[] {
@@ -211,6 +217,17 @@ function fieldDetail(field: Record<string, any>): string | undefined {
   return undefined;
 }
 
+type DetailRole = "purpose" | "dose" | "timing";
+
+function detailRoleForLabel(label: string): DetailRole | null {
+  const normalized = normalizeNumericCommas(label).replace(/\s+/g, " ").trim();
+  if (/\bpurpose\b/i.test(normalized) || /^e\.?g\.?,?\s*(?!\d)/i.test(normalized)) return "purpose";
+  if (/\b(?:dose|dosage|amount|strength)\b/i.test(normalized) || INLINE_DOSE_RE.test(normalized)) return "dose";
+  if (/\b(?:frequency|timing|how often|when taken|schedule)\b/i.test(normalized) ||
+      INLINE_FREQUENCY_RE.test(normalized) || /\b(?:am|pm|morning|evening|bedtime)\b/i.test(normalized)) return "timing";
+  return null;
+}
+
 export function parseTallyCurrentStackFields(
   fields: unknown,
   sourcePath = "fields"
@@ -226,14 +243,15 @@ export function parseTallyCurrentStackFields(
     const label = fieldLabel(field);
     if (!label || isPreferenceFieldOrValue(label)) return;
 
-    if (DETAIL_LABEL_RE.test(label)) {
+    const detailRole = detailRoleForLabel(label);
+    if (detailRole) {
       if (!currentItems.length) return;
       const detail = fieldDetail(field);
       if (!detail) return;
       for (const currentItem of currentItems) {
-        if (/\b(?:purpose)\b/i.test(label)) {
+        if (detailRole === "purpose") {
           currentItem.purpose = currentItem.purpose ?? detail;
-        } else if (/\b(?:dose|dosage)\b/i.test(label)) {
+        } else if (detailRole === "dose") {
           currentItem.dose = currentItem.dose ?? detail;
         } else {
           currentItem.timing = currentItem.timing ?? detail;

--- a/src/lib/reportPdf.ts
+++ b/src/lib/reportPdf.ts
@@ -1,5 +1,5 @@
 import { PDFDocument, PDFFont, PDFPage, StandardFonts, rgb, type RGB } from "pdf-lib";
-import { parseBlueprintReport } from "@/lib/blueprintReport";
+import { parseBlueprintReport } from "./blueprintReport";
 
 const PAGE_WIDTH = 612;
 const PAGE_HEIGHT = 792;
@@ -197,26 +197,25 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
         : Array.from({ length: columnCount }, () => 1 / columnCount);
     const widths = proportions.map((part) => CONTENT_WIDTH * part);
 
-    rows.forEach((row, rowIndex) => {
-      const cellFont = rowIndex === 0 ? bold : regular;
-      const cellSize = rowIndex === 0 ? 8.2 : 8;
+    const drawRow = (row: string[], rowIndex: number, isHeader = false) => {
+      const cellFont = isHeader ? bold : regular;
+      const cellSize = isHeader ? 8.2 : 8;
       const wrapped = row.map((cell, index) => wrap(cell, cellFont, cellSize, Math.max(28, widths[index] - 12)));
       const rowHeight = Math.max(22, ...wrapped.map((lines) => lines.length * 10 + 8));
-      ensureSpace(rowHeight + 2);
       const y = cursorY - rowHeight;
       page.drawRectangle({
         x: MARGIN,
         y,
         width: CONTENT_WIDTH,
         height: rowHeight,
-        color: rowIndex === 0 ? NAVY : rowIndex % 2 === 0 ? PALE_BLUE : WHITE,
+        color: isHeader ? NAVY : rowIndex % 2 === 0 ? PALE_BLUE : WHITE,
         borderColor: BORDER,
         borderWidth: 0.45,
       });
       let x = MARGIN;
       row.forEach((cell, index) => {
         if (index > 0) page.drawLine({ start: { x, y }, end: { x, y: y + rowHeight }, color: BORDER, thickness: 0.4 });
-        if (isBlueprint && index === statusColumn && rowIndex > 0) {
+        if (isBlueprint && index === statusColumn && !isHeader) {
           drawStatusPill(cell, x + 3, y + rowHeight / 2 - 7, widths[index] - 6);
         } else {
           wrapped[index].forEach((line, lineIndex) => {
@@ -225,7 +224,7 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
               y: y + rowHeight - 11 - lineIndex * 10,
               size: cellSize,
               font: cellFont,
-              color: rowIndex === 0 ? WHITE : TEXT,
+              color: isHeader ? WHITE : TEXT,
               maxWidth: widths[index] - 12,
             });
           });
@@ -233,6 +232,20 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
         x += widths[index];
       });
       cursorY = y;
+    };
+
+    rows.forEach((row, rowIndex) => {
+      const isHeader = rowIndex === 0;
+      const previewFont = isHeader ? bold : regular;
+      const previewSize = isHeader ? 8.2 : 8;
+      const rowHeight = Math.max(22, ...row.map((cell, index) =>
+        wrap(cell, previewFont, previewSize, Math.max(28, widths[index] - 12)).length * 10 + 8
+      ));
+      if (cursorY - rowHeight < CONTENT_BOTTOM) {
+        addPage();
+        if (!isHeader) drawRow(header, 0, true);
+      }
+      drawRow(row, rowIndex, isHeader);
     });
     cursorY -= 9;
   };


### PR DESCRIPTION
## Purpose

Preserve user-entered Tally dosage and timing details through the normalized Current Stack ledger, and address the highest-value report/PDF defects observed in the PR #34 output.

## Root causes

1. Example-style Tally labels such as `500mg`, `2 x Daily`, and `Daily, AM` were not recognized as dose/timing detail fields because they did not contain explicit words such as "dosage" or "frequency".
2. Even when the repeated-field parser attached a dose, the ledger merge helper reused item-name validation and rejected dose-only strings such as `500 mg`.
3. Document-wide cleanup removed the internal Analysis heading before section extraction, allowing the following analysis prose to leak into the This Week Focus card.
4. PDF tables continued across pages without repeating their column headers.

## What changed

- Recognize explicit and example-style Tally purpose, dose, strength, frequency, and timing labels.
- Preserve scalar dose-only detail values during ledger merging.
- Continue pairing repeated medication and supplement fields with their adjacent details.
- Canonicalize Omega, Omega-3, and Fish Oil to one `Omega-3` item.
- Preserve Analysis delimiters until section extraction so internal reasoning is removed rather than promoted into focus items.
- Repeat table headers when a Current Stack or Blueprint table crosses a PDF page boundary.
- Add focused executable assertions for real Tally label shapes and report focus cleanup.

## Files changed

- `src/lib/normalizedCurrentStackLedger.ts`
- `src/lib/blueprintReport.ts`
- `src/lib/reportPdf.ts`
- `src/_tests_/normalizedCurrentStackLedger.assert.ts`
- `src/_tests_/blueprintReport.assert.ts`

## Verified

- Example-labeled medication dose `500mg` retains submitted value `500 mg`.
- Example-labeled medication frequency `2 x Daily` is retained.
- Explicit repeated medication dose/frequency values are retained.
- Example-labeled supplement dose/timing values are retained.
- Repeated supplement dose/timing values are retained.
- Omega aliases deduplicate to one `Omega-3` ledger item.
- This Week Focus excludes Analysis prose.
- Canonical report parser assertions still pass.
- Representative multi-page PDF rendered with Poppler and was visually inspected; continued tables repeat headers.
- `npm run typecheck` passed.
- `npm run build` passed with inert placeholder environment values.
- `git diff --check` passed.

The build logged the expected failed network request to the inert Supabase placeholder; compilation and page generation completed.

## Not verified locally

- Real Tally submission ingestion and Supabase persistence require Preview/Production integrations.
- `npm run qa:env` correctly reported missing local secrets; no secrets were requested or committed.

## Manual production smoke test

1. Submit a fresh Tally intake containing multiple medications and supplements.
2. Enter dosage and timing using both the first-row and repeated-row fields.
3. Confirm Current Stack displays the reported purpose, dosage, and timing for every item.
4. Confirm Dosing & Notes says `Currently reported: [dose], [timing]` for current Blueprint supplements.
5. Confirm persisted `stack_items.dose` and `stack_items.timing` match the intake.
6. Confirm Omega/Omega-3 does not appear twice.
7. Confirm This Week Focus contains only actionable items and no Analysis prose.
8. Export the PDF and confirm split tables repeat their column headers.

## Risk / rollback

Focused parser and renderer update. No authentication, checkout, Stripe, Tally webhook contract, Supabase schema, recommendation policy, dosing registry, or compliance policy changed. Roll back commit `5b0a8df` if the Tally field association behaves unexpectedly.