### PR TITLE
Fix creatine evidence validation

### DIFF
--- a/src/lib/evidence.ts
+++ b/src/lib/evidence.ts
@@ -169,10 +169,10 @@ export function getTopCitationsFor(name: string, limit = 2): string[] {
   return sanitizeCitations(arr.slice(0, limit).map((e) => e.url));
 }
 
-/** Enforce PubMed/DOI only */
+/** Keep the same curated-source policy used by report generation. */
 export function sanitizeCitations(urls: string[]): string[] {
   const re =
-    /(https?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/|pmc\.ncbi\.nlm\.nih\.gov\/articles\/PMC\d+|doi\.org\/\S+))/i;
+    /(https?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/?|pmc\.ncbi\.nlm\.nih\.gov\/articles\/\S+|doi\.org\/\S+|jamanetwork\.com\/\S+|(?:[a-z0-9-]+\.)?biomedcentral\.com\/\S+|journals\.plos\.org\/\S+|nature\.com\/\S+|sciencedirect\.com\/\S+|amjmed\.com\/\S+|koreascience\.kr\/\S+|researchmgt\.monash\.edu\/\S+))/i;
   return (urls || [])
     .map((u) => (u || "").trim())
     .filter((u) => re.test(u));

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -171,7 +171,7 @@ const MIN_ANALYSIS_SENTENCES = 3;
 const BLUEPRINT_MIN_ROWS = 10; // business rule: always show ≥10 rows
 
 const MODEL_CITE_RE = /\bhttps?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/?|doi\.org\/\S+)\b/;
-const CURATED_CITE_RE = /\bhttps?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/?|pmc\.ncbi\.nlm\.nih\.gov\/articles\/\S+|doi\.org\/\S+|jamanetwork\.com\/\S+|biomedcentral\.com\/\S+|bmcpsychiatry\.biomedcentral\.com\/\S+|journals\.plos\.org\/\S+|nature\.com\/\S+|sciencedirect\.com\/\S+|amjmed\.com\/\S+|koreascience\.kr\/\S+|researchmgt\.monash\.edu\/\S+)\b/i;
+const CURATED_CITE_RE = /\bhttps?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/?|pmc\.ncbi\.nlm\.nih\.gov\/articles\/\S+|doi\.org\/\S+|jamanetwork\.com\/\S+|(?:[a-z0-9-]+\.)?biomedcentral\.com\/\S+|journals\.plos\.org\/\S+|nature\.com\/\S+|sciencedirect\.com\/\S+|amjmed\.com\/\S+|koreascience\.kr\/\S+|researchmgt\.monash\.edu\/\S+)\b/i;
 
 const HEADINGS = [
   "## Intro Summary",


### PR DESCRIPTION
## What changed

- Aligns the evidence sanitizer with the curated-source policy used by report generation.
- Accepts reputable Biomed Central journal subdomains, including the existing JISSN creatine source.
- Keeps the strict requirement that every Blueprint recommendation have aligned evidence.

## Root cause

Production generation found the curated creatine study at `jissn.biomedcentral.com`, but `sanitizeCitations()` discarded everything except PubMed, PMC, and DOI URLs. PR38's evidence gate then rejected the otherwise valid report with:

`Missing aligned evidence for Blueprint recommendations: Creatine Monohydrate`

The intake and dosage normalization were healthy; persistence never ran because of this contradictory evidence policy.

## Validation

- `npm run typecheck`
- `npm run build` with inert build-time placeholders
- `git diff --check`
- Direct assertion that the existing JISSN creatine citation passes the curated-source rule

## Manual smoke test

1. Generate a report that recommends or optimizes Creatine Monohydrate.
2. Confirm generation completes without an evidence error.
3. Confirm the report persists and reloads after refresh.
4. Confirm Creatine Monohydrate appears in Evidence & References with the JISSN source.
5. Confirm Weekly Focus reflects the intake goals and selected recommendation.
