### PR TITLE
Polish dashboard hierarchy and empty states

### DIFF
--- a/app/(app)/dashboard/DashboardClient.tsx
+++ b/app/(app)/dashboard/DashboardClient.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { Loader2 } from "lucide-react";
+import { FileText, History, Loader2 } from "lucide-react";
 
 import DashboardSnapshot from "@/components/dashboard/DashboardSnapshot";
 import NextSteps from "@/components/dashboard/NextSteps";
@@ -18,7 +17,6 @@ export default function DashboardClient() {
   const supabase = createClientComponentClient();
   const [user, setUser] = useState<any>(null);
   const [loading, setLoading] = useState(true);
-  const [showGreeting, setShowGreeting] = useState(true);
 
   // Get authed user
   useEffect(() => {
@@ -29,12 +27,6 @@ export default function DashboardClient() {
       setLoading(false);
     })();
   }, [supabase]);
-
-  // Soft fade greeting
-  useEffect(() => {
-    const timer = setTimeout(() => setShowGreeting(false), 1600);
-    return () => clearTimeout(timer);
-  }, []);
 
   // Ensure user exists in public.users
   useEffect(() => {
@@ -60,26 +52,22 @@ export default function DashboardClient() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB]">
-      <div className="max-w-6xl mx-auto p-6 space-y-6">
-        {/* Greeting splash */}
-        <AnimatePresence>
-          {showGreeting && (
-            <motion.h1
-              key="greeting"
-              initial={{ opacity: 0, y: -6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -6 }}
-              transition={{ duration: 0.5, ease: "easeOut" }}
-              className="text-4xl font-extrabold text-center mb-2"
-            >
-              Welcome back,{" "}
-              <span className="bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] bg-clip-text text-transparent">
-                {username}
-              </span>{" "}
-              👋
-            </motion.h1>
-          )}
-        </AnimatePresence>
+      <div className="max-w-6xl mx-auto p-4 sm:p-6 space-y-5">
+        <header className="flex flex-col gap-4 rounded-2xl bg-[#041B2D] p-5 text-white shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[#8DE5D5]">LVE360 Agent Dashboard</div>
+            <h1 className="mt-1 text-3xl font-bold">Welcome back, {username}</h1>
+            <p className="mt-1 text-sm text-white/75">Your plan, progress, and next best action in one place.</p>
+          </div>
+          <nav className="flex flex-wrap gap-2" aria-label="Report actions">
+            <a href="/results" className="inline-flex items-center rounded-lg bg-white px-3 py-2 text-sm font-semibold text-[#041B2D] hover:bg-[#EAFBF8]">
+              <FileText className="mr-2 h-4 w-4" /> View Blueprint
+            </a>
+            <a href="/dashboard/my-quiz" className="inline-flex items-center rounded-lg border border-white/30 px-3 py-2 text-sm font-semibold text-white hover:bg-white/10">
+              <History className="mr-2 h-4 w-4" /> Reports & PDF
+            </a>
+          </nav>
+        </header>
 
         {/* 1) Greeting & Snapshot */}
         <section aria-label="Snapshot and quick deltas">
@@ -91,19 +79,19 @@ export default function DashboardClient() {
           <NextSteps />
         </section>
 
-        {/* 3) Daily Check-in */}
-        <section id="daily-log" aria-label="Daily check-in">
-          <DailyLog />
-        </section>
-
-        {/* 4) Weekly Goal */}
+        {/* 3) Weekly focus */}
         <section id="weekly-goal" aria-label="Weekly goal">
           <WeeklyGoal />
         </section>
 
-        {/* 5) Today’s Plan (AM/PM checklist + manager) */}
+        {/* 4) Today’s Plan */}
         <section id="todays-plan" aria-label="Today’s plan">
           <TodaysPlan />
+        </section>
+
+        {/* 5) Daily Check-in */}
+        <section id="daily-log" aria-label="Daily check-in">
+          <DailyLog />
         </section>
 
         {/* 6) Progress Tracker (mini charts) */}

--- a/src/components/dashboard/DailyLog.tsx
+++ b/src/components/dashboard/DailyLog.tsx
@@ -36,6 +36,8 @@ export default function DailyLog() {
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
   const [prefilled, setPrefilled] = useState(false);
+  const [hasSleepValue, setHasSleepValue] = useState(false);
+  const [hasEnergyValue, setHasEnergyValue] = useState(false);
 
   const userIdRef = useRef<string | null>(null);
   const loadedRef = useRef(false);
@@ -68,12 +70,12 @@ export default function DailyLog() {
 
       if (!error && data) {
         const row = data as TodayRow;
-        if (row.sleep != null) setSleep(clamp(row.sleep, 1, 5));
-        if (row.energy != null) setEnergy(clamp(row.energy, 1, 10));
+        if (row.sleep != null) { setSleep(clamp(row.sleep, 1, 5)); setHasSleepValue(true); }
+        if (row.energy != null) { setEnergy(clamp(row.energy, 1, 10)); setHasEnergyValue(true); }
         if (row.weight != null) setWeight(String(row.weight));
         if (row.notes != null) setNotes(row.notes);
         setPrefilled(true);
-        lastSavedHash.current = hashState(row.sleep ?? 3, row.energy ?? 5, row.weight ?? null, row.notes ?? "");
+        lastSavedHash.current = hashState(row.sleep ?? null, row.energy ?? null, row.weight ?? null, row.notes ?? "");
       } else {
         // initialize baseline hash from defaults
         lastSavedHash.current = hashState(3, 5, null, "");
@@ -89,10 +91,8 @@ export default function DailyLog() {
 
     // Build current hash (notes excluded from autosave hash)
     const numericWeight = weight.trim() === "" ? null : Number(weight);
-    const hashed = hashState(sleep, energy, Number.isFinite(numericWeight) ? numericWeight : null, notes);
-
     // If only notes changed, do not autosave (manual Save handles notes)
-    const hashWithoutNotes = hashState(sleep, energy, Number.isFinite(numericWeight) ? numericWeight : null);
+    const hashWithoutNotes = hashState(hasSleepValue ? sleep : null, hasEnergyValue ? energy : null, Number.isFinite(numericWeight) ? numericWeight : null);
 
     const lastWithoutNotes = lastSavedHash.current.split("|NOTES:")[0];
     if (hashWithoutNotes === lastWithoutNotes) return;
@@ -106,12 +106,14 @@ export default function DailyLog() {
       if (saveTimer.current) clearTimeout(saveTimer.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sleep, energy, weight]);
+  }, [sleep, energy, weight, hasSleepValue, hasEnergyValue]);
 
   function onSleepChange(v: number) {
+    setHasSleepValue(true);
     setSleep(clamp(v, 1, 5));
   }
   function onEnergyChange(v: number) {
+    setHasEnergyValue(true);
     setEnergy(clamp(v, 1, 10));
   }
 
@@ -130,11 +132,9 @@ export default function DailyLog() {
       if (!isAutosave) setMsg(null);
 
       const w = weight.trim() === "" ? null : Number(weight);
-      const body: Record<string, any> = {
-        sleep,
-        energy,
-        notes: (notes || "").trim() || null,
-      };
+      const body: Record<string, any> = { notes: (notes || "").trim() || null };
+      if (hasSleepValue) body.sleep = sleep;
+      if (hasEnergyValue) body.energy = energy;
       if (w != null && Number.isFinite(w)) body.weight = w;
 
       const res = await fetch("/api/logs", {
@@ -146,7 +146,7 @@ export default function DailyLog() {
       if (!res.ok || !json?.ok) throw new Error(json?.error || "save_failed");
 
       // Update last saved signature
-      lastSavedHash.current = hashState(sleep, energy, w, notes);
+      lastSavedHash.current = hashState(hasSleepValue ? sleep : null, hasEnergyValue ? energy : null, w, notes);
 
       if (!isAutosave) setMsg({ kind: "ok", text: prefilled ? "Updated ✓" : "Saved ✓" });
       setPrefilled(true);
@@ -165,18 +165,18 @@ export default function DailyLog() {
   }
 
   return (
-    <div id="daily-log" className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm">
+    <div id="daily-log" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="flex items-end justify-between mb-1">
-        <h2 className="text-2xl font-bold text-[#041B2D]">📝 Daily Log</h2>
+        <h2 className="text-2xl font-bold text-[#041B2D]">Daily Check-in</h2>
         {prefilled && <span className="text-xs text-gray-600">Today’s values loaded</span>}
       </div>
-      <p className="text-gray-600 mb-4">Two sliders, an optional weight, and a quick note. 20 seconds, tops.</p>
+      <p className="text-gray-600 mb-4">A quick check-in keeps your trends and coaching grounded in how you actually feel.</p>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Sleep (1–5) */}
-        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4">
-          <div className="text-xs uppercase tracking-wide text-purple-600">Sleep quality</div>
-          <div className="text-xl font-bold text-[#041B2D] mt-1">{sleep} / 5</div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <div className="text-xs uppercase tracking-wide text-[#047F6D]">Sleep quality</div>
+          <div className="text-xl font-bold text-[#041B2D] mt-1">{hasSleepValue ? `${sleep} / 5` : "Not logged yet"}</div>
           <input
             type="range"
             min={1}
@@ -190,9 +190,9 @@ export default function DailyLog() {
         </div>
 
         {/* Energy (1–10) */}
-        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4">
-          <div className="text-xs uppercase tracking-wide text-purple-600">Energy</div>
-          <div className="text-xl font-bold text-[#041B2D] mt-1">{energy} / 10</div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <div className="text-xs uppercase tracking-wide text-[#047F6D]">Energy</div>
+          <div className="text-xl font-bold text-[#041B2D] mt-1">{hasEnergyValue ? `${energy} / 10` : "Not logged yet"}</div>
           <input
             type="range"
             min={1}
@@ -206,8 +206,8 @@ export default function DailyLog() {
         </div>
 
         {/* Weight (optional) */}
-        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4">
-          <div className="text-xs uppercase tracking-wide text-purple-600">Weight (optional)</div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <div className="text-xs uppercase tracking-wide text-[#047F6D]">Weight (optional)</div>
           <input
             inputMode="decimal"
             value={weight}
@@ -237,7 +237,7 @@ export default function DailyLog() {
         <button
           onClick={() => submit(false)}
           disabled={saving}
-          className="inline-flex items-center rounded-xl bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] px-4 py-2 text-white font-semibold shadow-md disabled:opacity-60"
+          className="inline-flex items-center rounded-xl bg-[#047F6D] px-4 py-2 text-white font-semibold shadow-md hover:bg-[#036957] disabled:opacity-60"
           aria-disabled={saving}
         >
           {saving && <Loader2 className="w-4 h-4 animate-spin mr-2" />} Save today’s log

--- a/src/components/dashboard/DashboardSnapshot.tsx
+++ b/src/components/dashboard/DashboardSnapshot.tsx
@@ -235,7 +235,7 @@ export default function DashboardSnapshot() {
   const hasAnyData = logs.length > 0 || goals != null || adherence7 != null;
 
   return (
-    <div className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm">
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       {/* Greeting + chips + quick actions */}
       <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-3">
         <div>
@@ -274,23 +274,6 @@ export default function DashboardSnapshot() {
               Adherence (7d): <strong className="text-[#7C3AED]">{adherence7}%</strong>
             </span>
           )}
-          {/* Quick actions */}
-          <a
-            href="#daily-log"
-            className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white"
-            aria-label="Log today"
-            title="Log today"
-          >
-            Log today
-          </a>
-          <a
-            href="#todays-plan"
-            className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white"
-            aria-label="Open Today’s Plan"
-            title="Open Today’s Plan"
-          >
-            Today’s plan
-          </a>
           {/* Edit targets toggle */}
           <button
             onClick={() => setShowTargets(true)}
@@ -305,10 +288,10 @@ export default function DashboardSnapshot() {
 
       {/* Coaching blurb from latest AI summary */}
       {latestAi?.summary && (
-        <div className="mb-4 text-[15px] text-[#041B2D] bg-gradient-to-br from-purple-50 to-yellow-50 border border-purple-100 rounded-xl p-3 flex items-start gap-2">
-          <Sparkles className="w-4 h-4 mt-0.5 text-[#7C3AED]" />
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-teal-200 bg-[#EAFBF8] p-3 text-[15px] text-[#041B2D]">
+          <Sparkles className="w-4 h-4 mt-0.5 text-[#047F6D]" />
           <div>
-            <div className="text-xs uppercase tracking-wide text-purple-600">
+            <div className="text-xs uppercase tracking-wide text-[#047F6D]">
               Coaching tip · {new Date(latestAi.created_at).toLocaleDateString()}
             </div>
             <div className="mt-0.5">{latestAi.summary}</div>
@@ -318,7 +301,7 @@ export default function DashboardSnapshot() {
 
       {/* Main conditional: empty state vs KPI grid */}
       {!hasAnyData ? (
-        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4 text-gray-700">
+        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-gray-700">
           No data yet — log your first day and set goals to see your snapshot come alive.
         </div>
       ) : (
@@ -452,8 +435,8 @@ function MetricCard({
   hint?: string;
 }) {
   return (
-    <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4 shadow-sm">
-      <div className="text-xs uppercase tracking-wide text-purple-600">{title}</div>
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div className="text-xs uppercase tracking-wide text-[#047F6D]">{title}</div>
       <div className="text-xl font-bold text-[#041B2D] mt-1">{primary}</div>
       <div className="text-sm text-gray-600 mt-0.5">{delta}</div>
       {hint && <div className="text-xs text-gray-500 mt-1">{hint}</div>}

--- a/src/components/dashboard/InsightsFeed.tsx
+++ b/src/components/dashboard/InsightsFeed.tsx
@@ -8,7 +8,7 @@ import { Loader2, Sparkles, RefreshCw } from "lucide-react";
  * InsightsFeed.tsx
  * - Shows latest AI insights (ai_summaries)
  * - POST /api/ai-insights → regenerate then refetch
- * - Adds per-card actions (UI-only): Apply tweak, Add reminder
+ * - Expands/collapses longer coaching summaries
  */
 
 type InsightRow = {
@@ -27,9 +27,6 @@ export default function InsightsFeed() {
   // UI niceties
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [toast, setToast] = useState<string | null>(null);
-  const [reminderFor, setReminderFor] = useState<InsightRow | null>(null);
-  const [remindTime, setRemindTime] = useState<string>("22:00"); // default 10:00pm
-  const [applyFor, setApplyFor] = useState<InsightRow | null>(null);
 
   useEffect(() => {
     if (!toast) return;
@@ -99,11 +96,11 @@ export default function InsightsFeed() {
   }, [insights, expanded]);
 
   return (
-    <div id="insights" className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm" aria-label="AI insights">
+    <div id="insights" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" aria-label="AI insights">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-2xl font-bold text-[#041B2D] flex items-center gap-2">
-          <Sparkles className="w-5 h-5 text-[#7C3AED]" />
-          AI Insights
+          <Sparkles className="w-5 h-5 text-[#047F6D]" />
+          Coaching Insights
         </h2>
         <button
           onClick={regenerate}
@@ -128,7 +125,7 @@ export default function InsightsFeed() {
       ) : error ? (
         <div className="text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3">{error}</div>
       ) : formatted.length === 0 ? (
-        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4 text-gray-700">
+        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-gray-700">
           No insights yet. Log your day or click{" "}
           <button onClick={regenerate} disabled={busy} className="underline underline-offset-2">
             Generate now
@@ -140,9 +137,9 @@ export default function InsightsFeed() {
           {formatted.map((it) => (
             <li
               key={it.id}
-              className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4"
+              className="rounded-xl border border-slate-200 bg-slate-50 p-4"
             >
-              <div className="text-xs uppercase tracking-wide text-purple-600 mb-1">
+              <div className="text-xs uppercase tracking-wide text-[#047F6D] mb-1">
                 {new Date(it.created_at).toLocaleString()}
               </div>
 
@@ -161,89 +158,9 @@ export default function InsightsFeed() {
                 )}
               </div>
 
-              {/* Action row */}
-              <div className="mt-3 flex flex-wrap gap-2">
-                <button
-                  onClick={() => setApplyFor(it)}
-                  className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white"
-                  aria-label="Apply this tweak"
-                  title="Apply this tweak"
-                >
-                  Apply tweak
-                </button>
-                <button
-                  onClick={() => {
-                    setReminderFor(it);
-                    setRemindTime("22:00");
-                  }}
-                  className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white"
-                  aria-label="Add a reminder related to this insight"
-                  title="Add reminder"
-                >
-                  Add reminder
-                </button>
-              </div>
             </li>
           ))}
         </ul>
-      )}
-
-      {/* Apply Tweak Modal (UI only, placeholder for future rules endpoint) */}
-      {applyFor && (
-        <Modal onClose={() => setApplyFor(null)} title="Apply this tweak">
-          <p className="text-sm text-gray-700">
-            We’ll remember this tweak and use it to personalize your suggestions. (This is a visual
-            confirmation for now.)
-          </p>
-          <div className="mt-4 flex justify-end gap-2">
-            <button onClick={() => setApplyFor(null)} className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white">
-              Cancel
-            </button>
-            <button
-              onClick={() => {
-                setApplyFor(null);
-                setToast("Tweak applied");
-              }}
-              className="rounded-lg bg-[#7C3AED] text-white px-3 py-1.5 text-sm"
-            >
-              Confirm
-            </button>
-          </div>
-        </Modal>
-      )}
-
-      {/* Reminder Modal (UI only, placeholder for reminders table/automation) */}
-      {reminderFor && (
-        <Modal onClose={() => setReminderFor(null)} title="Add reminder">
-          <div className="space-y-3">
-            <p className="text-sm text-gray-700">
-              Pick a daily time to nudge you about this insight. (UI-only for now.)
-            </p>
-            <div>
-              <label className="text-xs uppercase tracking-wide text-purple-600">Time</label>
-              <input
-                type="time"
-                value={remindTime}
-                onChange={(e) => setRemindTime(e.target.value)}
-                className="mt-1 rounded-lg border px-3 py-2"
-              />
-            </div>
-          </div>
-          <div className="mt-4 flex justify-end gap-2">
-            <button onClick={() => setReminderFor(null)} className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white">
-              Cancel
-            </button>
-            <button
-              onClick={() => {
-                setReminderFor(null);
-                setToast("Reminder added");
-              }}
-              className="rounded-lg bg-[#06C1A0] text-white px-3 py-1.5 text-sm"
-            >
-              Save
-            </button>
-          </div>
-        </Modal>
       )}
 
       {/* Toast */}
@@ -254,31 +171,6 @@ export default function InsightsFeed() {
           </div>
         </div>
       )}
-    </div>
-  );
-}
-
-/* ---------- Small modal ---------- */
-function Modal({
-  title,
-  children,
-  onClose,
-}: {
-  title: string;
-  children: React.ReactNode;
-  onClose: () => void;
-}) {
-  return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-[#041B2D]">{title}</h3>
-          <button onClick={onClose} className="text-gray-500 hover:text-gray-700" aria-label="Close">
-            ✕
-          </button>
-        </div>
-        <div className="mt-3">{children}</div>
-      </div>
     </div>
   );
 }

--- a/src/components/dashboard/NextSteps.tsx
+++ b/src/components/dashboard/NextSteps.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import {
-  Rocket, Target, CalendarPlus, Repeat, PackageOpen, Sparkles,
+  Rocket, Target, CalendarPlus, Repeat, PackageOpen,
   TrendingUp
 } from "lucide-react";
 
@@ -31,7 +31,7 @@ type UserRow = { id: string; email: string; tier: string | null };
 type GoalsRow = { id: string } | null;
 type LowStockItem = { id: string; name: string; refill_days_left: number | null };
 
-const SHOP_ROUTE = "/shop"; // change if your Fullscript entry differs
+const SHOP_ROUTE = "#todays-plan";
 
 export default function NextSteps() {
   const supabase = createClientComponentClient();
@@ -43,7 +43,6 @@ export default function NextSteps() {
   const [adherence7, setAdherence7] = useState<number | null>(null);
   const [lowStock, setLowStock] = useState<LowStockItem[]>([]);
   const [hasStack, setHasStack] = useState<boolean>(false);
-  const [hasAiRecent, setHasAiRecent] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
@@ -57,7 +56,6 @@ export default function NextSteps() {
         const since48Str = since48.toISOString().slice(0, 10);
         const since7 = new Date(); since7.setDate(since7.getDate() - 6);
         const since7Str = since7.toISOString().slice(0, 10);
-        const cutoffAI = new Date(); cutoffAI.setDate(cutoffAI.getDate() - 7);
 
         // Fetch in parallel (each limited to needed cols)
         const [
@@ -65,13 +63,11 @@ export default function NextSteps() {
           goalsQ,
           recentLogsQ,
           stacksQ,
-          aiQ,
         ] = await Promise.all([
           supabase.from("users").select("id, email, tier").eq("id", uid).maybeSingle(),
           supabase.from("goals").select("id").eq("user_id", uid).maybeSingle(),
           supabase.from("logs").select("id, log_date").eq("user_id", uid).gte("log_date", since48Str).limit(1),
           supabase.from("stacks").select("id").eq("user_id", uid).order("created_at", { ascending: false }).limit(1),
-          supabase.from("ai_summaries").select("id, created_at").eq("user_id", uid).order("created_at", { ascending: false }).limit(1),
         ]);
 
         setUser((userQ.data ?? null) as UserRow | null);
@@ -80,12 +76,6 @@ export default function NextSteps() {
 
         const stackId = stacksQ.data?.[0]?.id ?? null;
         setHasStack(!!stackId);
-
-        if (aiQ.data?.[0]?.created_at) {
-          setHasAiRecent(new Date(aiQ.data[0].created_at) >= cutoffAI);
-        } else {
-          setHasAiRecent(false);
-        }
 
         // Adherence 7d (defensive in case intake_events absent/empty)
         try {
@@ -164,7 +154,7 @@ export default function NextSteps() {
         icon: PackageOpen,
         title: "Refill supplements",
         desc: `${names}${lowStock.length > 2 ? "…" : ""} are running low. Avoid gaps in your routine.`,
-        actionLabel: "Reorder now",
+        actionLabel: "Review refills",
         href: SHOP_ROUTE,
         variant: "warning",
       });
@@ -196,24 +186,7 @@ export default function NextSteps() {
       });
     }
 
-    // 6) Generate insights (if none in last week)
-    if (!hasAiRecent) {
-      list.push({
-        key: "ai-refresh",
-        icon: Sparkles,
-        title: "Get fresh insights",
-        desc: "Quick tip from your latest logs and adherence data.",
-        actionLabel: "Refresh insights",
-        href: "#insights",
-        onClick: () => {
-          // Proxy-click a button with id="ai-refresh-proxy" inside InsightsFeed if present
-          try { (document.getElementById("ai-refresh-proxy") as HTMLButtonElement | null)?.click(); } catch {}
-        },
-        variant: "ghost",
-      });
-    }
-
-    // 7) Upsell if on free tier
+    // 6) Upsell if on free tier
     if ((user?.tier ?? "free").toLowerCase() === "free") {
       list.push({
         key: "upgrade",
@@ -239,8 +212,8 @@ export default function NextSteps() {
       });
     }
 
-    return list.slice(0, 4);
-  }, [hasRecentLog, adherence7, lowStock, goals, hasStack, hasAiRecent, user?.tier]);
+    return list.slice(0, 3);
+  }, [hasRecentLog, adherence7, lowStock, goals, hasStack, user?.tier]);
 
   if (loading) {
     return (
@@ -251,11 +224,14 @@ export default function NextSteps() {
   }
 
   return (
-    <section className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm" id="next-steps" aria-label="Next steps">
-      <h2 className="text-2xl font-bold text-[#041B2D] mb-4">➡️ Next Steps</h2>
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" id="next-steps" aria-label="Recommended next actions">
+      <div className="mb-4">
+        <div className="text-xs font-semibold uppercase tracking-[0.14em] text-[#047F6D]">Recommended next actions</div>
+        <h2 className="mt-1 text-2xl font-bold text-[#041B2D]">What to do next</h2>
+      </div>
 
       {ctas.length === 0 ? (
-        <div className="rounded-2xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4 text-gray-700">
+        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-gray-700">
           You’re all set for now. Keep up the momentum!
         </div>
       ) : (

--- a/src/components/dashboard/ProgressTracker.tsx
+++ b/src/components/dashboard/ProgressTracker.tsx
@@ -236,19 +236,19 @@ export default function ProgressTracker() {
   }
 
   return (
-    <div id="progress" className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm">
+    <div id="progress" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-2xl font-bold text-[#041B2D] flex items-center gap-2">
-          <span role="img" aria-label="chart">📊</span> Progress Tracker
+          Progress
         </h2>
 
         {/* Range tabs */}
-        <div className="inline-flex rounded-xl border border-purple-200 bg-white overflow-hidden">
+        <div className="inline-flex rounded-xl border border-slate-200 bg-white overflow-hidden">
           {(["7", "30", "90"] as RangeKey[]).map((k) => (
             <button
               key={k}
               onClick={() => setRange(k)}
-              className={`px-3 py-1.5 text-sm ${range === k ? "bg-purple-50 text-[#7C3AED]" : "hover:bg-gray-50 text-gray-700"}`}
+              className={`px-3 py-1.5 text-sm ${range === k ? "bg-[#EAFBF8] text-[#047F6D]" : "hover:bg-gray-50 text-gray-700"}`}
               aria-pressed={range === k}
             >
               {k}d
@@ -257,7 +257,13 @@ export default function ProgressTracker() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {logs.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
+          <div className="font-semibold text-[#041B2D]">Your trends will appear after your first check-in</div>
+          <p className="mt-1 text-sm text-gray-600">Log sleep, energy, or weight above to establish a starting point.</p>
+          <a href="#daily-log" className="mt-3 inline-flex rounded-lg bg-[#047F6D] px-3 py-2 text-sm font-semibold text-white">Complete today’s check-in</a>
+        </div>
+      ) : <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Weight */}
         <Card>
           <Header
@@ -311,7 +317,7 @@ export default function ProgressTracker() {
           />
 
           <div className="flex items-center gap-4" title="Ring shows your 7-day average vs. a max of 5.">
-            <ProgressRing value={sleep7 ?? 0} max={5} size={72} />
+            <ProgressRing value={sleep7} max={5} size={72} />
             <div>
               <div className="text-sm text-gray-600">7-day avg</div>
               <div className="text-xl font-semibold text-[#041B2D]">
@@ -352,7 +358,7 @@ export default function ProgressTracker() {
           />
 
           <div className="flex items-center gap-4" title="Ring shows your 7-day average vs. a max of 10.">
-            <ProgressRing value={energy7 ?? 0} max={10} size={72} />
+            <ProgressRing value={energy7} max={10} size={72} />
             <div>
               <div className="text-sm text-gray-600">7-day avg</div>
               <div className="text-xl font-semibold text-[#041B2D]">
@@ -383,7 +389,7 @@ export default function ProgressTracker() {
             showConfetti={confetti.energy}
           />
         </Card>
-      </div>
+      </div>}
     </div>
   );
 }
@@ -394,7 +400,7 @@ export default function ProgressTracker() {
 
 function Card({ children }: { children: React.ReactNode }) {
   return (
-    <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4 shadow-sm overflow-hidden relative">
+    <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50 p-4">
       {children}
     </div>
   );
@@ -527,7 +533,7 @@ function MetricSpark({
     <div>
       <div className="text-xs text-gray-600 mb-1 flex items-center gap-1">
         {label}
-        <span className="inline-block w-4 h-4 rounded-full bg-gray-100 text-gray-600 text-[10px] leading-4 text-center" title="Hover to see exact values">?</span>
+        <span className="text-xs text-gray-500">Hover for details</span>
       </div>
 
       <div className="relative">
@@ -675,8 +681,9 @@ function ConfettiBurst() {
    Small components/utils
 ------------------------ */
 
-function ProgressRing({ value, max, size = 72 }: { value: number; max: number; size?: number }) {
-  const v = Math.max(0, Math.min(max, Number.isFinite(value) ? value : 0));
+function ProgressRing({ value, max, size = 72 }: { value: number | null; max: number; size?: number }) {
+  const hasValue = typeof value === "number" && Number.isFinite(value);
+  const v = Math.max(0, Math.min(max, hasValue ? value : 0));
   const pct = Math.max(0, Math.min(1, max ? v / max : 0));
   const stroke = 8;
   const r = (size - stroke) / 2;
@@ -685,8 +692,8 @@ function ProgressRing({ value, max, size = 72 }: { value: number; max: number; s
   const rest = c - dash;
 
   return (
-    <svg width={size} height={size} role="img" aria-label={`Progress ${Math.round(pct * 100)}%`}>
-      <title>{`Progress: ${Math.round(pct * 100)}% of maximum`}</title>
+    <svg width={size} height={size} role="img" aria-label={hasValue ? `Progress ${Math.round(pct * 100)}%` : "No progress data yet"}>
+      <title>{hasValue ? `Progress: ${Math.round(pct * 100)}% of maximum` : "No data yet"}</title>
       <circle cx={size / 2} cy={size / 2} r={r} stroke="#E5E7EB" strokeWidth={stroke} fill="none" />
       <circle
         cx={size / 2}
@@ -700,7 +707,7 @@ function ProgressRing({ value, max, size = 72 }: { value: number; max: number; s
         transform={`rotate(-90 ${size / 2} ${size / 2})`}
       />
       <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="12" fill="#041B2D">
-        {Math.round(pct * 100)}%
+        {hasValue ? `${Math.round(pct * 100)}%` : "—"}
       </text>
     </svg>
   );

--- a/src/components/dashboard/TodaysPlan.tsx
+++ b/src/components/dashboard/TodaysPlan.tsx
@@ -281,9 +281,9 @@ useEffect(() => {
   }
 
   return (
-    <div id="todays-plan" className="bg-white/70 backdrop-blur-md rounded-2xl p-0 shadow-sm">
+    <div id="todays-plan" className="rounded-2xl border border-slate-200 bg-white p-0 shadow-sm">
       {/* Sticky Header */}
-      <div className="sticky top-0 z-10 bg-white/80 backdrop-blur-md rounded-t-2xl border-b border-purple-100">
+      <div className="sticky top-0 z-10 rounded-t-2xl border-b border-slate-200 bg-white/95 backdrop-blur-md">
         <div className="px-6 pt-5 pb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-2xl font-bold text-[#041B2D]">🗓️ Today’s Plan</h2>
@@ -326,7 +326,7 @@ useEffect(() => {
 
             <button
               onClick={() => setShowManager(true)}
-              className="inline-flex items-center rounded-xl bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] px-3 py-1.5 text-white text-sm font-semibold shadow-md"
+              className="inline-flex items-center rounded-xl bg-[#047F6D] px-3 py-1.5 text-white text-sm font-semibold shadow-md hover:bg-[#036957]"
               aria-label="Manage stack"
             >
               <Search className="w-4 h-4 mr-1" />
@@ -535,7 +535,7 @@ function LowStockBanner({ items }: { items: StackItem[] }) {
 function RecommendationBlock({ items, onActivate }: { items: StackItem[]; onActivate: (id: string) => void }) {
   return (
     <section aria-label="Recommendations to consider">
-      <div className="text-xs uppercase tracking-wide text-purple-600 mb-2">Recommendations to consider</div>
+      <div className="text-xs uppercase tracking-wide text-[#047F6D] mb-2">Recommendations to consider</div>
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
         <p className="mb-3 text-sm text-amber-900">
           These Blueprint ideas are not part of your daily checklist until you choose to add them.
@@ -571,9 +571,9 @@ function TimingBlock({
 }) {
   return (
     <section aria-label={title}>
-      <div className="text-xs uppercase tracking-wide text-purple-600 mb-2">{title}</div>
+      <div className="text-xs uppercase tracking-wide text-[#047F6D] mb-2">{title}</div>
       {items.length === 0 ? (
-        <div className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4 text-gray-600">
+        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-gray-600">
           No items in this timing.
         </div>
       ) : (
@@ -587,7 +587,7 @@ function TimingBlock({
             return (
               <li
                 key={it.id}
-                className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-3"
+                className="rounded-xl border border-slate-200 bg-slate-50 p-3"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex items-start gap-3">
@@ -663,7 +663,7 @@ function Tab({ label, active, onClick }: { label: ViewTab; active: boolean; onCl
     <button
       onClick={onClick}
       className={`rounded-full px-3 py-1 text-sm border ${
-        active ? "bg-[#7C3AED] text-white border-transparent" : "bg-white text-[#041B2D] border-purple-200"
+        active ? "bg-[#047F6D] text-white border-transparent" : "bg-white text-[#041B2D] border-slate-200"
       }`}
       aria-pressed={active}
       aria-label={`Show ${label} items`}

--- a/src/components/dashboard/WeeklyGoal.tsx
+++ b/src/components/dashboard/WeeklyGoal.tsx
@@ -94,14 +94,14 @@ export default function WeeklyGoal() {
 
   const changed = focus !== initialFocus;
   return (
-    <div className="rounded-2xl bg-white/70 p-6 shadow-sm" aria-label="Weekly focus">
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" aria-label="Weekly focus">
       <h2 className="flex items-center gap-2 text-2xl font-bold text-[#041B2D]">
-        <Target className="h-5 w-5 text-[#7C3AED]" /> Weekly Focus
+        <Target className="h-5 w-5 text-[#047F6D]" /> Weekly Focus
       </h2>
       <p className="mt-1 text-gray-600">Choose one practical experiment for this week.</p>
 
       <div className="mt-4">
-        <label className="text-xs uppercase tracking-wide text-purple-600" htmlFor="weekly-focus">This week I will</label>
+        <label className="text-xs uppercase tracking-wide text-[#047F6D]" htmlFor="weekly-focus">This week I will</label>
         <div className="relative">
           <input id="weekly-focus" value={focus} onChange={(event) => setFocus(event.target.value.slice(0, MAX_CHARS))}
             placeholder="e.g., Keep caffeine before noon" className="mt-1 w-full rounded-lg border px-3 py-2 pr-16" />
@@ -110,11 +110,11 @@ export default function WeeklyGoal() {
       </div>
 
       <div className="mt-3">
-        <div className="text-xs uppercase tracking-wide text-purple-600">Choose one starter focus</div>
+        <div className="text-xs uppercase tracking-wide text-[#047F6D]">Choose one starter focus</div>
         <div className="mt-1 flex flex-wrap gap-2">
           {PRESETS.map((preset) => (
             <button key={preset.label} onClick={() => setFocus(preset.focus)} aria-pressed={focus === preset.focus}
-              className={`rounded-full border px-3 py-1 text-sm ${focus === preset.focus ? "border-purple-600 bg-purple-600 text-white" : "hover:bg-white"}`}>
+              className={`rounded-full border px-3 py-1 text-sm ${focus === preset.focus ? "border-[#047F6D] bg-[#047F6D] text-white" : "border-slate-200 hover:bg-slate-50"}`}>
               {preset.label}
             </button>
           ))}
@@ -133,7 +133,7 @@ export default function WeeklyGoal() {
       <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-xs text-gray-500">{initialFocus ? `Current focus: “${initialFocus}”` : "Choose a focus to begin."}</div>
         <button onClick={() => save(false)} disabled={saving || !changed}
-          className="inline-flex items-center rounded-xl bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] px-4 py-2 font-semibold text-white shadow-md disabled:opacity-60">
+          className="inline-flex items-center rounded-xl bg-[#047F6D] px-4 py-2 font-semibold text-white shadow-md hover:bg-[#036957] disabled:opacity-60">
           {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {changed ? (focus.trim() ? "Save focus" : "Clear focus") : (focus ? "Saved" : "Choose a focus")}
           <ChevronRight className="ml-1 h-4 w-4" />


### PR DESCRIPTION
## Purpose

Make the paid dashboard feel coherent, trustworthy, and easier to use after PR #45 corrected its data and safety behavior.

## What changed

- Replaces the disappearing duplicate greeting with one permanent branded dashboard header.
- Adds prominent **View Blueprint** and **Reports & PDF** actions.
- Reorders the experience around next action → weekly focus → today’s plan → check-in → progress → insights.
- Reduces competing next-step cards from four to three and removes duplicate insight-refresh prompting.
- Removes the broken `/shop` destination and directs refill review to the active plan.
- Shows **Not logged yet** instead of presenting default sleep and energy values as user entries.
- Prevents untouched default slider values from being saved when the user logs only one metric.
- Adds a useful first-check-in empty state instead of empty 0% progress rings.
- Removes mock Apply tweak and Add reminder controls that did not persist real behavior.
- Standardizes primary cards around LVE360 navy, teal, white, and neutral slate styling.

## Verification

- `npm run typecheck`
- `npm run build` with inert placeholder configuration
- `git diff --check`
- React review: semantic links/buttons, stable list keys, timer cleanup, and truthful interactive states checked

## Not verified

- Authenticated visual QA with production Supabase data
- Blueprint/PDF links against a real current user session
- Responsive layout in the Vercel Preview browser

## Manual Preview QA

1. Confirm the dashboard shows one greeting and the user’s friendly first name.
2. Open **View Blueprint** and **Reports & PDF**.
3. Confirm the order is next actions, weekly focus, Today’s Plan, daily check-in, progress, insights.
4. With no log today, confirm sleep and energy say **Not logged yet**.
5. Move only one slider and save; confirm the untouched metric is not falsely submitted.
6. With no historical logs, confirm Progress displays the first-check-in empty state rather than 0% rings.
7. Confirm Coaching Insights has no nonfunctional Apply tweak or Add reminder controls.
8. Check desktop and mobile spacing, navigation, and card readability.

## Risk / rollback

No database schema, report generation, auth, checkout, or dashboard safety rules changed. Revert commit `c861e72` to roll back.
