### PR TITLE
Prevent duplicate Blueprint emails

### DIFF
--- a/app/(app)/results/premium/page.tsx
+++ b/app/(app)/results/premium/page.tsx
@@ -315,6 +315,7 @@ function ResultsContent() {
 
       const data = await api("/api/generate-stack", {
         tally_submission_id: tallyId,
+        generation_source: "premium-results-page",
       });
 
       const raw =

--- a/app/api/generate-stack/route.ts
+++ b/app/api/generate-stack/route.ts
@@ -268,7 +268,12 @@ export async function POST(req: NextRequest) {
       (body["tally_submission_id"] ?? body["tallyId"] ?? body["tally"] ?? "")?.toString().trim() ||
       null;
 
-    console.info("[API] /api/generate-stack received:", { submissionId, tallyShort });
+    const requestedSource = String(body["generation_source"] ?? "unknown").trim().toLowerCase();
+    const generationSource = /^[a-z0-9-]{1,40}$/.test(requestedSource)
+      ? requestedSource
+      : "unknown";
+
+    console.info("[API] /api/generate-stack received:", { submissionId, tallyShort, generationSource });
 
     // Resolve tally → UUID if needed (tolerate webhook lag)
     if (!submissionId && tallyShort) {
@@ -360,6 +365,13 @@ if (stackIdStr && typeof result?.markdown === "string" && result.markdown.trim()
     submissionId: submission.id,
     stackId: stackIdStr,
     markdown: result.markdown,
+    generationSource,
+  });
+  console.info("[generate-stack] report email result", {
+    submissionId: submission.id,
+    stackId: stackIdStr,
+    generationSource,
+    emailStatus: email.status,
   });
 }
 

--- a/app/api/tally-webhook/route.ts
+++ b/app/api/tally-webhook/route.ts
@@ -430,7 +430,10 @@ const submissionRow = {
       fetch(`${appUrl}/api/generate-stack`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ submission_id: submissionId }),
+        body: JSON.stringify({
+          submission_id: submissionId,
+          generation_source: "tally-webhook",
+        }),
       }).catch((err) => console.error("Background generate-stack failed:", err));
     } catch (e) {
       console.error("Failed to trigger generate-stack:", e);

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -417,9 +417,9 @@ async function generateStack() {
     setGenerating(true);
 
     // Kick off generation with whichever id we have
-    const payload: { tally_submission_id?: string; submission_id?: string } = tallyId
-      ? { tally_submission_id: tallyId as string }
-      : { submission_id: anyId as string };
+    const payload: { tally_submission_id?: string; submission_id?: string; generation_source: string } = tallyId
+      ? { tally_submission_id: tallyId as string, generation_source: "results-page" }
+      : { submission_id: anyId as string, generation_source: "results-page" };
 
     const data = await api("/api/generate-stack", payload);
     setStackId(

--- a/src/lib/reportEmail.ts
+++ b/src/lib/reportEmail.ts
@@ -13,9 +13,14 @@ type SendReportEmailInput = {
   submissionId: string;
   stackId: string;
   markdown: string;
+  generationSource: string;
 };
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function blueprintEmailIdempotencyKey(submissionId: string): string {
+  return `blueprint-email-${submissionId}`;
+}
 
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (character) => ({
@@ -79,7 +84,14 @@ export async function sendGeneratedBlueprintEmail(input: SendReportEmailInput): 
     const pdf = await renderReportPdf(report.canonicalMarkdown, REPORT_DISCLAIMER_TEXT);
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL?.trim() || "https://app.lve360.com").replace(/\/$/, "");
     const reportUrl = `${appUrl}/results?submission_id=${encodeURIComponent(input.submissionId)}`;
+    const idempotencyKey = blueprintEmailIdempotencyKey(input.submissionId);
     const resend = new Resend(apiKey);
+    console.info("[report-email] send attempt", {
+      submissionId: input.submissionId,
+      stackId: input.stackId,
+      generationSource: input.generationSource,
+      idempotencyKey,
+    });
     const { data, error } = await resend.emails.send(
       {
         from: process.env.REPORT_EMAIL_FROM?.trim() || "LVE360 <reports@lve360.com>",
@@ -94,14 +106,20 @@ export async function sendGeneratedBlueprintEmail(input: SendReportEmailInput): 
           contentType: "application/pdf",
         }],
       },
-      { idempotencyKey: `blueprint-${input.stackId}-${report.contentHash}` }
+      { idempotencyKey }
     );
 
     if (error || !data?.id) {
       console.error("[report-email] Resend rejected message", { stackId: input.stackId, error });
       return { status: "failed", reason: "provider-rejected" };
     }
-    console.info("[report-email] sent", { stackId: input.stackId, emailId: data.id });
+    console.info("[report-email] send completed", {
+      submissionId: input.submissionId,
+      stackId: input.stackId,
+      generationSource: input.generationSource,
+      idempotencyKey,
+      emailId: data.id,
+    });
     return { status: "sent", id: data.id };
   } catch (error) {
     console.error("[report-email] send failed", { stackId: input.stackId, error });


### PR DESCRIPTION
Fixes duplicate report emails when Tally and the results page trigger generation for the same intake. Root cause: the Resend idempotency key included the AI report content hash, so two slightly different generations produced two valid sends. The key now uses only the immutable submission ID, providing one-email-per-submission protection within Resend idempotency handling. Adds sanitized generation-source labels for Tally, free results, and premium results, plus structured attempt, completion, and status logs. No report content, PDF, email design, database schema, auth, or billing behavior changed. Validation: npm run typecheck passed, npm run build passed with inert build-time configuration, React caller changes passed review, and git diff --check passed.