### PR TITLE
Make dashboard plan safe and actionable

### DIFF
--- a/app/(app)/dashboard/DashboardClient.tsx
+++ b/app/(app)/dashboard/DashboardClient.tsx
@@ -12,6 +12,7 @@ import WeeklyGoal from "@/components/dashboard/WeeklyGoal";
 import TodaysPlan from "@/components/dashboard/TodaysPlan";
 import ProgressTracker from "@/components/dashboard/ProgressTracker";
 import InsightsFeed from "@/components/dashboard/InsightsFeed";
+import { getFriendlyFirstName } from "@/src/lib/displayName";
 
 export default function DashboardClient() {
   const supabase = createClientComponentClient();
@@ -55,9 +56,7 @@ export default function DashboardClient() {
     return null;
   }
 
-  const username =
-    user.email?.split("@")[0]?.charAt(0).toUpperCase() +
-      user.email?.split("@")[0]?.slice(1) || "Optimizer";
+  const username = getFriendlyFirstName(user);
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB]">

--- a/app/api/fullscript/add/route.ts
+++ b/app/api/fullscript/add/route.ts
@@ -90,8 +90,7 @@ export async function POST(req: Request) {
       source,                        // (leave as-is if your DB has this column)
       sku,                           // (leave as-is if your DB has this column)
       is_custom: source === "custom",
-      // Optional (recommended): make it appear in "Today’s Plan" immediately
-      // is_current: true,
+      is_current: true,
     });
 
     if (itemErr) throw itemErr;

--- a/app/api/stack-items/activate/route.ts
+++ b/app/api/stack-items/activate/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  const body = (await req.json().catch(() => null)) as { item_id?: string } | null;
+  if (!body?.item_id) return NextResponse.json({ ok: false, error: "item_id_required" }, { status: 400 });
+  const { data, error } = await supabase.from("stacks_items").update({ is_current: true })
+    .eq("id", body.item_id).eq("user_id", user.id).select("id").maybeSingle();
+  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+  if (!data) return NextResponse.json({ ok: false, error: "item_not_found" }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/stacks/combined/route.ts
+++ b/app/api/stacks/combined/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
   // 1) Current items explicitly marked as current
   const { data: current, error: currErr } = await supabase
     .from("stacks_items")
-    .select("id, stack_id, user_id, name, brand, dose, timing, timing_bucket, notes, link_amazon, link_fullscript, refill_days_left, last_refilled_at, supplement_id, created_at")
+    .select("id, stack_id, user_id, name, brand, dose, timing, timing_text, timing_bucket, notes, is_current, link_amazon, link_fullscript, refill_days_left, last_refilled_at, supplement_id, created_at")
     .eq("user_id", user.id)
     .eq("is_current", true);
 
@@ -35,7 +35,7 @@ export async function GET() {
   if (latestStack?.id) {
     const { data: bp, error: bpErr } = await supabase
       .from("stacks_items")
-      .select("id, stack_id, user_id, name, brand, dose, timing, timing_bucket, notes, link_amazon, link_fullscript, refill_days_left, last_refilled_at, supplement_id, created_at")
+      .select("id, stack_id, user_id, name, brand, dose, timing, timing_text, timing_bucket, notes, is_current, link_amazon, link_fullscript, refill_days_left, last_refilled_at, supplement_id, created_at")
       .eq("stack_id", latestStack.id);
     if (bpErr) return NextResponse.json({ ok: false, error: bpErr.message }, { status: 400 });
     blueprint = bp ?? [];

--- a/src/components/dashboard/DashboardSnapshot.tsx
+++ b/src/components/dashboard/DashboardSnapshot.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Loader2, Sparkles } from "lucide-react";
 import GoalsTargetsEditor from "./GoalsTargetsEditor";
+import { getFriendlyFirstName } from "@/src/lib/displayName";
 
 /**
  * DashboardSnapshot — Greeting & Daily Snapshot
@@ -52,9 +53,7 @@ export default function DashboardSnapshot() {
 
         // 1) Auth + friendly display name
         const { data: auth } = await supabase.auth.getUser();
-        const email = auth?.user?.email ?? "optimizer@lve360.com";
-        const base = email.split("@")[0];
-        setUsername(base.charAt(0).toUpperCase() + base.slice(1));
+        setUsername(getFriendlyFirstName(auth?.user));
 
         if (!auth?.user?.id) {
           setLoading(false);

--- a/src/components/dashboard/TodaysPlan.tsx
+++ b/src/components/dashboard/TodaysPlan.tsx
@@ -3,7 +3,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { CheckCircle2, Circle, TriangleAlert, PackageOpen, Pill, Search,} from "lucide-react";
-import { bucketsFromRecord } from "@/src/lib/timing"; // <- path to the file you created
+import {
+  cleanDashboardDose,
+  getDashboardItemKind,
+  getDashboardSchedule,
+  isBatchTrackable,
+  isPendingRecommendation,
+} from "@/src/lib/dashboardPlan";
 
 /* =========================
    Types
@@ -18,6 +24,8 @@ type StackItem = {
   timing: "AM" | "PM" | "AM/PM" | (string & {}) | null;
   /** ADD THIS: enables the normalizer to use either field */
   timing_bucket?: string | null;
+  timing_text?: string | null;
+  is_current?: boolean | null;
   notes: string | null;
   link_amazon: string | null;
   link_fullscript: string | null;
@@ -161,7 +169,7 @@ useEffect(() => {
 
   // Mark all in current view (All/AM/PM) as taken (true) or not (false)
   async function markAllInView(taken: boolean) {
-    const scoped = visibleItems.map((i) => i.id);
+    const scoped = visibleItems.filter(isBatchTrackable).map((i) => i.id);
     if (scoped.length === 0) return;
 
     await Promise.allSettled(
@@ -181,6 +189,21 @@ useEffect(() => {
       return next;
     });
     setToast(taken ? "Marked all visible items taken" : "Cleared all visible items");
+  }
+
+  async function activateRecommendation(itemId: string) {
+    const res = await fetch("/api/stack-items/activate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_id: itemId }),
+    });
+    const json = await res.json();
+    if (!res.ok || !json?.ok) {
+      setToast("Unable to add that recommendation");
+      return;
+    }
+    setItems((prev) => prev.map((item) => item.id === itemId ? { ...item, is_current: true } : item));
+    setToast("Added to your active plan");
   }
 
   // Reload items (after adding new in modal)
@@ -208,38 +231,34 @@ useEffect(() => {
   /* -------------------------
      Derived (AM/PM bucketing via normalizer)
   ------------------------- */
+  const pendingItems = useMemo(() => items.filter(isPendingRecommendation), [items]);
+  const activeItems = useMemo(() => items.filter((item) => !isPendingRecommendation(item)), [items]);
   const { itemsAM, itemsPM, itemsOther } = useMemo(() => {
-    const groups: { AM: StackItem[]; PM: StackItem[]; OTHER: StackItem[] } = {
-      AM: [], PM: [], OTHER: []
-    };
-    for (const it of items) {
-      // bucketsFromRecord looks at it.timing_bucket ?? it.timing
-      for (const b of bucketsFromRecord({ timing: it.timing, timing_bucket: it.timing_bucket })) {
-        groups[b].push(it);
-      }
+    const groups: { AM: StackItem[]; PM: StackItem[]; OTHER: StackItem[] } = { AM: [], PM: [], OTHER: [] };
+    for (const it of activeItems) {
+      const schedule = getDashboardSchedule(it);
+      if (schedule === "AM/PM") {
+        groups.AM.push(it);
+        groups.PM.push(it);
+      } else if (schedule === "AM") groups.AM.push(it);
+      else if (schedule === "PM") groups.PM.push(it);
+      else groups.OTHER.push(it);
     }
     return {
       itemsAM: groups.AM,
       itemsPM: groups.PM,
       itemsOther: groups.OTHER,
     };
-  }, [items]);
+  }, [activeItems]);
 
   // Items visible under current tab
   const visibleItems = useMemo<StackItem[]>(() => {
-    if (view === "All") return items;
+    if (view === "All") return activeItems;
     if (view === "AM") return itemsAM;
     return itemsPM;
-  }, [view, items, itemsAM, itemsPM]);
+  }, [view, activeItems, itemsAM, itemsPM]);
 
   // Completion overall + scoped
-  const completionOverall = useMemo(() => {
-    const ids = items.map((i) => i.id);
-    const total = ids.length || 1;
-    const done = ids.reduce((acc, id) => acc + (takenMap[id] ? 1 : 0), 0);
-    return Math.round((done / total) * 100);
-  }, [items, takenMap]);
-
   const completionScoped = useMemo(() => {
     const ids = visibleItems.map((i) => i.id);
     const total = ids.length || 1;
@@ -293,14 +312,16 @@ useEffect(() => {
           <div className="flex items-center gap-2">
             <button
               onClick={() => {
-                const allDone = visibleItems.length > 0 && visibleItems.every((i) => takenMap[i.id]);
+                const batchItems = visibleItems.filter(isBatchTrackable);
+                const allDone = batchItems.length > 0 && batchItems.every((i) => takenMap[i.id]);
                 markAllInView(!allDone);
               }}
               className="text-sm font-semibold text-[#06C1A0] underline underline-offset-2"
               title="Toggle all items in current tab"
               aria-label="Toggle all items in current tab"
             >
-              {visibleItems.length > 0 && visibleItems.every((i) => takenMap[i.id]) ? "Clear all" : "Mark all taken"}
+              {visibleItems.filter(isBatchTrackable).length > 0 &&
+              visibleItems.filter(isBatchTrackable).every((i) => takenMap[i.id]) ? "Clear routine" : "Mark routine taken"}
             </button>
 
             <button
@@ -330,14 +351,18 @@ useEffect(() => {
             <TimingBlock title="AM Routine" items={itemsAM} takenMap={takenMap} onToggle={toggleTaken} />
             <TimingBlock title="PM Routine" items={itemsPM} takenMap={takenMap} onToggle={toggleTaken} />
             {itemsOther.length > 0 && (
-              <TimingBlock title="Other / Unspecified" items={itemsOther} takenMap={takenMap} onToggle={toggleTaken} />
+              <TimingBlock title="Anytime, weekly, or as needed" items={itemsOther} takenMap={takenMap} onToggle={toggleTaken} />
             )}
           </>
         )}
 
+        {pendingItems.length > 0 && (
+          <RecommendationBlock items={pendingItems} onActivate={activateRecommendation} />
+        )}
+
         {/* Manage & Refill row */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <LowStockBanner items={items} />
+          <LowStockBanner items={activeItems} />
           {/* spacer to keep layout balanced; Manage sits in sticky header now */}
           <div className="h-0" />
         </div>
@@ -507,6 +532,32 @@ function LowStockBanner({ items }: { items: StackItem[] }) {
   );
 }
 
+function RecommendationBlock({ items, onActivate }: { items: StackItem[]; onActivate: (id: string) => void }) {
+  return (
+    <section aria-label="Recommendations to consider">
+      <div className="text-xs uppercase tracking-wide text-purple-600 mb-2">Recommendations to consider</div>
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+        <p className="mb-3 text-sm text-amber-900">
+          These Blueprint ideas are not part of your daily checklist until you choose to add them.
+        </p>
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="flex flex-col gap-3 rounded-lg bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="font-semibold text-[#041B2D]">{item.name}</div>
+                <div className="text-sm text-gray-700">{cleanDashboardDose(item.dose) ?? "Starting guidance is in your Blueprint"}</div>
+              </div>
+              <button onClick={() => onActivate(item.id)} className="rounded-lg border border-[#06C1A0] px-3 py-1.5 text-sm font-semibold text-[#047F6D] hover:bg-[#EAFBF8]">
+                Add to my plan
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
 function TimingBlock({
   title,
   items,
@@ -529,7 +580,9 @@ function TimingBlock({
         <ul className="space-y-2">
           {items.map((it) => {
             const taken = !!takenMap[it.id];
-            const link = it.link_fullscript || it.link_amazon || null;
+            const kind = getDashboardItemKind(it.name);
+            const schedule = getDashboardSchedule(it);
+            const link = kind === "supplement" ? it.link_fullscript || it.link_amazon || null : null;
             const low = (it.refill_days_left ?? Infinity) <= 10;
             return (
               <li
@@ -552,8 +605,18 @@ function TimingBlock({
                         {it.brand ? ` — ${it.brand}` : ""}
                       </div>
                       <div className="text-sm text-gray-700">
-                        {(it.dose || "Dose not set").replace(/\*\*/g, "")}
+                        {cleanDashboardDose(it.dose) || "Reported dose not set"}
                         {it.timing && !["AM", "PM", "AM/PM"].includes(it.timing) ? ` • ${it.timing}` : ""}
+                      </div>
+                      <div className="mt-1 flex flex-wrap gap-1.5">
+                        {kind !== "supplement" && (
+                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-700">
+                            {kind === "endocrine_active_supplement" ? "Hormone-active" : "Medication / hormone"}
+                          </span>
+                        )}
+                        {schedule === "WEEKLY" && <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700">Weekly</span>}
+                        {schedule === "AS_NEEDED" && <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700">As needed</span>}
+                        {schedule === "UNSCHEDULED" && <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">Schedule not set</span>}
                       </div>
                       {it.notes && (
                         <div className="text-xs text-gray-600 mt-0.5 line-clamp-2" title={it.notes}>
@@ -580,9 +643,7 @@ function TimingBlock({
                         <PackageOpen className="w-4 h-4 mr-1" />
                         Reorder
                       </a>
-                    ) : (
-                      <span className="text-xs text-gray-500">No link</span>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </li>

--- a/src/components/dashboard/WeeklyGoal.tsx
+++ b/src/components/dashboard/WeeklyGoal.tsx
@@ -1,448 +1,163 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { Loader2, Target, ChevronRight, X } from "lucide-react";
+import { ChevronRight, Loader2, Target } from "lucide-react";
 
-/**
- * WeeklyGoal.tsx — normalized goals, preset-only limit
- * GET  /api/goals?userId=<id>  -> { goals: string[], custom_goal: string|null }
- * POST /api/goals              -> { ok: true, goals: ... }
- */
+type GoalsGetResponse = { goals: string[]; custom_goal: string | null };
 
-type GoalsGetResponse = {
-  goals: string[];
-  custom_goal: string | null;
-};
-
-/* ---------------------------
-   Canonicals / aliases
---------------------------- */
 const PRESETS = [
-  "Sleep quality",
-  "Morning energy",
-  "Body weight",
-  "Stress",
-  "Focus",
-  "Gut comfort",
+  { label: "Sleep quality", focus: "Keep a consistent bedtime and wake time this week" },
+  { label: "Morning energy", focus: "Record morning energy on three days this week" },
+  { label: "Body weight", focus: "Take a 10-minute walk after the largest meal each day" },
+  { label: "Stress", focus: "Practice five minutes of slow breathing each day" },
+  { label: "Focus", focus: "Complete one distraction-free focus block each day" },
+  { label: "Gut comfort", focus: "Track meals and gut comfort on three days this week" },
 ] as const;
-type Canonical = (typeof PRESETS)[number];
 
-const ALIAS_TO_CANONICAL: Record<string, Canonical> = {
-  // Weight
-  "weight loss": "Body weight",
-  "lose weight": "Body weight",
-  "bodyweight": "Body weight",
-  // Sleep
-  "improve sleep": "Sleep quality",
-  "sleep": "Sleep quality",
-  "sleep quality": "Sleep quality",
-  // Energy
-  "increase energy": "Morning energy",
-  "energy": "Morning energy",
-  "morning energy": "Morning energy",
-  // Focus
-  "cognitive performance": "Focus",
-  "focus": "Focus",
-  // Stress
-  "stress management": "Stress",
-  "stress": "Stress",
-  // Gut
-  "gut health": "Gut comfort",
-  "gut comfort": "Gut comfort",
-};
-
-/* ---------------------------
-   Config
---------------------------- */
-const MAX_PRESETS = 3;   // limit only applies to presets
-const MAX_CHARS = 80;
+const MAX_CHARS = 100;
 const AUTOSAVE_MS = 800;
-const CAP_TOTAL_TAGS = 8; // global cap after normalization (presets + others)
 
-/* ---------------------------
-   Component
---------------------------- */
 export default function WeeklyGoal() {
   const supabase = createClientComponentClient();
-
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
-
-  const [focus, setFocus] = useState<string>("");
-  const [initialFocus, setInitialFocus] = useState<string>("");
-
-  // single source of truth for tags (presets + other)
-  const [tags, setTags] = useState<string[]>([]);
-  const [initialTags, setInitialTags] = useState<string[]>([]);
-
+  const [focus, setFocus] = useState("");
+  const [initialFocus, setInitialFocus] = useState("");
+  const [priorities, setPriorities] = useState<string[]>([]);
   const [toast, setToast] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [savedOnce, setSavedOnce] = useState(false);
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const PRESET_SET = useMemo(() => new Set(PRESETS), []);
-
-  // Derived: which saved tags are presets vs others
-  const selectedPresetTags = useMemo(
-    () => tags.filter((t) => PRESET_SET.has(t as Canonical)),
-    [tags, PRESET_SET]
-  );
-  const otherTags = useMemo(
-    () => tags.filter((t) => !PRESET_SET.has(t as Canonical)),
-    [tags, PRESET_SET]
-  );
-
-  /* ---------------------------
-     Toast auto-hide
-  --------------------------- */
-  useEffect(() => {
-    if (!toast) return;
-    const t = setTimeout(() => setToast(null), 2000);
-    return () => clearTimeout(t);
-  }, [toast]);
-
-  /* ---------------------------
-     Load user + goals
-  --------------------------- */
   useEffect(() => {
     (async () => {
       try {
-        setLoading(true);
-        setErrorMsg(null);
-
         const { data } = await supabase.auth.getUser();
         const id = data?.user?.id ?? null;
         setUserId(id);
-
-        if (!id) {
-          setErrorMsg("Not signed in.");
-          setLoading(false);
-          return;
-        }
-
-        const res = await fetch(`/api/goals?userId=${encodeURIComponent(id)}`, {
-          method: "GET",
-          cache: "no-store",
-        });
-        if (!res.ok) {
-          const j = await safeJson(res);
-          setErrorMsg(j?.error || `Goals API error (${res.status})`);
-          setLoading(false);
-          return;
-        }
-
-        const json = (await res.json()) as GoalsGetResponse;
-
-        // Normalize on load so UI starts clean
-        const normalized = normalizeGoals(Array.isArray(json.goals) ? json.goals : [], { capTotal: CAP_TOTAL_TAGS });
-        const f = (json.custom_goal ?? "").slice(0, MAX_CHARS);
-
-        setTags(normalized);
-        setInitialTags(normalized);
-        setFocus(f);
-        setInitialFocus(f);
-      } catch {
-        setErrorMsg("Unable to load weekly goal.");
+        if (!id) throw new Error("Not signed in.");
+        const res = await fetch(`/api/goals?userId=${encodeURIComponent(id)}`, { cache: "no-store" });
+        const json = (await safeJson(res)) as GoalsGetResponse | null;
+        if (!res.ok) throw new Error((json as any)?.error || "Unable to load weekly focus.");
+        const loadedFocus = (json?.custom_goal ?? "").slice(0, MAX_CHARS);
+        setPriorities(normalizePriorities(json?.goals ?? []));
+        setFocus(loadedFocus);
+        setInitialFocus(loadedFocus);
+      } catch (error: any) {
+        setErrorMsg(error?.message ?? "Unable to load weekly focus.");
       } finally {
         setLoading(false);
       }
     })();
   }, [supabase]);
 
-  /* ---------------------------
-     Debounced autosave
-  --------------------------- */
   useEffect(() => {
-    if (loading || !userId) return;
-    const changed = focus !== initialFocus || diff(tags, initialTags).length > 0;
-    if (!changed) return;
-
+    if (loading || !userId || focus === initialFocus) return;
     if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
-    autosaveTimer.current = setTimeout(() => {
-      save(true).catch(() => {});
-    }, AUTOSAVE_MS);
-
-    return () => {
-      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
-    };
+    autosaveTimer.current = setTimeout(() => save(true).catch(() => {}), AUTOSAVE_MS);
+    return () => { if (autosaveTimer.current) clearTimeout(autosaveTimer.current); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focus, tags]);
+  }, [focus, loading, userId]);
 
-  /* ---------------------------
-     Save (normalizes before POST)
-  --------------------------- */
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 2000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
   async function save(isAutosave = false) {
-    if (!userId) {
-      setErrorMsg("Not signed in.");
-      return;
-    }
+    if (!userId) return;
+    setSaving(true);
+    setErrorMsg(null);
     try {
-      setSaving(true);
-      setErrorMsg(null);
-
-      const normalizedForSave = normalizeGoals(tags, { capTotal: CAP_TOTAL_TAGS });
-
+      const normalizedFocus = focus.trim();
       const res = await fetch("/api/goals", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          userId,
-          goals: normalizedForSave,
-          custom_goal: (focus || "").trim() || null,
-        }),
+        body: JSON.stringify({ userId, goals: priorities, custom_goal: normalizedFocus || null }),
       });
-
       const json = await safeJson(res);
-      if (!res.ok || !json?.ok) {
-        throw new Error(json?.error || `Save failed (${res.status})`);
-      }
-
-      // Lock in baselines after save
-      setTags(normalizedForSave);
-      setInitialTags(normalizedForSave);
-      setInitialFocus(focus);
-      setSavedOnce(true);
-      if (!isAutosave) setToast("Weekly goal saved");
-    } catch (e: any) {
-      setErrorMsg(e?.message ?? "Save failed");
+      if (!res.ok || !json?.ok) throw new Error(json?.error || "Save failed");
+      setFocus(normalizedFocus);
+      setInitialFocus(normalizedFocus);
+      if (!isAutosave) setToast(normalizedFocus ? "Weekly focus saved" : "Weekly focus cleared");
+    } catch (error: any) {
+      setErrorMsg(error?.message ?? "Save failed");
     } finally {
       setSaving(false);
     }
   }
 
-  /* ---------------------------
-     UI actions
-  --------------------------- */
-  // Toggle within the PRESET subset (respect max)
-  function togglePreset(p: Canonical) {
-    const current = new Set(selectedPresetTags);
-    if (current.has(p)) {
-      current.delete(p);
-    } else {
-      if (selectedPresetTags.length >= MAX_PRESETS) {
-        setToast(`You can choose up to ${MAX_PRESETS}`);
-        return;
-      }
-      current.add(p);
-    }
-    // Recombine with other tags (unchanged)
-    setTags([...otherTags, ...Array.from(current)]);
-  }
+  if (loading) return <Card><Loader2 className="mr-2 h-5 w-5 animate-spin text-purple-600" /> Loading weekly focus…</Card>;
+  if (errorMsg) return <Card>{errorMsg}</Card>;
 
-  // Remove an "other" tag chip
-  function removeOther(tag: string) {
-    setTags((prev) => prev.filter((t) => t.toLowerCase() !== tag.toLowerCase()));
-  }
-
-  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      save(false);
-    } else if (e.key === "Escape") {
-      setFocus(initialFocus);
-    }
-  }
-
-  const focusCount = focus.length;
-  const changed = focus !== initialFocus || diff(tags, initialTags).length > 0;
-
-  /* ---------------------------
-     Render
-  --------------------------- */
-  if (loading) {
-    return (
-      <div className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm">
-        <div className="flex items-center text-gray-600">
-          <Loader2 className="w-5 h-5 animate-spin text-purple-600 mr-2" />
-          Loading weekly goal…
-        </div>
-      </div>
-    );
-  }
-
-  if (errorMsg) {
-    return (
-      <div className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm">
-        <div className="text-gray-700">{errorMsg}</div>
-      </div>
-    );
-  }
-
+  const changed = focus !== initialFocus;
   return (
-    <div className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm" aria-label="Weekly goal">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-[#041B2D] flex items-center gap-2">
-          <Target className="w-5 h-5 text-[#7C3AED]" />
-          Weekly Goal
-        </h2>
-      </div>
+    <div className="rounded-2xl bg-white/70 p-6 shadow-sm" aria-label="Weekly focus">
+      <h2 className="flex items-center gap-2 text-2xl font-bold text-[#041B2D]">
+        <Target className="h-5 w-5 text-[#7C3AED]" /> Weekly Focus
+      </h2>
+      <p className="mt-1 text-gray-600">Choose one practical experiment for this week.</p>
 
-      <p className="text-gray-600 mt-1">
-        Pick one focus for this week. Your plan and insights will adapt.
-      </p>
-
-      {/* Focus input */}
       <div className="mt-4">
-        <label className="text-xs uppercase tracking-wide text-purple-600">Weekly focus</label>
+        <label className="text-xs uppercase tracking-wide text-purple-600" htmlFor="weekly-focus">This week I will</label>
         <div className="relative">
-          <input
-            value={focus}
-            onChange={(e) => setFocus(e.target.value.slice(0, MAX_CHARS))}
-            onKeyDown={onKeyDown}
-            placeholder="e.g., In bed by 10:30pm"
-            className="mt-1 w-full rounded-lg border px-3 py-2 pr-14"
-            aria-describedby="focus-limit"
-          />
-          <div
-            id="focus-limit"
-            className={`absolute right-2 top-1/2 -translate-y-1/2 text-xs ${
-              focusCount > MAX_CHARS - 10 ? "text-gray-700" : "text-gray-400"
-            }`}
-            aria-live="polite"
-          >
-            {focusCount}/{MAX_CHARS}
-          </div>
+          <input id="weekly-focus" value={focus} onChange={(event) => setFocus(event.target.value.slice(0, MAX_CHARS))}
+            placeholder="e.g., Keep caffeine before noon" className="mt-1 w-full rounded-lg border px-3 py-2 pr-16" />
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">{focus.length}/{MAX_CHARS}</span>
         </div>
       </div>
 
-      {/* Preset chips */}
       <div className="mt-3">
-        <div className="text-xs uppercase tracking-wide text-purple-600">Quick presets</div>
+        <div className="text-xs uppercase tracking-wide text-purple-600">Choose one starter focus</div>
         <div className="mt-1 flex flex-wrap gap-2">
-          {PRESETS.map((p) => {
-            const active = selectedPresetTags.includes(p);
-            return (
-              <button
-                key={p}
-                onClick={() => togglePreset(p)}
-                className={`rounded-full border px-3 py-1 text-sm ${
-                  active ? "bg-purple-600 text-white border-purple-600" : "hover:bg-white"
-                }`}
-                aria-pressed={active}
-                aria-label={`Toggle preset ${p}`}
-              >
-                {p}
-              </button>
-            );
-          })}
-        </div>
-        <div className="mt-1 text-xs text-gray-500">
-          Choose up to {MAX_PRESETS}. {selectedPresetTags.length}/{MAX_PRESETS} selected.
+          {PRESETS.map((preset) => (
+            <button key={preset.label} onClick={() => setFocus(preset.focus)} aria-pressed={focus === preset.focus}
+              className={`rounded-full border px-3 py-1 text-sm ${focus === preset.focus ? "border-purple-600 bg-purple-600 text-white" : "hover:bg-white"}`}>
+              {preset.label}
+            </button>
+          ))}
         </div>
       </div>
 
-      {/* Other tags (non-preset) */}
-      {otherTags.length > 0 && (
-        <div className="mt-3">
-          <div className="text-xs uppercase tracking-wide text-purple-600">Other tags</div>
+      {priorities.length > 0 && (
+        <div className="mt-4">
+          <div className="text-xs uppercase tracking-wide text-gray-500">Your long-term priorities</div>
           <div className="mt-1 flex flex-wrap gap-2">
-            {otherTags.map((t) => (
-              <span
-                key={t}
-                className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-sm text-gray-700"
-                title={t}
-              >
-                {t}
-                <button
-                  onClick={() => removeOther(t)}
-                  className="ml-1 text-gray-500 hover:text-gray-700"
-                  aria-label={`Remove ${t}`}
-                  title="Remove"
-                >
-                  <X className="w-3.5 h-3.5" />
-                </button>
-              </span>
-            ))}
+            {priorities.map((priority) => <span key={priority} className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700">{priority}</span>)}
           </div>
         </div>
       )}
 
-      {/* Footer actions */}
-      <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-        <div className="text-xs text-gray-500">
-          {focus ? `Current: “${focus}”` : "No goal set yet"}
-          {savedOnce && (
-            <>
-              {" "}|{" "}
-              <a href="#todays-plan" className="underline underline-offset-2 hover:text-[#041B2D]">
-                Today’s Plan
-              </a>{" "}
-              •{" "}
-              <a href="#progress" className="underline underline-offset-2 hover:text-[#041B2D]">
-                Progress
-              </a>
-            </>
-          )}
-        </div>
-
-        <button
-          onClick={() => save(false)}
-          disabled={saving || !changed}
-          className="inline-flex items-center rounded-xl bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] px-4 py-2 text-white font-semibold shadow-md disabled:opacity-60"
-          aria-disabled={saving || !changed}
-        >
-          {saving && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
-          {changed ? "Save goal" : "Saved"}
-          <ChevronRight className="w-4 h-4 ml-1" />
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-xs text-gray-500">{initialFocus ? `Current focus: “${initialFocus}”` : "Choose a focus to begin."}</div>
+        <button onClick={() => save(false)} disabled={saving || !changed}
+          className="inline-flex items-center rounded-xl bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] px-4 py-2 font-semibold text-white shadow-md disabled:opacity-60">
+          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {changed ? (focus.trim() ? "Save focus" : "Clear focus") : (focus ? "Saved" : "Choose a focus")}
+          <ChevronRight className="ml-1 h-4 w-4" />
         </button>
       </div>
-
-      {/* Toast */}
-      {toast && (
-        <div className="fixed inset-x-0 bottom-6 z-[60] flex justify-center px-4" aria-live="polite">
-          <div className="rounded-xl border border-purple-200 bg-white/90 backdrop-blur-md shadow-lg px-4 py-2 text-sm text-[#041B2D]">
-            {toast}
-          </div>
-        </div>
-      )}
+      {toast && <div className="fixed inset-x-0 bottom-6 z-[60] flex justify-center px-4" aria-live="polite"><div className="rounded-xl border border-purple-200 bg-white/90 px-4 py-2 text-sm shadow-lg">{toast}</div></div>}
     </div>
   );
 }
 
-/* ---------------------------
-   Helpers
---------------------------- */
-async function safeJson(res: Response) {
-  try {
-    return await res.json();
-  } catch {
-    return null;
-  }
-}
-function diff(a: string[], b: string[]) {
-  const A = new Set(a.map((s) => s.toLowerCase()));
-  const B = new Set(b.map((s) => s.toLowerCase()));
-  const add = a.filter((x) => !B.has(x.toLowerCase()));
-  const rem = b.filter((x) => !A.has(x.toLowerCase()));
-  return [...add, ...rem];
+function Card({ children }: { children: React.ReactNode }) {
+  return <div className="flex items-center rounded-2xl bg-white/70 p-6 text-gray-700 shadow-sm">{children}</div>;
 }
 
-function toTitle(s: string) {
-  return s.replace(/\w\S*/g, (w) => w[0].toUpperCase() + w.slice(1).toLowerCase());
-}
-
-/** Normalize: trim, alias→canonical, dedupe (case-insensitive), title-case others, cap total. */
-function normalizeGoals(incoming: string[], opts?: { capTotal?: number }): string[] {
-  const capTotal = opts?.capTotal ?? 8;
-  const cleaned = (incoming || [])
-    .map((s) => (s ?? "").toString().trim().replace(/\s+/g, " "))
-    .filter(Boolean);
-
-  const mapped = cleaned.map((s) => {
-    const key = s.toLowerCase();
-    return (ALIAS_TO_CANONICAL as any)[key] ?? toTitle(s);
-  });
-
+function normalizePriorities(values: string[]) {
   const seen = new Set<string>();
-  const out: string[] = [];
-  for (const g of mapped) {
-    const k = g.toLowerCase();
-    if (!seen.has(k)) {
-      seen.add(k);
-      out.push(g);
-    }
-  }
-  return out.slice(0, capTotal);
+  return values.map((value) => String(value).trim().replace(/\s+/g, " ")).filter((value) => {
+    const key = value.toLowerCase();
+    if (!value || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, 8);
+}
+
+async function safeJson(res: Response) {
+  try { return await res.json(); } catch { return null; }
 }

--- a/src/lib/dashboardPlan.ts
+++ b/src/lib/dashboardPlan.ts
@@ -1,0 +1,52 @@
+import { isEndocrineActiveSupplementName, isMedicationOrHormoneName } from "@/src/lib/supplementEligibility";
+
+export type DashboardPlanInput = {
+  name?: string | null;
+  dose?: string | null;
+  timing?: string | null;
+  timing_text?: string | null;
+  timing_bucket?: string | null;
+  notes?: string | null;
+  is_current?: boolean | null;
+};
+
+export function getDashboardItemKind(name?: string | null) {
+  if (isEndocrineActiveSupplementName(name)) return "endocrine_active_supplement" as const;
+  if (isMedicationOrHormoneName(name)) return "medication_or_hormone" as const;
+  return "supplement" as const;
+}
+
+export function isPendingRecommendation(item: DashboardPlanInput): boolean {
+  if (item.is_current === true) return false;
+  if (/Blueprint status:\s*(?:New\s*[-–—]\s*consider|Clinician review)/i.test(item.notes ?? "")) return true;
+  return item.is_current === false;
+}
+
+export function getDashboardSchedule(item: DashboardPlanInput) {
+  const signal = [item.timing_bucket, item.timing, item.timing_text, item.dose, item.notes]
+    .filter(Boolean).join(" ").toLowerCase();
+  if (/\b(as needed|prn)\b/.test(signal)) return "AS_NEEDED" as const;
+  if (/\b(weekly|once a week|1x\s*(?:a|per)?\s*week)\b/.test(signal)) return "WEEKLY" as const;
+  const am = /\b(am|morning|breakfast)\b/.test(signal);
+  const pm = /\b(pm|evening|night|bedtime)\b/.test(signal);
+  if ((am && pm) || /\b(am\/pm|twice|bid|split)\b/.test(signal)) return "AM/PM" as const;
+  if (am) return "AM" as const;
+  if (pm) return "PM" as const;
+  if (/\b(daily|anytime|with (?:a )?(?:meal|food))\b/.test(signal)) return "ANYTIME" as const;
+  return "UNSCHEDULED" as const;
+}
+
+export function isBatchTrackable(item: DashboardPlanInput): boolean {
+  const schedule = getDashboardSchedule(item);
+  return !isPendingRecommendation(item) && getDashboardItemKind(item.name) === "supplement" &&
+    !["WEEKLY", "AS_NEEDED", "UNSCHEDULED"].includes(schedule);
+}
+
+export function cleanDashboardDose(value?: string | null): string | null {
+  if (!value) return null;
+  const cleaned = value.replace(/\*\*/g, "").replace(/^\s*[:;–—-]+\s*/, "")
+    .replace(/\bevidence\s*:\s*informed\b/gi, "evidence-informed")
+    .replace(/\blabel\s*:\s*directed\b/gi, "label-directed")
+    .replace(/(\d)\s*:\s*(\d)/g, "$1–$2").replace(/\s+/g, " ").trim();
+  return cleaned || null;
+}

--- a/src/lib/displayName.ts
+++ b/src/lib/displayName.ts
@@ -1,0 +1,19 @@
+type AuthUserLike = {
+  email?: string | null;
+  user_metadata?: Record<string, unknown> | null;
+};
+
+export function getFriendlyFirstName(user?: AuthUserLike | null): string {
+  const metadata = user?.user_metadata ?? {};
+  const candidates = [metadata.given_name, metadata.full_name, metadata.name];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) return titleCase(candidate.trim().split(/\s+/)[0]);
+  }
+  const localPart = (user?.email ?? "").split("@")[0].replace(/[._-]+/g, " ").trim();
+  const first = localPart.split(/\s+/)[0]?.replace(/\d+$/, "") || "Optimizer";
+  return titleCase(first);
+}
+
+function titleCase(value: string) {
+  return value ? value.charAt(0).toUpperCase() + value.slice(1).toLowerCase() : "Optimizer";
+}

--- a/src/lib/parseMarkdownToItems.ts
+++ b/src/lib/parseMarkdownToItems.ts
@@ -194,12 +194,13 @@ export function parseMarkdownToItems(md: string): ParsedItem[] {
       if (!/^\s*[-*]\s+/.test(raw)) continue;
 
       const line = raw.replace(/^\s*[-*]\s*/, "");
-      // Split only on the FIRST ":" or "—"
-      const parts = line.split(/[:—-]/);
-      if (!parts || parts.length < 2) continue;
+      // Split only on a deliberate item delimiter. Plain hyphens inside
+      // "evidence-informed", "label-directed", or "3-5 g" are content.
+      const split = line.match(/^(.+?)(?:\s+[—–-]\s+|:\s+)(.+)$/);
+      if (!split) continue;
 
-      const nameRaw = parts.shift()!.trim();
-      const remainder = parts.join(":").trim();
+      const nameRaw = split[1].trim();
+      const remainder = split[2].trim();
 
       const cleaned = cleanName(nameRaw);
       if (!cleaned || SEE_DN.test(cleaned)) continue;


### PR DESCRIPTION
## Purpose
Fix dashboard data integrity and daily-plan safety before visual redesign.

## Changes
- Separates pending Blueprint recommendations from the active daily checklist.
- Adds an authenticated Add to my plan action.
- Excludes medications, hormones, weekly, PRN, unscheduled, and pending items from bulk completion.
- Preserves timing text/current status in the combined stack response and adds schedule badges.
- Removes medication/hormone commerce links from the plan.
- Fixes hyphen-to-colon dose corruption and sanitizes legacy display values.
- Replaces contradictory weekly-goal selection with one actionable weekly focus while preserving long-term priorities.
- Uses auth metadata for a friendlier first-name greeting.

## Verified
- npm run typecheck
- npm run build with inert placeholder configuration
- git diff --check

## Not verified
- Live Supabase activation/RLS behavior
- Production dashboard with a real mixed medication/supplement stack

## Manual QA
1. Confirm New - consider items appear only under Recommendations to consider.
2. Add one recommendation and confirm it moves into the active plan.
3. Confirm Mark routine taken excludes prescriptions, hormones, weekly, PRN, pending, and unscheduled items.
4. Confirm Zepbound/Lunesta show Weekly/As needed labels.
5. Confirm dose text keeps evidence-informed, label-directed, and 3-5 formatting.
6. Confirm one weekly focus saves without changing long-term priorities.
7. Confirm medication/hormone rows have no shop link.

## Risk / rollback
No schema changes. Revert commit 2813aba to roll back.