### PR TITLE
Polish webpage and PDF report presentation parity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,3 +25,38 @@
   body {
     @apply bg-background text-foreground; } }
 html { scroll-behavior: smooth; }
+
+.report-surface { font-family: Arial, Helvetica, sans-serif; }
+.report-status {
+  display: inline-block;
+  border-radius: 9999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.15;
+  white-space: nowrap;
+}
+.report-status-current { background: #c7eadf; color: #122945; }
+.report-status-new { background: #d1e5f7; color: #122945; }
+.report-status-review { background: #ffe0ad; color: #744210; }
+
+@media print {
+  @page { margin: 0.55in; }
+  header, nav, footer, .report-no-print, .report-sidebar { display: none !important; }
+  body { background: white !important; }
+  .report-page { min-height: auto !important; overflow: visible !important; background: white !important; }
+  .report-page > [aria-hidden] { display: none !important; }
+  .report-surface { max-width: none !important; padding: 0 !important; }
+  .report-surface > div:first-child { margin-bottom: 1.5rem !important; }
+  .report-content { width: 100% !important; }
+  .report-section, .report-focus {
+    box-shadow: none !important;
+    break-inside: auto;
+    margin-bottom: 1rem !important;
+  }
+  .report-section h2, .report-prose h2 { break-after: avoid-page; }
+  .report-prose table { break-inside: auto; }
+  .report-prose tr { break-inside: avoid-page; }
+  .report-prose thead { display: table-header-group; }
+  .report-prose a { color: #122945 !important; text-decoration: none !important; }
+}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { isValidElement, Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import ReactMarkdown from "react-markdown";
@@ -9,6 +9,7 @@ import remarkGfm from "remark-gfm";
 import CTAButton from "@/components/CTAButton";
 import ResultsSidebar from "@/components/results/ResultsSidebar";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
+import { blueprintStatusTone, cleanReportDisplayText, reportSectionTitle } from "@/lib/reportPresentation";
 
 /* ───────── helpers ───────── */
 function sanitizeMarkdown(md: string): string {
@@ -70,27 +71,41 @@ async function fetchWithRetry(
 
 
 /* Markdown renderer */
+function textFromNode(value: ReactNode): string {
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (Array.isArray(value)) return value.map(textFromNode).join("");
+  if (isValidElement<{ children?: ReactNode }>(value)) return textFromNode(value.props.children);
+  return "";
+}
+
 function Prose({ children }: { children: string }) {
   return (
-    <div className="prose prose-gray max-w-none">
+    <div className="report-prose prose prose-gray max-w-none text-[#1F2937]">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
           h2: ({ node, ...props }) => (
             <h2
-              className="text-2xl font-bold text-teal-600 mt-8 mb-4 border-b border-gray-200 pb-1"
+              className="mt-8 mb-4 border-b border-slate-200 pb-2 text-2xl font-bold text-[#122945]"
               {...props}
             />
           ),
-          table: ({ node, ...props }) => (
-            <table className="w-full border-collapse my-4 text-sm shadow-sm" {...props} />
-          ),
-          thead: ({ node, ...props }) => <thead className="bg-[#06C1A0] text-white" {...props} />,
-          th: ({ node, ...props }) => <th className="px-3 py-0.5 text-left font-semibold" {...props} />,
-          td: ({ node, ...props }) => (
-            <td className="px-3 py-0.5 border-t border-gray-200 align-middle" {...props} />
-          ),
-          tr: ({ node, ...props }) => <tr className="even:bg-gray-50" {...props} />,
+          table: ({ node, ...props }) => <table className="my-4 w-full border-collapse overflow-hidden text-sm" {...props} />,
+          thead: ({ node, ...props }) => <thead className="bg-[#122945] text-white" {...props} />,
+          th: ({ node, ...props }) => <th className="px-3 py-2 text-left font-semibold" {...props} />,
+          td: ({ node, children, ...props }) => {
+            const tone = blueprintStatusTone(textFromNode(children));
+            return (
+              <td className="border-t border-[#D1DBE0] px-3 py-2 align-top" {...props}>
+                {tone ? <span className={`report-status report-status-${tone}`}>{children}</span> : children}
+              </td>
+            );
+          },
+          tr: ({ node, ...props }) => <tr className="even:bg-[#EFF5FA]" {...props} />,
+          ul: ({ node, ...props }) => <ul className="my-3 list-disc space-y-2 pl-6 marker:text-[#06C1A0]" {...props} />,
+          ol: ({ node, ...props }) => <ol className="my-3 list-decimal space-y-2 pl-6 marker:font-semibold marker:text-[#122945]" {...props} />,
+          li: ({ node, ...props }) => <li className="pl-1 leading-6" {...props} />,
+          p: ({ node, ...props }) => <p className="leading-7" {...props} />,
           strong: ({ node, ...props }) => <strong className="font-semibold text-[#041B2D]" {...props} />,
         }}
       >
@@ -106,14 +121,12 @@ function LinksTable({ raw, type }: { raw: string; type: "evidence" | "shopping" 
 
   const lines = raw.split("\n").map((l) => l.trim());
   const bulletLines = lines.filter((l) => l.startsWith("-"));
-  const analysisIndex = lines.findIndex((l) => l.toLowerCase().startsWith("**analysis"));
-  const analysis = analysisIndex !== -1 ? lines.slice(analysisIndex).join(" ") : null;
 
   const rows = bulletLines
     .map((line) => {
       const matches = Array.from(line.matchAll(linkRe));
       if (matches.length === 0) return null;
-      const namePart = line.replace(/^-+\s*/, "").split(":")[0].trim();
+      const namePart = cleanReportDisplayText(line.replace(/^-+\s*/, "").split(":")[0]);
       if (namePart.toLowerCase().includes("evidence pending")) return null; // skip placeholders
       const links = matches.map((m) => ({ text: m[1], url: m[2] }));
       return { name: namePart, links };
@@ -140,8 +153,8 @@ function LinksTable({ raw, type }: { raw: string; type: "evidence" | "shopping" 
 
   return (
     <div>
-      <table className="w-full border-collapse my-2 text-sm shadow-sm">
-        <thead className="bg-[#06C1A0] text-white">
+      <table className="my-2 w-full border-collapse overflow-hidden text-sm">
+        <thead className="bg-[#122945] text-white">
           <tr>
             <th className="px-3 py-0.5 text-left">Item</th>
             <th className="px-3 py-0.5 text-left">Action</th>
@@ -149,9 +162,9 @@ function LinksTable({ raw, type }: { raw: string; type: "evidence" | "shopping" 
         </thead>
         <tbody>
           {rows.map((r, i) => (
-            <tr key={i} className="even:bg-gray-50 border-t">
-              <td className="px-3 py-0.5">{r.name}</td>
-              <td className="px-3 py-0.5 space-x-2">
+            <tr key={i} className="border-t border-[#D1DBE0] even:bg-[#EFF5FA]">
+              <td className="px-3 py-2">{r.name}</td>
+              <td className="space-x-2 px-3 py-2">
                 {r.links.map((link, j) => (
                   <CTAButton
                     key={j}
@@ -177,17 +190,17 @@ function LinksTable({ raw, type }: { raw: string; type: "evidence" | "shopping" 
         </div>
       )}
 
-      {analysis && <p className="mt-3 text-sm text-gray-700 leading-relaxed">{analysis}</p>}
     </div>
   );
 }
 
 /* Section card wrapper */
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
+  const displayTitle = reportSectionTitle(title);
   return (
-    <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-md mb-8">
+    <section className="report-section mb-8 overflow-hidden rounded-2xl border border-[#D1DBE0] bg-white shadow-sm">
       <div className={title.includes("Contraindications") ? "border-b border-amber-200 bg-amber-50 px-6 py-4" : "bg-gradient-to-r from-[#041B2D] to-[#0B4B57] px-6 py-4"}>
-        <h2 className={title.includes("Contraindications") ? "text-xl font-semibold text-amber-900" : "text-xl font-semibold text-white"}>{title}</h2>
+        <h2 className={title.includes("Contraindications") ? "text-xl font-semibold text-amber-900" : "text-xl font-semibold text-white"}>{displayTitle}</h2>
       </div>
       <div className="p-6">{children}</div>
     </section>
@@ -485,7 +498,7 @@ async function exportPDF() {
   return (
     <motion.main
       data-report-hash={sec.contentHash}
-      className="relative isolate overflow-hidden min-h-screen bg-gradient-to-br from-[#F8F5FB] via-white to-[#EAFBF8]"
+      className="report-page relative isolate min-h-screen overflow-hidden bg-gradient-to-br from-[#EFF5FA] via-white to-[#E6F7F3]"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
@@ -496,17 +509,18 @@ async function exportPDF() {
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute top-[20rem] -right-24 h-[28rem] w-[28rem] rounded-full bg-[#D9C2F0] opacity-30 blur-3xl animate-[float_10s_ease-in-out_infinite]"
+        className="pointer-events-none absolute top-[20rem] -right-24 h-[28rem] w-[28rem] rounded-full bg-[#D9F4EE] opacity-35 blur-3xl animate-[float_10s_ease-in-out_infinite]"
         aria-hidden
       />
 
       {/* Content */}
-      <div className="relative z-10 max-w-6xl mx-auto py-20 px-6 font-sans">
+      <div className="report-surface relative z-10 mx-auto max-w-6xl px-6 py-20">
         {/* Header */}
         <div className="text-center mb-10">
-          <h1 className="text-5xl sm:text-6xl font-extrabold bg-gradient-to-r from-[#041B2D] via-[#06C1A0] to-purple-600 bg-clip-text text-transparent">
+          <h1 className="text-5xl font-extrabold tracking-tight text-[#122945] sm:text-6xl">
             Your LVE360 Blueprint
           </h1>
+          <div className="mx-auto mt-3 h-1 w-24 rounded-full bg-[#06C1A0]" />
           <p className="text-gray-600 mt-4 text-lg">Personalized insights for Longevity • Vitality • Energy</p>
           <p className="mt-2 text-gray-500 text-sm">$15/month Premium Access</p>
         </div>
@@ -514,9 +528,9 @@ async function exportPDF() {
         {/* two-column layout */}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
           {/* LEFT */}
-          <div className="lg:col-span-8">
+          <div className="report-content lg:col-span-8">
             {/* actions */}
-            <SectionCard title="Actions">
+            <div className="report-no-print"><SectionCard title="Actions">
               <div className="flex flex-wrap gap-4 justify-center">
                 <CTAButton onClick={generateStack} variant="gradient" disabled={warmingUp || generating || !ready}>
                   {warmingUp ? "⏳ Warming up…" : generating ? "🤖 Generating..." : ready ? "✨ Generate Free Report" : "⏳ Preparing…"}
@@ -546,13 +560,13 @@ async function exportPDF() {
 
               {/* 2-minute countdown while generating */}
               <TwoMinuteCountdown running={generating} />
-            </SectionCard>
+            </SectionCard></div>
 
             {error && <div className="text-center text-red-600 mb-6">{error}</div>}
 
             {sec.focusItems.length > 0 && (
-              <div className="mb-8 rounded-2xl border border-sky-200 bg-gradient-to-r from-sky-50 to-teal-50 p-6 shadow-sm">
-                <p className="text-xs font-bold uppercase tracking-[0.18em] text-sky-700">This Week Focus</p>
+              <div className="report-focus mb-8 rounded-2xl border border-[#9DCFC3] bg-gradient-to-r from-[#EFF5FA] to-[#E6F7F3] p-6 shadow-sm">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#122945]">This Week Focus</p>
                 <ol className="mt-3 grid gap-2 text-sm text-slate-800 sm:grid-cols-2">
                   {sec.focusItems.map((item, index) => <li key={item} className="rounded-xl bg-white/80 px-4 py-3"><strong>{index + 1}.</strong> {item}</li>)}
                 </ol>
@@ -615,7 +629,7 @@ async function exportPDF() {
                 <Prose>{sec.longevity}</Prose>
               </SectionCard>
             )}
-            {sec.weekTry && (
+            {sec.weekTry && sec.focusItems.length === 0 && (
               <SectionCard title="This Week Try">
                 <Prose>{sec.weekTry}</Prose>
               </SectionCard>
@@ -636,7 +650,7 @@ async function exportPDF() {
             </SectionCard>
 
             {/* export PDF */}
-            <div className="flex justify-center mt-8">
+            <div className="report-no-print mt-8 flex justify-center">
               <button
                 onClick={exportPDF}
                 disabled={exporting || generating || warmingUp || !stackId || !hasUsableSections(markdown)}
@@ -650,7 +664,7 @@ async function exportPDF() {
           </div>
 
           {/* RIGHT: sticky sidebar */}
-          <div className="lg:col-span-4">
+          <div className="report-sidebar lg:col-span-4">
             {stackId ? (
               <ResultsSidebar stackId={stackId} />
             ) : (

--- a/src/_tests_/blueprintReport.assert.ts
+++ b/src/_tests_/blueprintReport.assert.ts
@@ -9,7 +9,13 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 const representativeMarkdown = REPORT_SECTION_NAMES.map((name, index) => {
-  const analysis = index < 2 ? "\n\n**Analysis**\n\nThis must not survive." : "";
+  const analysis = index === 0
+    ? "\n\n**Analysis**: This inline analysis must not survive."
+    : index === 1
+      ? "\n\n**Analysis**\n\nThis must not survive."
+      : name === "Dosing & Notes"
+        ? "\n\nAnalysis: This dosing analysis must not survive."
+        : "";
   const body = name === "This Week Try"
     ? "- Take a ten-minute walk after lunch.\n- Keep a consistent bedtime.\n\n**Analysis**\n\nInternal reasoning must not become a focus item."
     : `Meaningful content for ${name}.${analysis}`;
@@ -31,6 +37,10 @@ assert(
 assert(
   !/^\s*(?:\*\*)?Analysis(?:\*\*)?\s*:?\s*$/im.test(report.canonicalMarkdown),
   "Expected empty Analysis headings to be removed",
+);
+assert(
+  !/inline analysis|dosing analysis|This must not survive/i.test(report.canonicalMarkdown),
+  "Expected internal analysis prose to be removed from presentation-only sections",
 );
 assert(validateBlueprintReport(report).length === 0, "Expected representative report to validate");
 

--- a/src/_tests_/reportPresentation.assert.ts
+++ b/src/_tests_/reportPresentation.assert.ts
@@ -1,0 +1,18 @@
+import {
+  blueprintStatusTone,
+  cleanReportDisplayText,
+  reportSectionTitle,
+} from "../lib/reportPresentation";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+assert(reportSectionTitle("Lifestyle Prescriptions") === "Lifestyle Foundations", "Expected user-friendly lifestyle heading");
+assert(cleanReportDisplayText("**Omega-3 (Current Stack)**") === "Omega-3 (Current Stack)", "Expected Markdown markers removed");
+assert(cleanReportDisplayText(": An evidence:informed option") === "An evidence-informed option", "Expected hanging colon removed");
+assert(blueprintStatusTone("Current - optimize") === "current", "Expected Current status tone");
+assert(blueprintStatusTone("New - consider") === "new", "Expected New status tone");
+assert(blueprintStatusTone("Clinician review") === "review", "Expected review status tone");
+
+console.log("reportPresentation assertions passed");

--- a/src/components/results/ResultsSidebar.tsx
+++ b/src/components/results/ResultsSidebar.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { bucketsFromRecord } from "@/src/lib/timing";
 import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
+import { cleanReportDisplayText } from "@/lib/reportPresentation";
 
 type Item = {
   id: string;
@@ -109,13 +110,6 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
     return <aside className="rounded-xl border p-4 text-sm text-zinc-600">No supplement items are available for this report yet.</aside>;
   }
 
-  // affiliate helpers (unchanged)
-  const amazonTag = process.env.NEXT_PUBLIC_AMAZON_TAG || "";
-  const fallbackAmazon = (name: string) =>
-    `https://www.amazon.com/s?k=${encodeURIComponent(
-      `${name} supplement`
-    )}` + (amazonTag ? `&tag=${encodeURIComponent(amazonTag)}` : "");
-
   const track = (
     url: string,
     src: "amazon" | "fullscript",
@@ -127,26 +121,27 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
 
   // Row renderer (dose + “Current” badge + links)
   const ItemRow = (i: Item) => {
-    const amazonUrl = i.link_amazon || fallbackAmazon(i.name);
+    const displayName = cleanReportDisplayText(i.name);
+    const displayDose = i.dose ? cleanReportDisplayText(i.dose) : "";
     return (
       <li key={i.id} className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="text-sm truncate">
-            {i.name}
+            {displayName}
             {i.is_current ? (
               <span className="ml-1 align-middle text-[10px] px-1 py-0.5 rounded bg-emerald-100 text-emerald-700">
                 Current
               </span>
             ) : null}
           </div>
-          {i.dose ? (
-            <div className="text-xs text-zinc-500 truncate">{i.dose}</div>
+          {displayDose ? (
+            <div className="text-xs text-zinc-500 truncate">{displayDose}</div>
           ) : null}
         </div>
         <div className="flex gap-2 shrink-0">
           {i.link_fullscript ? (
             <a
-              href={track(i.link_fullscript, "fullscript", i.name)}
+              href={track(i.link_fullscript, "fullscript", displayName)}
               className="text-xs underline"
               target="_blank"
               rel="noopener noreferrer nofollow"
@@ -154,14 +149,16 @@ export default function ResultsSidebar({ stackId }: { stackId: string }) {
               Fullscript
             </a>
           ) : null}
-          <a
-            href={track(amazonUrl, "amazon", i.name)}
-            className="text-xs underline"
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-          >
-            Amazon
-          </a>
+          {i.link_amazon ? (
+            <a
+              href={track(i.link_amazon, "amazon", displayName)}
+              className="text-xs underline"
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+            >
+              Amazon
+            </a>
+          ) : null}
         </div>
       </li>
     );

--- a/src/lib/blueprintReport.ts
+++ b/src/lib/blueprintReport.ts
@@ -41,8 +41,9 @@ function extract(markdown: string, heading: ReportSectionName): string {
   }
 
   let body = lines.slice(headingIndex + 1, nextHeadingIndex).join("\n");
-  if (["Intro Summary", "Goals", "Evidence & References", "Shopping Links", "Lifestyle Prescriptions", "Longevity Levers", "This Week Try"].includes(heading)) {
-    body = body.split(/^\s*\*\*Analysis\*\*\s*:?\s*$/im)[0] ?? body;
+  const analysisLine = /^\s*(?:\*\*)?Analysis(?:\*\*)?\s*:?\s*(.*)$/im;
+  if (["Intro Summary", "Goals", "Dosing & Notes", "Evidence & References", "Shopping Links", "Lifestyle Prescriptions", "Longevity Levers", "This Week Try"].includes(heading)) {
+    body = body.split(analysisLine)[0] ?? body;
   }
   const labels: Partial<Record<ReportSectionName, string>> = {
     "Contraindications & Med Interactions": "Safety Takeaway",
@@ -50,7 +51,11 @@ function extract(markdown: string, heading: ReportSectionName): string {
     "Your Blueprint Recommendations": "Why These Recommendations",
     "Follow-up Plan": "Follow-up Priorities",
   };
-  if (labels[heading]) body = body.replace(/^\s*\*\*Analysis\*\*\s*:?\s*$/im, `### ${labels[heading]}`);
+  if (labels[heading]) {
+    body = body.replace(analysisLine, (_match, inline: string) =>
+      `### ${labels[heading]}${inline?.trim() ? `\n\n${inline.trim()}` : ""}`
+    );
+  }
   return cleanText(body);
 }
 

--- a/src/lib/reportPdf.ts
+++ b/src/lib/reportPdf.ts
@@ -1,5 +1,6 @@
 import { PDFDocument, PDFFont, PDFPage, StandardFonts, rgb, type RGB } from "pdf-lib";
 import { parseBlueprintReport } from "./blueprintReport";
+import { cleanReportDisplayText, REPORT_THEME_RGB, reportSectionTitle } from "./reportPresentation";
 
 const PAGE_WIDTH = 612;
 const PAGE_HEIGHT = 792;
@@ -8,19 +9,19 @@ const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
 const FOOTER_Y = 25;
 const CONTENT_BOTTOM = 48;
 
-const NAVY = rgb(0.07, 0.16, 0.27);
-const TEAL = rgb(0.03, 0.62, 0.53);
-const PALE_TEAL = rgb(0.9, 0.97, 0.95);
-const PALE_BLUE = rgb(0.94, 0.96, 0.98);
-const PALE_AMBER = rgb(1, 0.96, 0.86);
+const NAVY = rgb(...REPORT_THEME_RGB.navy);
+const TEAL = rgb(...REPORT_THEME_RGB.teal);
+const PALE_TEAL = rgb(...REPORT_THEME_RGB.paleTeal);
+const PALE_BLUE = rgb(...REPORT_THEME_RGB.paleBlue);
+const PALE_AMBER = rgb(...REPORT_THEME_RGB.paleAmber);
 const PALE_RED = rgb(1, 0.93, 0.91);
-const TEXT = rgb(0.14, 0.17, 0.2);
-const MUTED = rgb(0.38, 0.43, 0.48);
-const BORDER = rgb(0.82, 0.86, 0.88);
+const TEXT = rgb(...REPORT_THEME_RGB.slate);
+const MUTED = rgb(...REPORT_THEME_RGB.muted);
+const BORDER = rgb(...REPORT_THEME_RGB.border);
 const WHITE = rgb(1, 1, 1);
 
 function pdfText(value: string): string {
-  return String(value ?? "")
+  return cleanReportDisplayText(String(value ?? ""))
     .replace(/â€”|â€“|\u2014|\u2013/g, "-")
     .replace(/â€¢|\u2022/g, "-")
     .replace(/â‰¥|\u2265/g, ">=")
@@ -155,7 +156,7 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
       borderColor: safety ? rgb(0.86, 0.48, 0.42) : rgb(0.58, 0.82, 0.77),
       borderWidth: 0.7,
     });
-    page.drawText(pdfText(title), { x: MARGIN + 11, y: cursorY - 13, size: 12.5, font: bold, color: NAVY });
+    page.drawText(pdfText(reportSectionTitle(title)), { x: MARGIN + 11, y: cursorY - 13, size: 12.5, font: bold, color: NAVY });
     cursorY -= 37;
     if (safety) {
       ensureSpace(42);
@@ -295,6 +296,11 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
         while (index + 1 < lines.length && !/^##\s+/.test(lines[index + 1].trim())) index++;
         continue;
       }
+      // This content is already promoted into the opening focus card.
+      if (/^This Week Try$/i.test(heading) && report.focusItems.length) {
+        while (index + 1 < lines.length && !/^##\s+/.test(lines[index + 1].trim())) index++;
+        continue;
+      }
       drawSectionHeader(heading);
       continue;
     }
@@ -318,14 +324,14 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
     drawParagraph(line);
   }
 
-  const disclaimerLines = wrap(disclaimer, regular, 8.5, CONTENT_WIDTH - 20);
-  const disclaimerHeight = disclaimerLines.length * 11 + 18;
-  ensureSpace(disclaimerHeight + 53);
-  cursorY -= 8;
-  drawSectionHeader("Important Wellness Disclaimer");
+  const disclaimerLines = wrap(disclaimer, regular, 8.2, CONTENT_WIDTH - 20);
+  const disclaimerHeight = disclaimerLines.length * 10 + 34;
+  ensureSpace(disclaimerHeight + 10);
+  cursorY -= 6;
   page.drawRectangle({ x: MARGIN, y: cursorY - disclaimerHeight, width: CONTENT_WIDTH, height: disclaimerHeight, color: PALE_BLUE, borderColor: BORDER, borderWidth: 0.7 });
+  page.drawText("IMPORTANT WELLNESS DISCLAIMER", { x: MARGIN + 10, y: cursorY - 15, size: 8.6, font: bold, color: NAVY });
   disclaimerLines.forEach((line, index) => {
-    page.drawText(line, { x: MARGIN + 10, y: cursorY - 14 - index * 11, size: 8.5, font: regular, color: MUTED });
+    page.drawText(line, { x: MARGIN + 10, y: cursorY - 29 - index * 10, size: 8.2, font: regular, color: MUTED });
   });
   cursorY -= disclaimerHeight;
 

--- a/src/lib/reportPresentation.ts
+++ b/src/lib/reportPresentation.ts
@@ -1,0 +1,43 @@
+export const REPORT_THEME = {
+  navy: "#122945",
+  teal: "#06C1A0",
+  slate: "#1F2937",
+  muted: "#64748B",
+  paleTeal: "#E6F7F3",
+  paleBlue: "#EFF5FA",
+  paleAmber: "#FFF4D6",
+  border: "#D1DBE0",
+} as const;
+
+export const REPORT_THEME_RGB = {
+  navy: [18 / 255, 41 / 255, 69 / 255] as const,
+  teal: [6 / 255, 193 / 255, 160 / 255] as const,
+  slate: [31 / 255, 41 / 255, 55 / 255] as const,
+  muted: [100 / 255, 116 / 255, 139 / 255] as const,
+  paleTeal: [230 / 255, 247 / 255, 243 / 255] as const,
+  paleBlue: [239 / 255, 245 / 255, 250 / 255] as const,
+  paleAmber: [255 / 255, 244 / 255, 214 / 255] as const,
+  border: [209 / 255, 219 / 255, 224 / 255] as const,
+} as const;
+
+export function reportSectionTitle(title: string): string {
+  return title === "Lifestyle Prescriptions" ? "Lifestyle Foundations" : title;
+}
+
+export function cleanReportDisplayText(value: string): string {
+  return String(value ?? "")
+    .replace(/\*\*|__|`/g, "")
+    .replace(/^\s*[:;|]+\s*/, "")
+    .replace(/\bevidence\s*:\s*informed\b/gi, "evidence-informed")
+    .replace(/\s+([,.;:])/g, "$1")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+export function blueprintStatusTone(value: string): "current" | "review" | "new" | null {
+  const status = cleanReportDisplayText(value).toLowerCase();
+  if (status === "current - optimize") return "current";
+  if (status === "clinician review") return "review";
+  if (status === "new - consider") return "new";
+  return null;
+}


### PR DESCRIPTION
## Purpose

Make the webpage report and downloadable PDF feel like one LVE360 product, while preserving PR33–PR35 report content, dosage guidance, and generation behavior.

## What changed

- Added shared report presentation tokens for navy/teal/slate colors and display cleanup.
- Aligned webpage typography, section cards, tables, bullets, Blueprint status pills, and focus card with the exported PDF.
- Renamed the user-facing “Lifestyle Prescriptions” heading to “Lifestyle Foundations” in both views without changing the canonical report contract.
- Removed inline/standalone internal Analysis prose from presentation-only sections and replaced useful analysis blocks with existing human-readable labels.
- Removed the duplicate bottom “This Week Try” when the opening focus card is present.
- Stopped the sidebar from inventing fallback Amazon links; it now respects persisted shopping eligibility, including safety blocks such as Berberine with glucose-lowering context.
- Sanitized hanging colons, literal Markdown markers, and malformed display punctuation in link/sidebar labels.
- Added print CSS so browser printing excludes navigation, actions, sidebar, and decorative background while preserving report tables and repeated table headers.
- Kept the exported PDF’s branded header, status pills, table styling, safety callout, page footer, and final disclaimer aligned to the shared palette.
- Compacted the final PDF disclaimer and removed the duplicated “This Week Try” section from the PDF body.

## Files changed

- `app/globals.css`
- `app/results/page.tsx`
- `src/components/results/ResultsSidebar.tsx`
- `src/lib/blueprintReport.ts`
- `src/lib/reportPdf.ts`
- `src/lib/reportPresentation.ts`
- `src/_tests_/blueprintReport.assert.ts`
- `src/_tests_/reportPresentation.assert.ts`

## Checks

- `npm run typecheck` — passed.
- `npm run build` — passed with inert placeholder environment values.
- Blueprint report assertions — passed.
- Presentation cleanup/status assertions — passed.
- `git diff --check` — passed.
- Representative PDF rendered to PNG and all pages were visually inspected.
- `npm run qa:env` — expected failure because the local sandbox has no real Supabase, OpenAI, Tally, Stripe, or application URL variables; no secrets were requested or committed.

## Manual QA

1. Generate a fresh production report from a normal Tally intake.
2. Confirm webpage and PDF use the same section names, item text, tables, bullets, and Blueprint statuses.
3. Confirm no visible `Analysis`, hanging colon, literal `**`, or duplicate “This Week Try.”
4. Confirm a safety-blocked recommendation such as Berberine has no Amazon link in either Shopping Links or the sidebar.
5. Confirm eligible supplements still retain their stored Amazon/Fullscript links.
6. Export the PDF and inspect table continuation, page headers/footers, safety callout, focus card, and final disclaimer.
7. Use browser Print Preview and confirm navigation, Actions, sidebar, and decorative background are excluded.

## Scope / risk

Presentation and commerce-parity cleanup only. No Tally contract, dose registry, recommendation policy, report generation, authentication, checkout, Stripe, or Supabase schema changes.

Rollback commit: `4f61fc6`.