### PR TITLE
PR #37: Refine report trust language and affiliate disclosures

### DIFF
--- a/app/(app)/results/premium/page.tsx
+++ b/app/(app)/results/premium/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import CTAButton from "@/components/CTAButton";
+import { AFFILIATE_DISCLOSURE_NEAR_LINKS, AFFILIATE_DISCLOSURE_SUPPORT } from "@/lib/reportDisclosures";
 
 /* ───────── helpers ───────── */
 function sanitizeMarkdown(md: string): string {
@@ -134,6 +135,11 @@ function LinksTable({
 
   return (
     <div>
+      {type === "shopping" && (
+        <div className="mb-4 rounded-xl border border-[#9DCFC3] bg-[#E6F7F3] px-4 py-3 text-sm leading-6 text-[#173B43]">
+          <strong>Affiliate disclosure:</strong> {AFFILIATE_DISCLOSURE_NEAR_LINKS}
+        </div>
+      )}
       <table className="w-full border-collapse my-2 text-sm shadow-sm">
         <thead className="bg-[#06C1A0] text-white">
           <tr>
@@ -510,6 +516,9 @@ return (
           seek professional care. By using this report, you agree that decisions
           about your health remain your responsibility and that LVE360 is not
           liable for how information is applied.
+        </p>
+        <p className="mt-4 border-t border-slate-200 pt-4 text-sm leading-relaxed text-gray-700">
+          <strong>Affiliate disclosure:</strong> {AFFILIATE_DISCLOSURE_NEAR_LINKS} {AFFILIATE_DISCLOSURE_SUPPORT}
         </p>
       </SectionCard>
 

--- a/app/api/export-pdf/route.ts
+++ b/app/api/export-pdf/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { renderReportPdf } from "@/lib/reportPdf";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
+import { AFFILIATE_DISCLOSURE_NEAR_LINKS, AFFILIATE_DISCLOSURE_SUPPORT } from "@/lib/reportDisclosures";
 
 function isUUID(id: string) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
@@ -25,7 +26,7 @@ function stripFences(md: string) {
 }
 
 const DISCLAIMER_TEXT =
-  "This plan from LVE360 (Longevity | Vitality | Energy) is for educational purposes only and is not medical advice. It is not intended to diagnose, treat, cure, or prevent any disease. Always consult with your healthcare provider before starting new supplements or making significant lifestyle changes, especially if you are pregnant, nursing, managing a medical condition, or taking prescriptions. Supplements are regulated under the Dietary Supplement Health and Education Act (DSHEA); results vary and no outcomes are guaranteed. If you experience unexpected effects, discontinue use and seek professional care. By using this report, you agree that decisions about your health remain your responsibility and that LVE360 is not liable for how information is applied.";
+  `This plan from LVE360 (Longevity | Vitality | Energy) is for educational purposes only and is not medical advice. It is not intended to diagnose, treat, cure, or prevent any disease. Always consult with your healthcare provider before starting new supplements or making significant lifestyle changes, especially if you are pregnant, nursing, managing a medical condition, or taking prescriptions. Supplements are regulated under the Dietary Supplement Health and Education Act (DSHEA); results vary and no outcomes are guaranteed. If you experience unexpected effects, discontinue use and seek professional care. By using this report, you agree that decisions about your health remain your responsibility and that LVE360 is not liable for how information is applied. Affiliate disclosure: ${AFFILIATE_DISCLOSURE_NEAR_LINKS} ${AFFILIATE_DISCLOSURE_SUPPORT}`;
 
 export async function GET(req: NextRequest) {
   try {

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,12 @@ html { scroll-behavior: smooth; }
     break-inside: auto;
     margin-bottom: 1rem !important;
   }
+  .report-section { margin-bottom: 0.65rem !important; }
+  .report-section > div:first-child { padding: 0.45rem 0.75rem !important; }
+  .report-section > div:last-child { padding: 0.7rem !important; }
+  .report-focus { margin-bottom: 0.65rem !important; padding: 0.75rem !important; }
+  .report-prose { font-size: 9.5pt !important; line-height: 1.35 !important; }
+  .report-prose p, .report-prose li { line-height: 1.35 !important; }
   .report-section h2, .report-prose h2 { break-after: avoid-page; }
   .report-prose table { break-inside: auto; }
   .report-prose tr { break-inside: avoid-page; }

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -10,6 +10,7 @@ import CTAButton from "@/components/CTAButton";
 import ResultsSidebar from "@/components/results/ResultsSidebar";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
 import { blueprintStatusTone, cleanReportDisplayText, reportSectionTitle } from "@/lib/reportPresentation";
+import { AFFILIATE_DISCLOSURE_NEAR_LINKS, AFFILIATE_DISCLOSURE_SUPPORT } from "@/lib/reportDisclosures";
 
 /* ───────── helpers ───────── */
 function sanitizeMarkdown(md: string): string {
@@ -153,6 +154,11 @@ function LinksTable({ raw, type }: { raw: string; type: "evidence" | "shopping" 
 
   return (
     <div>
+      {type === "shopping" && (
+        <div className="mb-4 rounded-xl border border-[#9DCFC3] bg-[#E6F7F3] px-4 py-3 text-sm leading-6 text-[#173B43]">
+          <strong>Affiliate disclosure:</strong> {AFFILIATE_DISCLOSURE_NEAR_LINKS}
+        </div>
+      )}
       <table className="my-2 w-full border-collapse overflow-hidden text-sm">
         <thead className="bg-[#122945] text-white">
           <tr>
@@ -586,6 +592,9 @@ async function exportPDF() {
             )}
             {sec.contra && (
               <SectionCard title="Contraindications & Med Interactions">
+                <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-950">
+                  <strong>Safety review:</strong> Only material cautions are highlighted below. Items without a specific flag are omitted.
+                </div>
                 <Prose>{sec.contra}</Prose>
               </SectionCard>
             )}
@@ -646,6 +655,9 @@ async function exportPDF() {
                 and no outcomes are guaranteed. If you experience unexpected effects, discontinue use and seek
                 professional care. By using this report, you agree that decisions about your health remain your
                 responsibility and that LVE360 is not liable for how information is applied.
+              </p>
+              <p className="mt-4 border-t border-slate-200 pt-4 text-sm leading-relaxed text-gray-700">
+                <strong>Affiliate disclosure:</strong> {AFFILIATE_DISCLOSURE_NEAR_LINKS} {AFFILIATE_DISCLOSURE_SUPPORT}
               </p>
             </SectionCard>
 

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -11,6 +11,7 @@ import getSubmissionWithChildren from "@/lib/getSubmissionWithChildren";
 import { supabaseAdmin } from "@/lib/supabase";
 import parseMarkdownToItems from "@/lib/parseMarkdownToItems";
 import { formatStartingGuidance } from "@/lib/supplementDosingRegistry";
+import { AFFILIATE_DISCLOSURE_NEAR_LINKS } from "@/lib/reportDisclosures";
 import { parseBlueprintReport, validateBlueprintReport } from "@/lib/blueprintReport";
 import { applySafetyChecks } from "@/lib/safetyCheck";
 import { enrichAffiliateLinks, buildAmazonSearchLink } from "@/lib/affiliateLinks";
@@ -350,7 +351,7 @@ function buildCurrentStackSection(ledger: NormalizedCurrentStackLedgerItem[]): s
   const body = ledger.length
     ? `| Current Item | Type | Purpose | Dosage | Timing |\n| --- | --- | --- | --- | --- |\n${ledger.map((item) => `| ${item.name} | ${currentStackKindLabel(item.kind)} | ${item.purpose ?? "Not provided"} | ${item.dose ?? "Not provided"} | ${item.timing ?? "Not provided"} |`).join("\n")}`
     : "No current medications, supplements, or hormones were reported in the intake.";
-  return `## Current Stack\n\n${body}\n\n**Analysis**\n\nThis section reflects the current medications, supplements, and hormones reported in the intake. Review it for accuracy and discuss changes or potential interactions with a qualified clinician.`;
+  return `## Current Stack\n\n${body}\n\n**Analysis**\n\nConfirm these entries match your intake. Prescribed medication and hormone instructions are shown for context and are not changed by this report.`;
 }
 
 const FORBIDDEN_COMPLIANCE_RE = /\b(?:therapeutically|therapeutic|alleviate symptoms?|safe|no significant interactions?)\b/i;
@@ -363,7 +364,9 @@ function complianceSafeLanguage(text: string): string {
     .replace(/\bsafe to use\b/gi, "appropriate to consider only after clinician review")
     .replace(/\bsafe\b/gi, "appropriate")
     .replace(/\bno significant interactions?\b/gi, "No specific interaction was flagged by this report")
-    .replace(/\bno specific conflicts? (?:were )?detected(?: from your intake)?\b/gi, "No specific interaction was flagged by this report");
+    .replace(/\bno specific conflicts? (?:were )?detected(?: from your intake)?\b/gi, "No specific interaction was flagged by this report")
+    .replace(/\bcaloric restriction\b/gi, "a sustainable calorie pattern")
+    .replace(/\bintermittent fasting\b/gi, "consistent meal timing that supports adequate nutrition");
 }
 
 function ensureContraCurrentStackCoverage(
@@ -376,50 +379,41 @@ function ensureContraCurrentStackCoverage(
   if (!body || !ledger.length) return complianceSafeLanguage(passB);
   const beforeAnalysis = body.split(/^\*\*Analysis\*\*/im)[0] ?? "";
   const sourceBullets = beforeAnalysis.split(/\r?\n/).filter((line) => /^\s*[-*]\s+/.test(line));
-  const sourceByLabel = new Map(sourceBullets.flatMap((line) => {
-    const bold = line.match(/^\s*[-*]\s+\*\*([^*]+)\*\*/)?.[1];
-    const plain = line.match(/^\s*[-*]\s+([^:]+):/)?.[1];
-    const label = (bold ?? plain ?? "").replace(/:+$/g, "").trim().toLowerCase();
-    return label ? [[label, line] as const] : [];
-  }));
   const sedationContext = /\b(?:lunesta|eszopiclone|xanax|zanax|alprazolam|melatonin|glycine)\b/i;
-  const bullets = ledger.map((item) => {
-    const existing = sourceByLabel.get(item.name.toLowerCase());
-    let detail = existing
-      ? existing
-          .replace(/^\s*[-*]\s+/, "")
-          .replace(/^\*\*[^*]+\*\*\s*(?::|--|\u2014|-)?\s*/, "")
-          .trim()
-      : "No specific interaction was flagged by this report.";
-    detail = detail.replace(new RegExp(`^(?:\\*\\*)?${escapeRe(item.name)}(?:\\*\\*)?\\s*:?\\s*`, "i"), "").trim();
-    if (sedationContext.test(item.name)) {
-      detail = "This item may add to drowsiness when combined with other sleep-supporting or sedating items. Review the combined routine with a qualified clinician or pharmacist.";
-    } else if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(item.name)) {
-      detail = "Glucose-lowering medication or blood-sugar context was reported. Coordinate review with a qualified clinician or pharmacist before changing use.";
-    }
-    const review = /qualified clinician|pharmacist/i.test(detail)
-      ? detail
-      : `${detail.replace(/[.\s]+$/, "")}. Review with a qualified clinician or pharmacist before changing use.`;
-    return `- **${item.name}:** ${complianceSafeLanguage(review)}`;
-  });
-  const analysisSource = body.match(/^\*\*Analysis\*\*\s*([\s\S]*)$/im)?.[1]
-    ?.split(/\r?\n/)
-    .filter((line) => !/^\s*[-*]\s+/.test(line) && !/^\s*\*\*Analysis\*\*/i.test(line))
-    .join(" ")
-    .replace(/\s+/g, " ")
-    .trim();
-  const analysis = complianceSafeLanguage(analysisSource ||
-    "This report highlights potential considerations from the Current Stack but does not establish that any combination is appropriate for an individual. Review medications, hormones, hormone-active supplements, and other supplements with a qualified clinician or pharmacist. Seek individualized guidance before starting, stopping, or changing any item.");
+  const materialBullets = sourceBullets.filter((line) => {
+    if (/no specific interaction|no significant interaction|no specific conflict/i.test(line)) return false;
+    if (sedationContext.test(line)) return false;
+    return /interaction|caution|monitor|spacing|separat|avoid|risk|drows|sedat|bleed|glucose|blood sugar|thyroid|kidney|liver|anticoagul|procedure/i.test(line);
+  }).map((line) => complianceSafeLanguage(line
+    .replace(/review with a qualified clinician or pharmacist before changing use\.?/gi, "")
+    .replace(/\s+([.,])/g, "$1")
+    .replace(/\s{2,}/g, " ")
+    .trim()));
+  const bullets: string[] = Array.from(new Set(materialBullets));
+  const sedatingItems = ledger.filter((item) => sedationContext.test(item.name)).map((item) => item.name);
+  if (sedatingItems.length >= 2) {
+    bullets.unshift(`- **Monitor — Sedating routine:** ${sedatingItems.join(", ")} may have additive drowsiness. Avoid driving if drowsy and keep prescribed instructions unchanged.`);
+  }
+  const thyroidItem = ledger.find((item) => /\b(?:armour thyroid|levothyroxine|synthroid|thyroid)\b/i.test(item.name));
+  const spacingItems = ledger.filter((item) => /\b(?:magnesium|psyllium|fiber|calcium|iron)\b/i.test(item.name)).map((item) => item.name);
+  if (thyroidItem && spacingItems.length) {
+    bullets.push(`- **Monitor — Thyroid medication spacing:** Keep ${spacingItems.join(", ")} separated from ${thyroidItem.name} according to its prescription or label instructions; ask a pharmacist if the timing is unclear.`);
+  }
+  if (berberineRequiresReview && ledger.some((item) => /^berberine(?:\s+hcl)?$/i.test(item.name))) {
+    bullets.push("- **Clinician review — Berberine:** Glucose-lowering medication or blood-sugar context was reported. Do not add or change Berberine without coordinated review.");
+  }
+  if (!bullets.length) {
+    bullets.push("- **No material flags identified:** No specific interaction requiring action was identified from the reported stack. Recheck safety whenever medications or supplements change.");
+  }
+  const analysis = "Only material cautions are highlighted here. Keep prescription instructions unchanged and recheck this section whenever your stack changes.";
   const repaired = `${header}\n\n${bullets.join("\n")}\n\n**Analysis**\n\n${analysis}`;
   return complianceSafeLanguage(passB.replace(`${header}${body}`, repaired));
 }
 
 function validateCurrentStackParity(md: string, ledger: NormalizedCurrentStackLedgerItem[]) {
   const currentBody = sectionChunk(md, "## Current Stack").toLowerCase();
-  const contraBody = sectionChunk(md, "## Contraindications & Med Interactions").toLowerCase();
   const currentMissing = ledger.filter((item) => !currentBody.includes(item.name.toLowerCase()));
-  const contraMissing = ledger.filter((item) => !contraBody.includes(item.name.toLowerCase()));
-  const mismatch = Array.from(new Set([...currentMissing, ...contraMissing].map((item) => item.name)));
+  const mismatch = Array.from(new Set(currentMissing.map((item) => item.name)));
   return { valid: mismatch.length === 0, mismatch };
 }
 
@@ -469,12 +463,15 @@ function sanitizeBlueprintTable(
     const name = validItemName(cells[1]);
     if (!name || isMalformedCurrentStackName(name) || !isEligibleSupplementName(name) || !allowed.has(name.toLowerCase())) return [];
     const whyCell = cells.length >= 4 ? cells[3] : cells[2];
-    return [{ name, why: cleanName(whyCell || "") || "Consider based on intake goals and clinician review", explicit: true }];
+    return [{ name, why: cleanName(whyCell || "") || "Selected to complement the reported goals and current routine", explicit: true }];
   });
-  const candidates = [...parsedItems];
+  const candidates = parsedItems.filter((item) =>
+    !(berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(item.name))
+  );
   for (const name of DEFAULT_BLUEPRINT_ITEMS) {
     if (!allowed.has(name.toLowerCase())) continue;
-    candidates.push({ name, why: "Consider based on intake goals and clinician review", explicit: false });
+    if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(name)) continue;
+    candidates.push({ name, why: "Selected to complement the reported goals and current routine", explicit: false });
   }
   const candidateNames = new Set<string>();
   const deduped = candidates.filter((item) => {
@@ -485,14 +482,12 @@ function sanitizeBlueprintTable(
   });
   const classified = deduped.map((item) => ({
     ...item,
-    status: berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(item.name)
-      ? "Clinician review" as const
-      : currentSupplements.has(normalizeSupplementName(item.name).toLowerCase())
+    status: currentSupplements.has(normalizeSupplementName(item.name).toLowerCase())
         ? "Current - optimize" as const
         : "New - consider" as const,
   }));
   const currentPool = classified.filter((item) => item.status === "Current - optimize").slice(0, 5);
-  const clinicianPool = classified.filter((item) => item.status === "Clinician review" && item.explicit).slice(0, 1);
+  const clinicianPool: typeof classified = [];
   const newPool = classified.filter((item) => item.status === "New - consider");
   const selected = [...currentPool];
   const reservedClinician = clinicianPool.length;
@@ -507,9 +502,7 @@ function sanitizeBlueprintTable(
   const header = "| Rank | Supplement | Status | Why it Matters |\n| --- | --- | --- | --- |";
   return `${header}\n${items.map((item, index) => {
     const status = item.status;
-    const why = status === "Clinician review"
-      ? `${item.why.replace(/[.\s]+$/, "")}. Coordinate with a qualified clinician before considering use.`
-      : item.why;
+    const why = item.why;
     return `| ${index + 1} | ${item.name} | ${status} | ${complianceSafeLanguage(why)} |`;
   }).join("\n")}`;
 }
@@ -575,9 +568,9 @@ function consistentDosingBody(
     const current = ledger.find((item) => item.kind === "supplement" &&
       normalizeSupplementName(item.name).toLowerCase() === normalizeSupplementName(name).toLowerCase());
     const reported = [current?.dose, current?.timing].filter(Boolean).join(", ");
-    if (current && reported) return `- **${name}** -- Currently reported: ${reported}. Review before changing.`;
+    if (current && reported) return `- **${name}** -- Your reported routine: ${reported}.`;
     if (berberineRequiresReview && /^berberine(?:\s+hcl)?$/i.test(name)) {
-      return `- **${name}** -- Clinician review is required before considering use because glucose-lowering medication or blood-sugar context was reported. Do not start without coordinated review.`;
+      return `- **${name}** -- Not included as a starting recommendation because glucose-lowering medication or blood-sugar context was reported.`;
     }
     const startingGuidance = formatStartingGuidance(name);
     if (startingGuidance) return `- **${name}** -- ${startingGuidance}`;
@@ -594,17 +587,18 @@ function consistentDosingBody(
     .filter((item) => !blueprintSet.has(normalizeSupplementName(item.name).toLowerCase()) && !coveredCurrent.has(normalizeSupplementName(item.name).toLowerCase()))
     .map((item) => {
       const details = [item.dose ? `dose: ${item.dose}` : null, item.timing ? `timing: ${item.timing}` : null].filter(Boolean).join("; ");
-      return `- **${item.name}** -- Current ${currentStackKindLabel(item.kind).toLowerCase()} reported${details ? ` (${details})` : ""}. Review interactions and any changes with a qualified clinician or pharmacist.`;
+      const instruction = item.kind === "supplement"
+        ? "Shown for context; no change is suggested by this report."
+        : "Keep the prescribed instructions unchanged.";
+      return `- **${item.name}** -- Current ${currentStackKindLabel(item.kind).toLowerCase()} reported${details ? ` (${details})` : ""}. ${instruction}`;
     });
   const currentNotes = [...uniqueCurrentLines, ...missingCurrentLines];
   const currentBlock = currentNotes.length
     ? `\n\n### Current Stack Notes\n\n${currentNotes.join("\n")}`
     : "";
-  const analysisIndex = body.search(/^\*\*Analysis\*\*/im);
-  const analysis = analysisIndex >= 0
-    ? body.slice(analysisIndex).trim()
-    : "**Analysis**\n\nThese notes cover every Blueprint recommendation. Specific dosing should be reviewed with a clinician when it cannot be provided safely from the intake alone.";
-  return complianceSafeLanguage(`${blueprintLines.join("\n")}${currentBlock}\n\n${analysis}`.trim());
+  const sectionGuidance = "Starting points below are general educational guidance for eligible supplements. Keep prescribed medication and hormone instructions exactly as directed by the prescriber, and introduce only one new supplement at a time.";
+  const analysis = "**Analysis**\n\nUse the lowest practical starting point, track how you respond, and change only one variable at a time. Item-specific cautions and spacing instructions take priority over general timing guidance.";
+  return complianceSafeLanguage(`${sectionGuidance}\n\n${blueprintLines.join("\n")}${currentBlock}\n\n${analysis}`.trim());
 }
 
 function assembleCanonicalReport(
@@ -1226,7 +1220,7 @@ function overrideEvidenceInMarkdown(md: string, section: string): string {
 
 function buildShoppingLinksSection(items: StackItem[]): string {
   if (!items || items.length === 0) {
-    return "## Shopping Links\n\n- No links available yet.\n\n**Analysis**\n\nLinks will be provided once products are mapped.";
+    return `## Shopping Links\n\n**Affiliate disclosure:** ${AFFILIATE_DISCLOSURE_NEAR_LINKS}\n\n- No links available yet.\n\n**Analysis**\n\nLinks will be provided once eligible products are mapped.`;
   }
   const bullets = items.map((it) => {
     const name = `${cleanName(it.name)}${it.is_current ? " (Current Stack)" : ""}`;
@@ -1237,7 +1231,20 @@ function buildShoppingLinksSection(items: StackItem[]): string {
     if (it.link_other) links.push(`[Other](${it.link_other})`);
     return `- **${name}**: ${links.join(" • ")}`;
   });
-  return `## Shopping Links\n\n${bullets.join("\n")}\n\n**Analysis**\n\nThese links are provided for convenience. Premium users may see Fullscript options when available; Amazon links are shown for everyone.`;
+  return `## Shopping Links\n\n**Affiliate disclosure:** ${AFFILIATE_DISCLOSURE_NEAR_LINKS}\n\n${bullets.join("\n")}\n\n**Analysis**\n\nThese links are optional conveniences. Product eligibility follows the same safety and recommendation rules used throughout this report.`;
+}
+
+function buildPracticalFollowUpSection(): string {
+  return `## Follow-up Plan
+
+- **Week 1:** Add no more than one new supplement. Keep the rest of the routine stable so any change is easier to interpret.
+- **Week 2:** Record energy, sleep, digestion, and adherence two or three times during the week.
+- **Weeks 4-6:** Compare the same measures with your starting point and keep only changes that are useful and well tolerated.
+- **Recheck sooner:** Regenerate the Blueprint if a medication, supplement, health condition, or major goal changes.
+
+**Analysis**
+
+Use the smallest change that can be measured. Stop a newly added item if unexpected effects occur and seek appropriate care for urgent or severe symptoms.`;
 }
 
 // ----------------------------------------------------------------------------
@@ -1330,7 +1337,7 @@ Output ONLY the section "## Your Blueprint Recommendations" as a Markdown table 
 - Never recommend endocrine-active supplements such as DHEA or Pregnenolone by default.
 - Select from the recommendable supplement ledger. Do not simply copy the Current Stack unless a legitimate current supplement has a clear optimization reason.
 - Status must be exactly "Current - optimize" for a reported current supplement, "New - consider" for a new option, or "Clinician review" when coordinated review is needed.
-- ${berberineRequiresReview ? "Berberine must use Clinician review status and explicit coordinated clinician-review language because glucose-lowering context is present." : "Berberine still requires conservative clinician-review language."}
+- ${berberineRequiresReview ? "Do not include Berberine because glucose-lowering medication or blood-sugar context is present; choose another eligible lower-risk option." : "Include Berberine only when it is otherwise eligible and relevant."}
 - Use short, plain-English rationales ("Why it Matters").
 - If dosing/timing is relevant, write "See Dosing & Notes".
 - Do NOT output any other text. Do NOT include END. Only the table.
@@ -1367,16 +1374,16 @@ Generate ONLY these two sections, in this order:
 
 ## Contraindications & Med Interactions
 - Identify potential conflicts among medications, hormones, and supplements.
-- Review every normalized Current Stack item shown in CLIENT; do not silently omit an item.
-- Use exactly one bullet per Current Stack item and put every bullet before Analysis.
-- If no specific interaction is identified for an item, write "No specific interaction was flagged by this report" and recommend review with a qualified clinician or pharmacist.
+- Highlight only material conflicts, spacing issues, or monitoring considerations; omit routine items with no specific flag.
+- Group overlapping cautions, such as multiple sedating items, into one clear bullet.
+- Prefix material bullets with "Monitor" or "Clinician review" according to severity.
 - Call out classes (e.g., MAO-B risk, serotonin, anticoagulants).
 - Avoid definitive safety statements and disease-treatment wording. Analysis must be last.
 - Use plain English. End with **Analysis** (≥3 sentences).
 
 ## Dosing & Notes
 - Bullet each recommended supplement with dose + timing (AM/PM/with meals) and short note.
-- For a current Blueprint supplement with known dose or timing, write "Currently reported: [dose], [timing]. Review before changing."
+- For a current Blueprint supplement with known dose or timing, write "Your reported routine: [dose], [timing]."
 - Put non-Blueprint current items only under a separate "### Current Stack Notes" subsection.
 - For Berberine with Metformin, Zepbound, diabetes, glucose, or blood-sugar context, require coordinated clinician review and do not imply it is appropriate to start.
 - Reference meds/hormones when timing matters.
@@ -2107,6 +2114,7 @@ modelUsed = resC?.modelUsed ?? modelUsed;
   // ---------- Stitch full Markdown in canonical user-facing order ----------
 restMd = replaceOrAppendSection(restMd, buildCurrentStackSection(currentStackLedger));
 let md = assembleCanonicalReport(restMd, tableMd, dosingMd, currentStackLedger, berberineRequiresReview);
+md = replaceOrAppendSection(md, buildPracticalFollowUpSection());
 
 
   // Sanity: enforce headings and pad the Blueprint without exposing END.

--- a/src/lib/reportDisclosures.ts
+++ b/src/lib/reportDisclosures.ts
@@ -1,0 +1,6 @@
+export const AFFILIATE_DISCLOSURE_NEAR_LINKS =
+  "LVE360 may earn a small commission when you purchase through certain links, at no additional cost to you. As an Amazon Associate I earn from qualifying purchases.";
+
+export const AFFILIATE_DISCLOSURE_SUPPORT =
+  "Affiliate commissions help support the cost of producing free reports and maintaining LVE360. Recommendations are based on your goals, reported information, safety rules, and available evidence—not commission availability.";
+

--- a/src/lib/reportPdf.ts
+++ b/src/lib/reportPdf.ts
@@ -162,7 +162,7 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
       ensureSpace(42);
       page.drawRectangle({ x: MARGIN, y: cursorY - 32, width: CONTENT_WIDTH, height: 34, color: PALE_AMBER, borderColor: rgb(0.88, 0.7, 0.32), borderWidth: 0.8 });
       page.drawText("SAFETY REVIEW", { x: MARGIN + 10, y: cursorY - 12, size: 8, font: bold, color: NAVY });
-      page.drawText("Review the combined Current Stack with a qualified clinician or pharmacist before making changes.", {
+      page.drawText("Only material cautions are highlighted; items without a specific flag are omitted.", {
         x: MARGIN + 10, y: cursorY - 25, size: 8.5, font: regular, color: TEXT,
       });
       cursorY -= 43;
@@ -339,7 +339,7 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
   pages.forEach((pdfPage, index) => {
     drawBrandHeader(pdfPage);
     pdfPage.drawLine({ start: { x: MARGIN, y: 41 }, end: { x: PAGE_WIDTH - MARGIN, y: 41 }, color: BORDER, thickness: 0.5 });
-    pdfPage.drawText("Educational wellness information - review changes with a qualified clinician.", {
+    pdfPage.drawText("Educational wellness guidance.", {
       x: MARGIN, y: FOOTER_Y, size: 7.2, font: regular, color: MUTED,
     });
     const pageLabel = `Page ${index + 1} of ${pages.length}`;

--- a/src/lib/supplementDosingRegistry.ts
+++ b/src/lib/supplementDosingRegistry.ts
@@ -51,6 +51,5 @@ export function formatStartingGuidance(name: string): string | null {
     entry.adjustment ? `Adjustment: ${entry.adjustment}.` : null,
     entry.guardrail ? `Guardrail: ${entry.guardrail}.` : null,
     entry.caution ? `Safety note: ${entry.caution}.` : null,
-    "This is general wellness guidance, not a prescription.",
   ].filter(Boolean).join(" ");
 }


### PR DESCRIPTION
## Purpose

Make the PR36 report feel more useful and less alarmist while preserving material safety guardrails, and add clear affiliate disclosures to the webpage and exported PDF.

## What changed

- Replaced one-warning-per-item behavior with risk-tiered safety output.
- Groups overlapping sedation cautions and adds deterministic thyroid-spacing guidance.
- Omits routine items that have no material interaction flag.
- Excludes Berberine from Blueprint recommendations when glucose-lowering context is present, allowing a usable lower-risk recommendation to fill the slot.
- Replaces repetitive per-item clinician disclaimers with one section-level dosing boundary.
- Carries reported supplement routines forward without repeatedly saying “review before changing.”
- Adds a practical Week 1 / Week 2 / Weeks 4–6 follow-up loop.
- Adds the required affiliate disclosure beside shopping links and in the final disclaimer on free, premium, and exported-PDF reports.
- Aligns the webpage and PDF safety callout language.
- Tightens browser-print spacing and removes clinician language from the PDF footer.
- Softens broad caloric-restriction and intermittent-fasting language.
- Keeps report emailing out of scope for a focused PR38.

## Checks

- `npm run typecheck` — passed.
- `npm run build` — passed with inert build-time placeholders.
- `git diff --check` — passed.
- Representative PDF rendered with the production renderer, converted to images with Poppler, and visually inspected — passed.
- Expected placeholder Supabase fetch warning during build was non-blocking.

## Manual QA

1. Generate a report with ordinary supplements plus multiple sedating items and thyroid medication.
2. Confirm the safety section shows only material, grouped cautions—not one clinician warning per item.
3. Confirm Berberine is absent from Blueprint and shopping when Metformin/Zepbound/blood-sugar context exists.
4. Confirm Blueprint still has exactly 10 recommendations and the replacement item has dose/timing guidance.
5. Confirm current supplement dosing says “Your reported routine” without blanket “review before changing.”
6. Confirm the practical follow-up plan appears.
7. Confirm affiliate disclosure appears immediately above shopping links and again in the final disclaimer.
8. Export the PDF and verify the matching safety callout, disclosure, footer, page numbers, and final disclaimer.
9. Print/save the webpage report and confirm compact spacing remains readable.

## Not changed

No auth, checkout, Stripe, Tally, Supabase schema, email delivery, or report-email behavior was changed.