### PR TITLE
Canonicalize the LVE360 web experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .next
 node_modules
 next-env.d.ts
+tsconfig.tsbuildinfo
 .env

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,9 +3,30 @@ import Link from "next/link";
 import { SpeedInsights } from "@vercel/speed-insights/next"; // ✅ Added import
 import { Analytics } from "@vercel/analytics/react";
 
+const canonicalUrl = "https://app.lve360.com";
+
 export const metadata = {
-  title: "LVE360",
+  metadataBase: new URL(canonicalUrl),
+  title: {
+    default: "LVE360",
+    template: "%s | LVE360",
+  },
   description: "Longevity | Vitality | Energy",
+  alternates: {
+    canonical: "./",
+  },
+  openGraph: {
+    type: "website",
+    url: canonicalUrl,
+    siteName: "LVE360",
+    title: "LVE360",
+    description: "Longevity | Vitality | Energy",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "LVE360",
+    description: "Longevity | Vitality | Energy",
+  },
 };
 
 export default function RootLayout({ children }) {

--- a/docs/canonical-domain-rollout.md
+++ b/docs/canonical-domain-rollout.md
@@ -1,0 +1,37 @@
+# Canonical domain rollout
+
+The canonical production origin is `https://app.lve360.com`.
+
+## Vercel configuration
+
+The production project must receive requests for all three hosts:
+
+- `app.lve360.com` — canonical application host
+- `lve360.com` — legacy host redirected by Next.js
+- `www.lve360.com` — legacy host redirected by Next.js
+
+Before merging, confirm that `lve360.com` and `www.lve360.com` are assigned to the
+same Vercel project as `app.lve360.com`. Remove any Vercel-level redirect from
+`www.lve360.com` to the old root-domain deployment so the application redirect
+rules can run.
+
+## Verification
+
+After the production deployment, verify that paths and query strings survive:
+
+```text
+https://lve360.com/pricing?plan=annual
+  -> 308 https://app.lve360.com/pricing?plan=annual
+
+https://www.lve360.com/results
+  -> 308 https://app.lve360.com/results
+```
+
+Also verify that `https://app.lve360.com/` returns `200` without a redirect loop
+and emits canonical metadata using the app origin.
+
+## Rollback
+
+If host routing interferes with the application, revert the production deployment
+or remove the two host-based rules from `next.config.js`. Do not change the
+`app.lve360.com` assignment during rollback.

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,21 @@
-const path = require('path');
-
-module.exports = {
-  webpack: (config) => {
-    config.resolve.alias['@'] = path.resolve(__dirname, 'src');
-    return config;
-  },
-};
+const path = require("path");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
   // IMPORTANT: do NOT set `output: 'export'`
+  webpack: (config) => {
+    config.resolve.alias["@"] = path.resolve(__dirname, "src");
+    return config;
+  },
+  async redirects() {
+    return ["lve360.com", "www.lve360.com"].map((host) => ({
+      source: "/:path*",
+      has: [{ type: "host", value: host }],
+      destination: "https://app.lve360.com/:path*",
+      permanent: true,
+    }));
+  },
 };
+
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "qa:env": "node scripts/check-env.mjs",
     "qa:build": "npm run typecheck && npm run build",
+    "qa:canonical-host": "node src/_tests_/canonicalHost.assert.mjs",
     "qa:all": "npm run qa:env && npm run qa:build"
   },
   "dependencies": {

--- a/src/_tests_/canonicalHost.assert.mjs
+++ b/src/_tests_/canonicalHost.assert.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const nextConfig = require("../../next.config.js");
+const redirects = await nextConfig.redirects();
+
+assert.equal(redirects.length, 2, "both legacy hosts must redirect");
+
+assert.deepEqual(
+  redirects.map((rule) => rule.has[0].value).sort(),
+  ["lve360.com", "www.lve360.com"],
+  "redirect rules must cover the root and www hosts",
+);
+
+for (const rule of redirects) {
+  assert.equal(rule.source, "/:path*", "redirects must preserve every path");
+  assert.equal(
+    rule.destination,
+    "https://app.lve360.com/:path*",
+    "redirects must target the canonical app host",
+  );
+  assert.equal(rule.permanent, true, "canonical redirects must be permanent");
+}
+
+assert.equal(
+  redirects.some((rule) => rule.has[0].value === "app.lve360.com"),
+  false,
+  "the canonical host must never redirect",
+);
+
+console.log("canonical host assertions passed");


### PR DESCRIPTION
## Purpose
Make `https://app.lve360.com` the single canonical production origin and prepare the legacy root and `www` hosts to redirect into the live application without dropping paths or query strings.

## What changed
- Added permanent host-based redirects for `lve360.com` and `www.lve360.com`.
- Added canonical, Open Graph, and Twitter metadata rooted at `app.lve360.com`.
- Consolidated the duplicate `next.config.js` exports so redirects and the existing alias configuration both apply.
- Added a deterministic canonical-host QA assertion and rollout/rollback notes.
- Ignored generated TypeScript build metadata.

## Verified
- `npm run qa:canonical-host` passes.
- `npm run typecheck` passes.
- Local host-header smoke test returns `308` for both legacy hosts, preserves `/pricing?plan=annual`, and returns `200` for the canonical host.
- `git diff --check` passes.

## Not verified
- Full production build cannot complete locally because required launch environment variables are not present; it compiles and type-checks before failing while collecting `/api/models-healthcheck` because `OPENAI_API_KEY` is absent.
- Production redirects require `lve360.com` and `www.lve360.com` to be assigned to this Vercel project. The root domain is not currently listed on the project, and `www` presently redirects to the old root experience before the app handles the request.

## Risks / rollback
Host routing is isolated to two exact legacy hosts. Preview deployments and `app.lve360.com` are not redirected. Roll back by reverting this PR or removing the two rules from `next.config.js`; keep the canonical app-domain assignment intact.

## Follow-up
After preview validation, assign the root and `www` domains to this Vercel project, remove the old Vercel-level `www` redirect, deploy, and repeat the redirect smoke test.