### PR TITLE
Audit PR 04: Create Blueprint action handoff and CTA

### DIFF
--- a/app/api/blueprint-action/route.ts
+++ b/app/api/blueprint-action/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { buildBlueprintActionCandidates } from "@/lib/blueprintActions";
+import { parseBlueprintReport } from "@/lib/blueprintReport";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const COOKIE_NAME = "lve360_blueprint_action";
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type HandoffPointer = { stackId: string; actionId: string };
+
+function encodePointer(pointer: HandoffPointer): string {
+  return Buffer.from(JSON.stringify(pointer), "utf8").toString("base64url");
+}
+
+function decodePointer(raw: string | undefined): HandoffPointer | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8")) as Partial<HandoffPointer>;
+    if (!parsed.stackId || !UUID_RE.test(parsed.stackId) || !parsed.actionId || parsed.actionId.length > 80) return null;
+    return { stackId: parsed.stackId, actionId: parsed.actionId };
+  } catch {
+    return null;
+  }
+}
+
+function markdownFromStack(stack: { sections: unknown; summary: string | null }): string {
+  const sections = stack.sections;
+  if (sections && typeof sections === "object" && "markdown" in sections) {
+    const markdown = (sections as { markdown?: unknown }).markdown;
+    if (typeof markdown === "string") return markdown;
+  }
+  return stack.summary ?? "";
+}
+
+async function resolvePointer(pointer: HandoffPointer) {
+  const { data: stack, error } = await supabaseAdmin
+    .from("stacks")
+    .select("id, sections, summary")
+    .eq("id", pointer.stackId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!stack) return null;
+
+  const report = parseBlueprintReport(markdownFromStack(stack));
+  return buildBlueprintActionCandidates(report).find((candidate) => candidate.id === pointer.actionId) ?? null;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const pointer = decodePointer(req.cookies.get(COOKIE_NAME)?.value);
+    if (!pointer) return NextResponse.json({ ok: true, selected: null });
+    const selected = await resolvePointer(pointer);
+    if (!selected || selected.kind !== "lifestyle") {
+      const response = NextResponse.json({ ok: true, selected: null });
+      response.cookies.delete(COOKIE_NAME);
+      return response;
+    }
+    return NextResponse.json({ ok: true, selected });
+  } catch (error) {
+    console.error("[blueprint-action] resolve failed", error);
+    return NextResponse.json({ ok: false, error: "handoff_unavailable" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => null)) as { stack_id?: string; action_id?: string } | null;
+    if (!body?.stack_id || !UUID_RE.test(body.stack_id) || !body.action_id || body.action_id.length > 80) {
+      return NextResponse.json({ ok: false, error: "invalid_action" }, { status: 400 });
+    }
+
+    const pointer = { stackId: body.stack_id, actionId: body.action_id };
+    const selected = await resolvePointer(pointer);
+    if (!selected) return NextResponse.json({ ok: false, error: "action_not_found" }, { status: 404 });
+    if (selected.kind !== "lifestyle") {
+      return NextResponse.json({ ok: false, error: "action_requires_review" }, { status: 422 });
+    }
+
+    const response = NextResponse.json({ ok: true, selected });
+    response.cookies.set(COOKIE_NAME, encodePointer(pointer), {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30,
+    });
+    return response;
+  } catch (error) {
+    console.error("[blueprint-action] save failed", error);
+    return NextResponse.json({ ok: false, error: "handoff_unavailable" }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.delete(COOKIE_NAME);
+  return response;
+}

--- a/app/onboarding/OnboardingHandoffClient.tsx
+++ b/app/onboarding/OnboardingHandoffClient.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowRight, CheckCircle2 } from "lucide-react";
+
+type SelectedAction = { label: string; category: string };
+
+export default function OnboardingHandoffClient() {
+  const [selected, setSelected] = useState<SelectedAction | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/blueprint-action", { cache: "no-store" })
+      .then((response) => response.json())
+      .then((data) => { if (!cancelled) setSelected(data?.selected ?? null); })
+      .catch(() => { if (!cancelled) setSelected(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB] px-6 py-20">
+      <div className="mx-auto max-w-2xl rounded-3xl border border-[#CDE9E3] bg-white p-8 shadow-xl sm:p-12">
+        <p className="text-sm font-bold uppercase tracking-[0.18em] text-[#087F72]">Your first week</p>
+        <h1 className="mt-3 text-4xl font-extrabold tracking-tight text-[#041B2D]">Start with one action you can repeat</h1>
+        <p className="mt-4 text-lg leading-7 text-slate-600">
+          Your Blueprint becomes useful when it turns into a small practice. We will use this choice to shape your first weekly plan.
+        </p>
+
+        <div className="mt-8 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5">
+          {loading ? (
+            <p className="text-slate-600">Loading your selected action...</p>
+          ) : selected ? (
+            <div className="flex gap-3">
+              <CheckCircle2 className="mt-0.5 h-6 w-6 shrink-0 text-[#087F72]" aria-hidden="true" />
+              <div>
+                <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">Selected from your Blueprint</p>
+                <p className="mt-2 text-lg font-semibold leading-7 text-[#041B2D]">{selected.label}</p>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <p className="font-semibold text-[#041B2D]">Choose your first small lifestyle action in the dashboard.</p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">Older Blueprints and reports without a weekly focus use this safe fallback.</p>
+            </div>
+          )}
+        </div>
+
+        <p className="mt-5 text-sm leading-6 text-slate-500">
+          Supplement and medication changes stay in your Blueprint for clinician or pharmacist review. They are never turned into habits automatically.
+        </p>
+
+        <a
+          href="/dashboard"
+          className="mt-8 inline-flex w-full items-center justify-center rounded-xl bg-[#08A88A] px-5 py-3 font-bold text-white shadow-sm transition hover:bg-[#078B74]"
+        >
+          Continue to my dashboard <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,11 @@
+import { requireTier } from "@/app/_auth/requireTier";
+
+import OnboardingHandoffClient from "./OnboardingHandoffClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function OnboardingPage() {
+  await requireTier(["premium", "trial"], { next: "/onboarding" });
+  return <OnboardingHandoffClient />;
+}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -8,6 +8,7 @@ import remarkGfm from "remark-gfm";
 
 import CTAButton from "@/components/CTAButton";
 import ResultsSidebar from "@/components/results/ResultsSidebar";
+import { buildBlueprintActionCandidates } from "@/lib/blueprintActions";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
 import { blueprintStatusTone, cleanReportDisplayText, reportSectionTitle } from "@/lib/reportPresentation";
 import { AFFILIATE_DISCLOSURE_NEAR_LINKS, AFFILIATE_DISCLOSURE_SUPPORT } from "@/lib/reportDisclosures";
@@ -317,6 +318,8 @@ function ResultsContent() {
   const [stackId, setStackId] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
+  const [handoffActionId, setHandoffActionId] = useState<string | null>(null);
+  const [handoffError, setHandoffError] = useState<string | null>(null);
   const [flow, setFlow] = useState<"idle" | "warmup" | "generating" | "done" | "error">("idle");
 
   const searchParams = useSearchParams();
@@ -497,9 +500,36 @@ async function exportPDF() {
       follow: report.sections["Follow-up Plan"], lifestyle: report.sections["Lifestyle Prescriptions"],
       longevity: report.sections["Longevity Levers"], weekTry: report.sections["This Week Try"],
       focusItems: report.focusItems,
+      focusActions: buildBlueprintActionCandidates(report),
       contentHash: report.contentHash,
     };
   }, [markdown]);
+
+  async function buildFirstWeek(actionId: string) {
+    if (!stackId) {
+      setHandoffError("Generate your Blueprint before choosing a first-week action.");
+      return;
+    }
+    setHandoffActionId(actionId);
+    setHandoffError(null);
+    try {
+      const response = await fetch("/api/blueprint-action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ stack_id: stackId, action_id: actionId }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data?.ok) {
+        throw new Error(data?.error === "action_requires_review"
+          ? "This item needs professional review and cannot become an automatic habit."
+          : "We could not save that action. Please try again.");
+      }
+      window.location.assign("/upgrade");
+    } catch (error) {
+      setHandoffError(error instanceof Error ? error.message : "We could not save that action. Please try again.");
+      setHandoffActionId(null);
+    }
+  }
 
   return (
     <motion.main
@@ -570,12 +600,30 @@ async function exportPDF() {
 
             {error && <div className="text-center text-red-600 mb-6">{error}</div>}
 
-            {!warmingUp && !generating && flow !== "error" && sec.focusItems.length > 0 && (
+            {!warmingUp && !generating && flow !== "error" && Boolean(markdown) && Boolean(stackId) && sec.focusActions.length > 0 && (
               <div className="report-focus mb-8 rounded-2xl border border-[#9DCFC3] bg-gradient-to-r from-[#EFF5FA] to-[#E6F7F3] p-6 shadow-sm">
                 <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#122945]">This Week Focus</p>
-                <ol className="mt-3 grid gap-2 text-sm text-slate-800 sm:grid-cols-2">
-                  {sec.focusItems.map((item, index) => <li key={item} className="rounded-xl bg-white/80 px-4 py-3"><strong>{index + 1}.</strong> {item}</li>)}
+                <p className="mt-2 text-sm text-slate-600">Choose one lifestyle action to carry into your first week. Supplement and medication changes stay in the Blueprint for review.</p>
+                <ol className="mt-4 grid gap-3 text-sm text-slate-800 sm:grid-cols-2">
+                  {sec.focusActions.map((action, index) => (
+                    <li key={action.id} className="flex flex-col rounded-xl bg-white/90 px-4 py-4 shadow-sm">
+                      <p className="leading-6"><strong>{index + 1}.</strong> {action.label}</p>
+                      {action.kind === "lifestyle" ? (
+                        <button
+                          type="button"
+                          onClick={() => buildFirstWeek(action.id)}
+                          disabled={handoffActionId !== null || !stackId}
+                          className="mt-auto pt-4 text-left text-sm font-bold text-[#087F72] hover:text-[#05675D] disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {handoffActionId === action.id ? "Saving your choice..." : "Build my first week"}
+                        </button>
+                      ) : (
+                        <p className="mt-auto pt-4 text-xs font-semibold uppercase tracking-wide text-amber-700">Keep in Blueprint for review</p>
+                      )}
+                    </li>
+                  ))}
                 </ol>
+                {handoffError && <p className="mt-3 text-sm font-medium text-red-700">{handoffError}</p>}
               </div>
             )}
 

--- a/app/upgrade/UpgradeClient.tsx
+++ b/app/upgrade/UpgradeClient.tsx
@@ -58,12 +58,20 @@ function Inner() {
   const [tier, setTier] = useState<Tier>("free");
   const [checking, setChecking] = useState(true);
   const [banner, setBanner] = useState<string | null>(null);
+  const [selectedAction, setSelectedAction] = useState<{ label: string; category: string } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     (async () => {
       try {
+        const handoff = await fetch("/api/blueprint-action", { cache: "no-store" })
+          .then((response) => response.ok ? response.json() : null)
+          .catch(() => null);
+        const action = handoff?.selected ?? null;
+        if (!cancelled) setSelectedAction(action);
+        const premiumDestination = action ? "/onboarding" : "/dashboard";
+
         console.log("[/upgrade] start check");
         let res = await fetch("/api/users/tier", { cache: "no-store" });
         console.log("[/upgrade] tier status:", res.status);
@@ -96,9 +104,9 @@ function Inner() {
         setTier(t);
 
         if (t === "premium") {
-          setBanner("Welcome back! Redirecting to your dashboard…");
-          console.log("[/upgrade] is premium → /dashboard");
-          setTimeout(() => router.replace("/dashboard"), 400);
+          setBanner(action ? "Your first-week action is ready. Opening onboarding..." : "Welcome back! Redirecting to your dashboard...");
+          console.log("[/upgrade] premium destination", premiumDestination);
+          setTimeout(() => router.replace(premiumDestination), 400);
           return;
         }
 
@@ -128,9 +136,9 @@ function Inner() {
             }
             const j = await rr.json().catch(() => null);
             if (j?.tier === "premium") {
-              console.log("[/upgrade] flip detected → /dashboard");
-              setBanner("All set! Taking you to your dashboard…");
-              setTimeout(() => router.replace("/dashboard"), 400);
+              console.log("[/upgrade] premium flip destination", premiumDestination);
+              setBanner(action ? "All set! Opening your first-week setup..." : "All set! Taking you to your dashboard...");
+              setTimeout(() => router.replace(premiumDestination), 400);
               return;
             }
             await new Promise((s) => setTimeout(s, 500));
@@ -209,6 +217,14 @@ function Inner() {
           <p className="mb-6 text-sm text-indigo-800 bg-indigo-50 border border-indigo-200 rounded-md px-3 py-2">
             {banner || "Checking your account…"}
           </p>
+        )}
+
+        {selectedAction && (
+          <div className="mb-7 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-4 text-left">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">Coming with you from your Blueprint</p>
+            <p className="mt-2 font-semibold leading-6 text-[#041B2D]">{selectedAction.label}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-600">After checkout, we will use this to start your first week.</p>
+          </div>
         )}
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">

--- a/app/upgrade/success/SuccessClient.tsx
+++ b/app/upgrade/success/SuccessClient.tsx
@@ -19,6 +19,11 @@ function Inner() {
 
     (async () => {
       try {
+        const handoff = await fetch("/api/blueprint-action", { cache: "no-store" })
+          .then((response) => response.ok ? response.json() : null)
+          .catch(() => null);
+        const premiumDestination = handoff?.selected ? "/onboarding" : "/dashboard";
+
         // 1) Confirm with Stripe (cookie not required)
         const res = await fetch(`/api/stripe/confirm?session_id=${sessionId}`, {
           method: "GET",
@@ -40,8 +45,8 @@ function Inner() {
         //    If this 401s, the cookie isn't available yet → go to login with next=/dashboard.
         const tierRes = await fetch("/api/users/tier", { cache: "no-store" });
         if (tierRes.status === 401) {
-          setMsg("Almost done — please confirm login…");
-          router.replace("/login?next=/dashboard");
+          setMsg("Almost done. Please confirm login...");
+          router.replace(`/login?next=${encodeURIComponent(premiumDestination)}`);
           return;
         }
 
@@ -64,15 +69,15 @@ function Inner() {
           }
 
           if (isPremium) {
-            setMsg("Welcome to Premium! Redirecting…");
-            setTimeout(() => router.replace("/dashboard"), 600);
+            setMsg(handoff?.selected ? "Welcome to Premium! Opening your first-week setup..." : "Welcome to Premium! Redirecting...");
+            setTimeout(() => router.replace(premiumDestination), 600);
             return;
           }
         }
 
         // 4) Default success route
-        setMsg("Welcome to Premium! Redirecting…");
-        setTimeout(() => router.replace("/dashboard"), 600);
+        setMsg(handoff?.selected ? "Welcome to Premium! Opening your first-week setup..." : "Welcome to Premium! Redirecting...");
+        setTimeout(() => router.replace(premiumDestination), 600);
       } catch {
         setMsg("Network hiccup. Taking you back…");
         setTimeout(() => router.replace("/upgrade"), 1200);

--- a/src/_tests_/blueprintActions.assert.ts
+++ b/src/_tests_/blueprintActions.assert.ts
@@ -1,0 +1,35 @@
+import { buildBlueprintActionCandidates } from "../lib/blueprintActions";
+import { parseBlueprintReport } from "../lib/blueprintReport";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const report = parseBlueprintReport(`
+## This Week Try
+
+- Take a ten-minute walk after lunch on Monday, Wednesday, and Friday.
+- Take magnesium 200 mg before bed.
+- Call a friend after your Saturday morning coffee.
+`);
+const candidates = buildBlueprintActionCandidates(report);
+
+assert(candidates.length === 3, "Expected every weekly focus item to receive a stable action candidate");
+assert(candidates[0].kind === "lifestyle", "Expected a walking action to enter the habit handoff");
+assert(candidates[0].category === "movement", "Expected a walking action to be categorized as movement");
+assert(candidates[1].kind === "review_only", "Expected a supplement dose to remain review-only");
+assert(candidates[2].category === "relationships", "Expected a social action to be categorized as relationships");
+
+const sameReport = buildBlueprintActionCandidates(parseBlueprintReport(report.canonicalMarkdown));
+assert(candidates[0].id === sameReport[0].id, "Expected action IDs to be stable for the same report content");
+
+const legacyCandidates = buildBlueprintActionCandidates(parseBlueprintReport("## Intro Summary\n\nA legacy report."));
+assert(legacyCandidates.length === 1, "Expected a safe legacy fallback");
+assert(legacyCandidates[0].kind === "lifestyle", "Expected the legacy fallback to be a lifestyle action");
+assert(legacyCandidates[0].source === "legacy_fallback", "Expected the fallback source to be explicit");
+
+const reviewOnlyCandidates = buildBlueprintActionCandidates(parseBlueprintReport("## This Week Try\n\n- Start magnesium 200 mg before bed."));
+assert(reviewOnlyCandidates.some((candidate) => candidate.kind === "review_only"), "Expected the supplement action to stay review-only");
+assert(reviewOnlyCandidates.some((candidate) => candidate.kind === "lifestyle"), "Expected a safe fallback when all report actions require review");
+
+console.log("blueprintActions assertions passed");

--- a/src/lib/blueprintActions.ts
+++ b/src/lib/blueprintActions.ts
@@ -1,0 +1,66 @@
+import type { BlueprintReport } from "./blueprintReport";
+
+export type BlueprintActionCategory =
+  | "movement"
+  | "nutrition"
+  | "sleep"
+  | "mindset"
+  | "relationships"
+  | "focus"
+  | "lifestyle";
+
+export type BlueprintActionCandidate = {
+  id: string;
+  label: string;
+  category: BlueprintActionCategory;
+  kind: "lifestyle" | "review_only";
+  source: "report" | "legacy_fallback";
+};
+
+const SAFETY_SENSITIVE_RE = /\b(?:supplement|vitamin|magnesium|creatine|omega[- ]?3|fish oil|ashwagandha|melatonin|probiotic|medication|medicine|prescription|dose|dosage|capsule|tablet|softgel|clinician|physician|doctor|pharmacist|blood test|lab(?:oratory)?|\d+(?:\.\d+)?\s*(?:mg|mcg|µg|iu))\b/i;
+
+function categoryFor(label: string): BlueprintActionCategory {
+  if (/\b(?:walk|steps?|exercise|workout|strength|cardio|movement|mobility|stretch)\b/i.test(label)) return "movement";
+  if (/\b(?:meal|food|protein|fiber|vegetable|fruit|water|hydrate|nutrition|eat)\b/i.test(label)) return "nutrition";
+  if (/\b(?:sleep|bed|wake|wind[- ]?down|evening|morning light)\b/i.test(label)) return "sleep";
+  if (/\b(?:relationship|friend|family|partner|connect|conversation|gratitude)\b/i.test(label)) return "relationships";
+  if (/\b(?:focus|deep work|career|learn|read|cognitive|screen)\b/i.test(label)) return "focus";
+  if (/\b(?:stress|breath|meditat|journal|reflect|mindful|emotion)\b/i.test(label)) return "mindset";
+  return "lifestyle";
+}
+
+export function isSafetySensitiveBlueprintAction(label: string): boolean {
+  return SAFETY_SENSITIVE_RE.test(label);
+}
+
+export function buildBlueprintActionCandidates(report: BlueprintReport): BlueprintActionCandidate[] {
+  if (report.focusItems.length === 0) {
+    return [{
+      id: `${report.contentHash}:fallback`,
+      label: "Choose one small lifestyle action from your Blueprint during onboarding.",
+      category: "lifestyle",
+      kind: "lifestyle",
+      source: "legacy_fallback",
+    }];
+  }
+
+  const candidates: BlueprintActionCandidate[] = report.focusItems.map((label, index) => ({
+    id: `${report.contentHash}:${index}`,
+    label,
+    category: categoryFor(label),
+    kind: isSafetySensitiveBlueprintAction(label) ? "review_only" : "lifestyle",
+    source: "report",
+  }));
+
+  if (candidates.every((candidate) => candidate.kind === "review_only")) {
+    candidates.push({
+      id: `${report.contentHash}:fallback`,
+      label: "Choose one small lifestyle action from your Blueprint during onboarding.",
+      category: "lifestyle",
+      kind: "lifestyle",
+      source: "legacy_fallback",
+    });
+  }
+
+  return candidates;
+}


### PR DESCRIPTION
## Purpose

Turn the free Blueprint into a concrete paid-product handoff by letting a user select one safe lifestyle action for their first week.

## What changed

- classifies weekly Blueprint items into lifestyle actions or review-only safety items
- adds a **Build my first week** CTA to eligible Blueprint actions
- stores only validated report and action identifiers in a secure same-site cookie
- carries the selection through login, Stripe checkout, cancellation, and paid activation
- shows the selected action on the upgrade page
- routes paid users with a selection into a focused onboarding handoff
- keeps supplement and medication changes in review-only status
- supplies a safe fallback for older reports and reports with no eligible lifestyle action
- adds focused assertions for categorization, stable IDs, safety blocking, and fallback behavior

## Verification

- `npm run typecheck`
- focused Blueprint action assertions
- `npm run build` with safe placeholder configuration
- local API checks for empty state and malformed input rejection
- local browser checks for `/results` and `/upgrade`
- no browser console errors or framework error overlays

## Not verified

- a real Tally report selection using production data
- a real Stripe transaction and cross-device magic-link handoff
- local `qa:env` remains unavailable because launch secrets are intentionally not stored in this checkout

## Safety and privacy

- no health or action text is placed in URLs or Stripe metadata
- the server resolves every action against the persisted Blueprint before accepting it
- safety-sensitive supplement and medication actions cannot enter the habit flow
- no Supabase migration or new RLS surface is required

## Risks and rollback

The handoff is additive. Rollback by removing the Blueprint action API, onboarding handoff page, CTA integration, and the post-payment destination check. Existing report generation, checkout, and dashboard behavior remain available.

## Follow-up

Audit PR 05 should persist the confirmed lifestyle action into the outcome-driven paid onboarding and weekly plan model.