### PR TITLE
Use company voice in affiliate disclosure

### DIFF
--- a/src/lib/reportDisclosures.ts
+++ b/src/lib/reportDisclosures.ts
@@ -1,6 +1,5 @@
 export const AFFILIATE_DISCLOSURE_NEAR_LINKS =
-  "LVE360 may earn a small commission when you purchase through certain links, at no additional cost to you. As an Amazon Associate I earn from qualifying purchases.";
+  "LVE360 may earn a small commission when you purchase through certain links, at no additional cost to you. These commissions help keep personalized LVE360 reports free. Amazon-required disclosure: \u201cAs an Amazon Associate I earn from qualifying purchases.\u201d";
 
 export const AFFILIATE_DISCLOSURE_SUPPORT =
-  "Affiliate commissions help support the cost of producing free reports and maintaining LVE360. Recommendations are based on your goals, reported information, safety rules, and available evidence—not commission availability.";
-
+  "Recommendations are based on your goals, reported information, safety rules, and available evidence\u2014not commission availability.";

--- a/src/lib/reportDisclosures.ts
+++ b/src/lib/reportDisclosures.ts
@@ -1,5 +1,5 @@
 export const AFFILIATE_DISCLOSURE_NEAR_LINKS =
-  "LVE360 may earn a small commission when you purchase through certain links, at no additional cost to you. These commissions help keep personalized LVE360 reports free. Amazon-required disclosure: \u201cAs an Amazon Associate I earn from qualifying purchases.\u201d";
+  "LVE360 may earn a small commission when you purchase through certain links, at no additional cost to you. These commissions help keep personalized LVE360 reports free. As an Amazon Associate, we earn from qualifying purchases.";
 
 export const AFFILIATE_DISCLOSURE_SUPPORT =
   "Recommendations are based on your goals, reported information, safety rules, and available evidence\u2014not commission availability.";

--- a/src/lib/reportPdf.ts
+++ b/src/lib/reportPdf.ts
@@ -338,7 +338,20 @@ export async function renderReportPdf(markdown: string, disclaimer: string): Pro
       continue;
     }
     if (/^###\s+/.test(line)) {
-      ensureSpace(24);
+      // Keep subsection headings with the first line of content that follows.
+      // Without this reservation, headings can be orphaned at the foot of a page.
+      let nextContent = "";
+      for (let lookahead = index + 1; lookahead < lines.length; lookahead++) {
+        const candidate = lines[lookahead].trim();
+        if (!candidate) continue;
+        if (/^#{1,3}\s+/.test(candidate)) break;
+        nextContent = candidate.replace(/^[-*]\s+/, "");
+        break;
+      }
+      const nextContentHeight = nextContent
+        ? wrap(pdfText(nextContent), regular, 9.5, CONTENT_WIDTH).length * 12 + 8
+        : 16;
+      ensureSpace(24 + Math.min(nextContentHeight, 72));
       drawParagraph(line.replace(/^###\s+/, ""), { font: bold, size: 10.5, color: NAVY });
       continue;
     }


### PR DESCRIPTION
Updates the affiliate disclosure to use LVE360 company voice, explains that commissions help keep personalized reports free, and preserves recommendation independence language. Also carries forward the PDF subsection pagination fix that keeps Safety Takeaway and How to Measure Progress with their following content. Validation: npm run typecheck passed; production build previously passed with inert build-time configuration.