### PR TITLE
Fix weekly focus generation regression

### DIFF
--- a/app/api/generate-stack/route.ts
+++ b/app/api/generate-stack/route.ts
@@ -323,23 +323,16 @@ try {
   console.error("[generate-stack] generator soft-fail:", msg);
   await logFailure("generate-stack", msg, { submissionId, mode });
 
-  // Soft fallback: create/refresh an empty warning stack so UI can render
-  const fb = await ensureFallbackStack(submission, [
-    isTimeout
-      ? "Generation took too long. Please retry."
-      : "Generation temporarily failed. Please retry.",
-  ]);
-
   return NextResponse.json(
     {
-      ok: true,
+      ok: false,
       mode,
       user_tier: tier,
-      stack: fb,
-      itemsInserted: 0,
-      ai: { markdown: fb.markdown, raw: fb.raw },
+      error: isTimeout
+        ? "Generation took too long. Please retry."
+        : "Generation temporarily failed. Please retry.",
     },
-    { status: 200 }
+    { status: isTimeout ? 504 : 500 }
   );
 }
 // Validation is advisory (do NOT fail the request if generator succeeded)

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -570,7 +570,7 @@ async function exportPDF() {
 
             {error && <div className="text-center text-red-600 mb-6">{error}</div>}
 
-            {sec.focusItems.length > 0 && (
+            {!warmingUp && !generating && flow !== "error" && sec.focusItems.length > 0 && (
               <div className="report-focus mb-8 rounded-2xl border border-[#9DCFC3] bg-gradient-to-r from-[#EFF5FA] to-[#E6F7F3] p-6 shadow-sm">
                 <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#122945]">This Week Focus</p>
                 <ol className="mt-3 grid gap-2 text-sm text-slate-800 sm:grid-cols-2">

--- a/src/lib/blueprintReport.ts
+++ b/src/lib/blueprintReport.ts
@@ -30,9 +30,29 @@ function cleanText(value: string): string {
 
 function extract(markdown: string, heading: ReportSectionName): string {
   const lines = markdown.split(/\r?\n/);
-  const headingPattern = /^##\s+(.+?)\s*$/;
-  const headingIndex = lines.findIndex((line) => headingPattern.exec(line)?.[1] === heading);
-  if (headingIndex === -1) return "";
+  const headingPattern = /^\s*##\s+(.+?)\s*$/;
+  const normalizeHeading = (value: string) => value
+    .replace(/^\d+[.)]\s*/, "")
+    .replace(/[*_`]/g, "")
+    .replace(/\s*:$/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+  const expectedHeading = normalizeHeading(heading);
+  const headingIndex = lines.findIndex((line) => {
+    const match = headingPattern.exec(line);
+    return Boolean(match && normalizeHeading(match[1]) === expectedHeading);
+  });
+  if (headingIndex === -1) {
+    const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const fallbackHeading = new RegExp(`##\\s+(?:\\d+[.)]\\s*)?${escaped}\\s*:?\\s*(?:\\r?\\n|$)`, "i");
+    const match = fallbackHeading.exec(markdown);
+    if (!match) return "";
+    const bodyStart = match.index + match[0].length;
+    const remainder = markdown.slice(bodyStart);
+    const nextHeading = /(?:^|\r?\n)\s*##\s+/m.exec(remainder);
+    return cleanSectionBody(remainder.slice(0, nextHeading?.index ?? remainder.length), heading);
+  }
 
   let nextHeadingIndex = lines.length;
   for (let index = headingIndex + 1; index < lines.length; index++) {
@@ -42,7 +62,11 @@ function extract(markdown: string, heading: ReportSectionName): string {
     }
   }
 
-  let body = lines.slice(headingIndex + 1, nextHeadingIndex).join("\n");
+  return cleanSectionBody(lines.slice(headingIndex + 1, nextHeadingIndex).join("\n"), heading);
+}
+
+function cleanSectionBody(rawBody: string, heading: ReportSectionName): string {
+  let body = rawBody;
   const analysisLine = /^\s*(?:\*\*)?Analysis(?:\*\*)?\s*:?\s*(.*)$/im;
   if (["Intro Summary", "Goals", "Dosing & Notes", "Evidence & References", "Shopping Links", "Lifestyle Prescriptions", "Longevity Levers", "This Week Try"].includes(heading)) {
     body = body.split(analysisLine)[0] ?? body;

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -1287,20 +1287,30 @@ function buildActionableThisWeekSection(blueprintTable: string, client: any): st
     .filter((line) => /^\s*\|\s*\d+\s*\|/.test(line))
     .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()))
     .find((cells) => cells[2] === "New - consider")?.[1];
-  const goals = reportedGoals(client).join(" ").toLowerCase();
-  const goalHabit = /sleep/.test(goals)
-    ? "Keep the same bedtime and wake time on at least five days."
-    : /muscle|strength/.test(goals)
-      ? "Complete two resistance-training sessions and record the exercises used."
-      : "Take a 10-minute walk after your largest meal on at least four days.";
+  const goals = reportedGoals(client).map((goal) => goal.toLowerCase());
+  const goalActions: Array<{ matches: RegExp; action: string }> = [
+    { matches: /weight|body composition|fat loss/, action: "Take a 10-minute walk after your largest meal on at least four days and note completion." },
+    { matches: /sleep/, action: "Keep the same bedtime and wake time on at least five days and record morning energy." },
+    { matches: /muscle|strength/, action: "Complete two resistance-training sessions and record the exercises used." },
+    { matches: /cogn|focus|memory|brain/, action: "Schedule one 25-minute distraction-free focus block on at least four days and note your focus afterward." },
+    { matches: /inflam|joint/, action: "Record joint comfort or soreness on three days using the same 1-to-10 scale." },
+    { matches: /energy|fatigue/, action: "Record morning and afternoon energy on three days using the same 1-to-10 scale." },
+    { matches: /longevity|aging/, action: "Complete at least 150 minutes of total walking or other moderate activity this week." },
+  ];
+  const matchedGoalActions = goalActions
+    .filter(({ matches }) => goals.some((goal) => matches.test(goal)))
+    .map(({ action }) => action);
   const firstAction = newItem
     ? `If you choose to add ${newItem}, make it the only new supplement this week and use the starting guidance in this report.`
     : "Add no more than one new supplement this week.";
+  const actions = Array.from(new Set([
+    firstAction,
+    ...matchedGoalActions,
+    "Record one consistent outcome tied to your top goal on three days.",
+  ])).slice(0, 3);
   return `## This Week Try
 
-- ${firstAction}
-- Record sleep quality and morning energy on three days.
-- ${goalHabit}`;
+${actions.map((action) => `- ${action}`).join("\n")}`;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/lib/reportIntegrity.ts
+++ b/src/lib/reportIntegrity.ts
@@ -1,9 +1,3 @@
-const DEFAULT_FOCUS_ITEMS = [
-  "Add no more than one new supplement this week.",
-  "Record sleep quality and morning energy on three days.",
-  "Take a 10-minute walk after your largest meal.",
-];
-
 const NON_ACTIONABLE_FOCUS_RE = /^(?:this week[, ]+)?(?:try|experiment with|focus on|consider)(?: the following)?\s*:?[\s.]*$/i;
 
 function plainText(value: string): string {
@@ -14,7 +8,7 @@ function plainText(value: string): string {
     .trim();
 }
 
-export function normalizeFocusItems(raw: string, fallback = DEFAULT_FOCUS_ITEMS): string[] {
+export function normalizeFocusItems(raw: string): string[] {
   const candidates = String(raw ?? "")
     .split(/\r?\n/)
     .filter((line) => /^\s*(?:[-*]|\d+[.)])\s+/.test(line))
@@ -25,12 +19,7 @@ export function normalizeFocusItems(raw: string, fallback = DEFAULT_FOCUS_ITEMS)
       !NON_ACTIONABLE_FOCUS_RE.test(item) &&
       !/^analysis\b/i.test(item)
     );
-  const unique = Array.from(new Set(candidates));
-  for (const item of fallback) {
-    if (unique.length >= 3) break;
-    if (!unique.includes(item)) unique.push(item);
-  }
-  return unique.slice(0, 4);
+  return Array.from(new Set(candidates)).slice(0, 4);
 }
 
 export function recommendationRationale(name: string): string | null {
@@ -62,4 +51,3 @@ export function neutralGoalDescription(goal: string): string {
   if (/energy|fatigue/.test(value)) return "Support steadier daytime energy and recovery.";
   return "Make measurable, sustainable progress toward this stated wellness priority.";
 }
-


### PR DESCRIPTION
## What changed

- Removed generic Weekly Focus fallback copy from the report parser.
- Generates up to three Weekly Focus actions from the user's selected goals and first eligible new recommendation.
- Hides Weekly Focus while a report is warming up, generating, or has failed.
- Hardened canonical H2 extraction for numbered, punctuated, and variably spaced headings.
- Returns a real generation error instead of replacing a saved report with an empty fallback stack.

## Root cause

PR38 made the parser manufacture three generic focus items even when the report Markdown was empty. Production logs also showed canonical validation marking all 12 sections empty and refusing persistence. The API then returned a successful empty fallback and cleared stack items, so the page kept polling while displaying generic advice.

## Validation

- `npm run typecheck`
- `npm run build` with inert build-time placeholders
- `git diff --check`
- Direct parser assertion: all 12 representative sections are populated
- Direct Focus assertion: personalized actions are retained
- Direct empty-report assertion: zero Focus items are manufactured

## Manual production smoke test

1. Submit an intake with at least two goals, such as Weight Loss and Improve Sleep.
2. Generate a new report and confirm no Weekly Focus card appears during generation.
3. Confirm the completed report contains three actions tied to the selected goals and an eligible new recommendation.
4. Confirm the report and stack items persist and reload after refresh.
5. Force or observe a failed generation and confirm the prior saved report is not erased.
