### PR TITLE
Audit PR 06: Ship Today v1 as the dashboard default

### DIFF
--- a/app/(app)/dashboard/DashboardClient.tsx
+++ b/app/(app)/dashboard/DashboardClient.tsx
@@ -1,124 +1,86 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { FileText, History, Loader2 } from "lucide-react";
+import { useEffect } from "react";
+import { ChevronDown, FileText, History } from "lucide-react";
 
-import DashboardSnapshot from "@/components/dashboard/DashboardSnapshot";
-import NextSteps from "@/components/dashboard/NextSteps";
 import DailyLog from "@/components/dashboard/DailyLog";
-import WeeklyGoal from "@/components/dashboard/WeeklyGoal";
-import TodaysPlan from "@/components/dashboard/TodaysPlan";
-import ProgressTracker from "@/components/dashboard/ProgressTracker";
 import InsightsFeed from "@/components/dashboard/InsightsFeed";
-import { getFriendlyFirstName } from "@/src/lib/displayName";
+import ProgressTracker from "@/components/dashboard/ProgressTracker";
+import TodayExperience from "@/components/dashboard/TodayExperience";
+import TodaysPlan from "@/components/dashboard/TodaysPlan";
+import type { WeeklyExperiment } from "@/lib/activation";
 
-export default function DashboardClient({ activationStatus }: { activationStatus: "missing" | "draft" | "active" }) {
-  const supabase = createClientComponentClient();
-  const [user, setUser] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-
-  // Get authed user
+export default function DashboardClient({
+  username,
+  experiment,
+  safetyReviewCount,
+}: {
+  username: string;
+  experiment: WeeklyExperiment | null;
+  safetyReviewCount: number;
+}) {
   useEffect(() => {
-    (async () => {
-      const { data, error } = await supabase.auth.getUser();
-      if (error) console.error("Auth fetch failed:", error.message);
-      setUser(data?.user ?? null);
-      setLoading(false);
-    })();
-  }, [supabase]);
-
-  // Ensure user exists in public.users
-  useEffect(() => {
-    fetch("/api/provision-user", { method: "POST" }).catch((err) =>
-      console.error("Provision user failed:", err)
-    );
+    fetch("/api/provision-user", { method: "POST" }).catch((error) => {
+      console.error("Provision user failed:", error);
+    });
   }, []);
 
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <Loader2 className="w-6 h-6 animate-spin text-purple-600" />
-      </div>
-    );
-  }
-
-  if (!user) {
-    if (typeof window !== "undefined") window.location.href = "/login";
-    return null;
-  }
-
-  const username = getFriendlyFirstName(user);
-
   return (
-    <main className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB]">
-      <div className="max-w-6xl mx-auto p-4 sm:p-6 space-y-5">
-        <header className="flex flex-col gap-4 rounded-2xl bg-[#041B2D] p-5 text-white shadow-sm sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[#8DE5D5]">LVE360 Agent Dashboard</div>
-            <h1 className="mt-1 text-3xl font-bold">Welcome back, {username}</h1>
-            <p className="mt-1 text-sm text-white/75">Your plan, progress, and next best action in one place.</p>
-          </div>
-          <nav className="flex flex-wrap gap-2" aria-label="Report actions">
-            <a href="/results" className="inline-flex items-center rounded-lg bg-white px-3 py-2 text-sm font-semibold text-[#041B2D] hover:bg-[#EAFBF8]">
-              <FileText className="mr-2 h-4 w-4" /> View Blueprint
-            </a>
-            <a href="/dashboard/my-quiz" className="inline-flex items-center rounded-lg border border-white/30 px-3 py-2 text-sm font-semibold text-white hover:bg-white/10">
-              <History className="mr-2 h-4 w-4" /> Reports & PDF
-            </a>
-          </nav>
-        </header>
+    <div className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB]">
+      <div className="mx-auto max-w-5xl space-y-5 p-4 sm:p-6">
+        <nav className="flex flex-wrap justify-end gap-2" aria-label="Blueprint and report actions">
+          <a href="/results" className="inline-flex items-center rounded-lg bg-white px-3 py-2 text-sm font-semibold text-[#041B2D] shadow-sm hover:bg-[#EAFBF8]">
+            <FileText className="mr-2 h-4 w-4" /> View Blueprint
+          </a>
+          <a href="/dashboard/my-quiz" className="inline-flex items-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-[#041B2D] hover:bg-slate-50">
+            <History className="mr-2 h-4 w-4" /> Reports and PDF
+          </a>
+        </nav>
 
-        {activationStatus !== "active" ? (
-          <section className="rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5 shadow-sm" aria-label="First-week setup">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Make your membership useful this week</p>
-                <h2 className="mt-1 text-xl font-bold text-[#041B2D]">{activationStatus === "draft" ? "Finish setting up your first practice" : "Build your first focused week"}</h2>
-                <p className="mt-1 text-sm leading-6 text-slate-600">Choose one repeatable lifestyle action, give it a cue, and define the version that counts on a hard day.</p>
-              </div>
-              <a href="/onboarding" className="inline-flex shrink-0 items-center justify-center rounded-xl bg-[#08A88A] px-5 py-3 font-bold text-white hover:bg-[#078B74]">
-                {activationStatus === "draft" ? "Continue setup" : "Set up my week"}
-              </a>
-            </div>
-          </section>
-        ) : null}
+        <TodayExperience
+          username={username}
+          initialExperiment={experiment}
+          safetyReviewCount={safetyReviewCount}
+        />
 
-        {/* 1) Greeting & Snapshot */}
-        <section aria-label="Snapshot and quick deltas">
-          <DashboardSnapshot />
-        </section>
-
-        {/* 2) Coach-first: Next Steps (smart CTAs) */}
-        <section id="next-steps" aria-label="Next steps">
-          <NextSteps />
-        </section>
-
-        {/* 3) Weekly focus */}
-        <section id="weekly-goal" aria-label="Weekly goal">
-          <WeeklyGoal />
-        </section>
-
-        {/* 4) Today’s Plan */}
-        <section id="todays-plan" aria-label="Today’s plan">
-          <TodaysPlan />
-        </section>
-
-        {/* 5) Daily Check-in */}
-        <section id="daily-log" aria-label="Daily check-in">
+        <section id="daily-log" aria-label="Quick check-in">
           <DailyLog />
         </section>
 
-        {/* 6) Progress Tracker (mini charts) */}
-        <section id="progress" aria-label="Progress tracker">
-          <ProgressTracker />
-        </section>
+        <Disclosure title="Your supplement routine" description="Track your current stack, review timing, and manage refills when you need it.">
+          <TodaysPlan />
+        </Disclosure>
 
-        {/* 7) Insights & Tweaks (AI summaries) */}
-        <section id="insights" aria-label="AI insights">
-          <InsightsFeed />
-        </section>
+        <Disclosure title="Progress and coaching" description="Explore trends and refresh your coaching insights.">
+          <div className="space-y-5">
+            <ProgressTracker />
+            <InsightsFeed />
+          </div>
+        </Disclosure>
       </div>
-    </main>
+    </div>
+  );
+}
+
+function Disclosure({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details className="group rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <summary className="flex cursor-pointer list-none items-center gap-4 p-5 marker:content-none sm:p-6">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-xl font-bold text-[#041B2D]">{title}</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
+        </div>
+        <ChevronDown className="h-5 w-5 shrink-0 text-[#087F72] transition-transform group-open:rotate-180" />
+      </summary>
+      <div className="border-t border-slate-200 p-4 sm:p-6">{children}</div>
+    </details>
   );
 }

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import GoalsTargetsEditor from "@/src/components/dashboard/GoalsTargetsEditor";
 import DashboardClient from "./DashboardClient";
+import { getFriendlyFirstName } from "@/src/lib/displayName";
+import type { WeeklyExperiment } from "@/lib/activation";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -23,20 +25,35 @@ export default async function Page() {
     return null;
   }
 
-  const { data: goals } = await supabase
-    .from("goals")
-    .select("*")
-    .eq("user_id", user.id)
-    .maybeSingle();
+  const [{ data: goals }, { data: experiment }, { data: latestStack }] = await Promise.all([
+    supabase.from("goals").select("*").eq("user_id", user.id).maybeSingle(),
+    supabase
+      .from("weekly_experiments")
+      .select("*")
+      .eq("user_id", user.id)
+      .in("status", ["draft", "active"])
+      .order("updated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("stacks")
+      .select("id")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
 
-  const { data: experiment } = await supabase
-    .from("weekly_experiments")
-    .select("status")
-    .eq("user_id", user.id)
-    .in("status", ["draft", "active"])
-    .order("updated_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  let safetyReviewCount = 0;
+  if (latestStack?.id) {
+    const { data: safetyItems } = await supabase
+      .from("stacks_items")
+      .select("notes")
+      .eq("stack_id", latestStack.id);
+    safetyReviewCount = (safetyItems ?? []).filter((item) =>
+      /clinician review|interaction|contraindicat|avoid|safety flag|use caution/i.test(item.notes ?? "")
+    ).length;
+  }
 
   const targetWeight = goals?.target_weight ?? null;
   const targetSleep = goals?.target_sleep ?? null;
@@ -44,9 +61,14 @@ export default async function Page() {
 
   return (
     <>
-      {/* Show the editor only if no targets set yet */}
+      <DashboardClient
+        username={getFriendlyFirstName(user)}
+        experiment={(experiment as WeeklyExperiment | null) ?? null}
+        safetyReviewCount={safetyReviewCount}
+      />
+
       {(targetWeight == null && targetSleep == null && targetEnergy == null) ? (
-        <div className="max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="mx-auto w-full max-w-5xl px-4 pb-8 sm:px-6">
           <GoalsTargetsEditor
             targetWeight={targetWeight}
             targetSleep={targetSleep}
@@ -55,8 +77,6 @@ export default async function Page() {
         </div>
       ) : null}
 
-      {/* Your existing dashboard app stays untouched */}
-      <DashboardClient activationStatus={experiment?.status === "active" ? "active" : experiment?.status === "draft" ? "draft" : "missing"} />
     </>
   );
 }

--- a/app/api/today/route.ts
+++ b/app/api/today/route.ts
@@ -1,0 +1,143 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+import type { WeeklyExperiment } from "@/lib/activation";
+import {
+  completionCount,
+  isCompletionKind,
+  parseLocalDate,
+  weekBounds,
+  type DailyPracticeCompletion,
+} from "@/lib/today";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+async function requirePaidUser() {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user?.id) return { error: "unauthorized" as const, user: null };
+
+  const { data: profile } = await getSupabaseAdmin()
+    .from("users")
+    .select("tier")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profile?.tier !== "premium" && profile?.tier !== "trial") {
+    return { error: "premium_required" as const, user: null };
+  }
+  return { error: null, user };
+}
+
+function authErrorResponse(error: "unauthorized" | "premium_required") {
+  return NextResponse.json({ ok: false, error }, { status: error === "unauthorized" ? 401 : 403 });
+}
+
+async function activeExperiment(userId: string): Promise<WeeklyExperiment | null> {
+  const { data, error } = await getSupabaseAdmin()
+    .from("weekly_experiments")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as WeeklyExperiment | null) ?? null;
+}
+
+async function loadWeek(userId: string, experimentId: string, localDate: string) {
+  const bounds = weekBounds(localDate);
+  const { data, error } = await getSupabaseAdmin()
+    .from("daily_practice_completions")
+    .select("completion_date, completion_kind")
+    .eq("user_id", userId)
+    .eq("experiment_id", experimentId)
+    .gte("completion_date", bounds.start)
+    .lte("completion_date", bounds.end)
+    .order("completion_date", { ascending: true });
+  if (error) throw error;
+  const completions = (data ?? []) as DailyPracticeCompletion[];
+  return { bounds, completions, completed: completionCount(completions) };
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const auth = await requirePaidUser();
+    if (auth.error || !auth.user) return authErrorResponse(auth.error ?? "unauthorized");
+
+    const localDate = parseLocalDate(req.nextUrl.searchParams.get("date"));
+    if (!localDate) return NextResponse.json({ ok: false, error: "invalid_local_date" }, { status: 400 });
+
+    const experiment = await activeExperiment(auth.user.id);
+    if (!experiment) return NextResponse.json({ ok: true, experiment: null, completions: [], completed: 0 });
+    const week = await loadWeek(auth.user.id, experiment.id, localDate);
+    return NextResponse.json({ ok: true, experiment, ...week });
+  } catch (error) {
+    console.error("[today] load failed", error);
+    return NextResponse.json({ ok: false, error: "today_unavailable" }, { status: 500 });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const auth = await requirePaidUser();
+    if (auth.error || !auth.user) return authErrorResponse(auth.error ?? "unauthorized");
+
+    const body = await req.json().catch(() => null);
+    const localDate = parseLocalDate(body?.date);
+    if (!localDate || !isCompletionKind(body?.kind)) {
+      return NextResponse.json({ ok: false, error: "invalid_completion" }, { status: 400 });
+    }
+
+    const experiment = await activeExperiment(auth.user.id);
+    if (!experiment) return NextResponse.json({ ok: false, error: "activation_required" }, { status: 409 });
+
+    const admin = getSupabaseAdmin();
+    const { error } = await admin.from("daily_practice_completions").upsert({
+      user_id: auth.user.id,
+      experiment_id: experiment.id,
+      completion_date: localDate,
+      completion_kind: body.kind,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: "user_id,experiment_id,completion_date" });
+    if (error) throw error;
+
+    const week = await loadWeek(auth.user.id, experiment.id, localDate);
+    return NextResponse.json({ ok: true, experiment, ...week });
+  } catch (error) {
+    console.error("[today] save failed", error);
+    return NextResponse.json({ ok: false, error: "today_unavailable" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const auth = await requirePaidUser();
+    if (auth.error || !auth.user) return authErrorResponse(auth.error ?? "unauthorized");
+
+    const localDate = parseLocalDate(req.nextUrl.searchParams.get("date"));
+    if (!localDate) return NextResponse.json({ ok: false, error: "invalid_local_date" }, { status: 400 });
+
+    const experiment = await activeExperiment(auth.user.id);
+    if (!experiment) return NextResponse.json({ ok: false, error: "activation_required" }, { status: 409 });
+
+    const { error } = await getSupabaseAdmin()
+      .from("daily_practice_completions")
+      .delete()
+      .eq("user_id", auth.user.id)
+      .eq("experiment_id", experiment.id)
+      .eq("completion_date", localDate);
+    if (error) throw error;
+
+    const week = await loadWeek(auth.user.id, experiment.id, localDate);
+    return NextResponse.json({ ok: true, experiment, ...week });
+  } catch (error) {
+    console.error("[today] undo failed", error);
+    return NextResponse.json({ ok: false, error: "today_unavailable" }, { status: 500 });
+  }
+}

--- a/src/_tests_/today.assert.ts
+++ b/src/_tests_/today.assert.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+
+import { completionCount, isCompletionKind, parseLocalDate, weekBounds } from "../lib/today";
+
+const now = new Date("2026-07-21T23:30:00.000Z");
+
+assert.equal(parseLocalDate("2026-07-21", now), "2026-07-21");
+assert.equal(parseLocalDate("2026-07-20", now), "2026-07-20");
+assert.equal(parseLocalDate("2026-07-22", now), "2026-07-22");
+assert.equal(parseLocalDate("2026-07-19", now), null);
+assert.equal(parseLocalDate("07/21/2026", now), null);
+assert.equal(parseLocalDate("2026-02-30", now), null);
+
+assert.equal(isCompletionKind("full"), true);
+assert.equal(isCompletionKind("minimum"), true);
+assert.equal(isCompletionKind("skipped"), false);
+
+assert.deepEqual(weekBounds("2026-07-21"), {
+  start: "2026-07-20",
+  end: "2026-07-26",
+  days: [
+    "2026-07-20", "2026-07-21", "2026-07-22", "2026-07-23",
+    "2026-07-24", "2026-07-25", "2026-07-26",
+  ],
+});
+
+assert.equal(completionCount([
+  { completion_date: "2026-07-20", completion_kind: "minimum" },
+  { completion_date: "2026-07-20", completion_kind: "full" },
+  { completion_date: "2026-07-21", completion_kind: "full" },
+]), 2);
+
+console.log("today assertions passed");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Check,
+  CheckCircle2,
+  Circle,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+} from "lucide-react";
+
+import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
+import type { CompletionKind, DailyPracticeCompletion } from "@/lib/today";
+
+type TodayResponse = {
+  ok: boolean;
+  experiment: WeeklyExperiment | null;
+  completions: DailyPracticeCompletion[];
+  completed: number;
+  bounds?: { start: string; end: string; days: string[] };
+  error?: string;
+};
+
+export default function TodayExperience({
+  username,
+  initialExperiment,
+  safetyReviewCount,
+}: {
+  username: string;
+  initialExperiment: WeeklyExperiment | null;
+  safetyReviewCount: number;
+}) {
+  const [localDate, setLocalDate] = useState("");
+  const [experiment, setExperiment] = useState(initialExperiment);
+  const [completions, setCompletions] = useState<DailyPracticeCompletion[]>([]);
+  const [weekDays, setWeekDays] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [loadingState, setLoadingState] = useState(!!initialExperiment);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const date = toLocalDate(new Date());
+    setLocalDate(date);
+    if (!initialExperiment) {
+      setLoadingState(false);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/today?date=${date}`, { cache: "no-store" })
+      .then(async (response) => {
+        const json = await response.json().catch(() => null) as TodayResponse | null;
+        if (!response.ok || !json?.ok) throw new Error("We could not load today's progress.");
+        return json;
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setExperiment(json.experiment);
+        setCompletions(json.completions ?? []);
+        setWeekDays(json.bounds?.days ?? []);
+      })
+      .catch((loadError: Error) => {
+        if (!cancelled) setError(loadError.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingState(false);
+      });
+    return () => { cancelled = true; };
+  }, [initialExperiment]);
+
+  const todayCompletion = useMemo(
+    () => completions.find((item) => item.completion_date === localDate) ?? null,
+    [completions, localDate]
+  );
+  const completedCount = useMemo(
+    () => new Set(completions.map((item) => item.completion_date)).size,
+    [completions]
+  );
+
+  async function saveCompletion(kind: CompletionKind) {
+    if (!localDate) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/today", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date: localDate, kind }),
+      });
+      const json = await response.json().catch(() => null) as TodayResponse | null;
+      if (!response.ok || !json?.ok) throw new Error("Your progress was not saved. Please try again.");
+      setCompletions(json.completions ?? []);
+      setWeekDays(json.bounds?.days ?? []);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Your progress was not saved.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function undoCompletion() {
+    if (!localDate) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/today?date=${localDate}`, { method: "DELETE" });
+      const json = await response.json().catch(() => null) as TodayResponse | null;
+      if (!response.ok || !json?.ok) throw new Error("We could not undo that completion.");
+      setCompletions(json.completions ?? []);
+      setWeekDays(json.bounds?.days ?? []);
+    } catch (undoError) {
+      setError(undoError instanceof Error ? undoError.message : "We could not undo that completion.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!experiment || experiment.status !== "active") {
+    return (
+      <section className="rounded-3xl border border-[#9DCFC3] bg-white p-6 shadow-sm sm:p-8" aria-labelledby="today-heading">
+        <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">Today</p>
+        <h1 id="today-heading" className="mt-2 text-3xl font-bold tracking-tight text-[#041B2D] sm:text-4xl">
+          Good to see you, {username}.
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">
+          Set up one focused practice so LVE360 can help you turn your Blueprint into a week you can actually follow.
+        </p>
+        <a href="/onboarding" className="mt-6 inline-flex items-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white hover:bg-[#06695F]">
+          Build my focused week <ArrowRight className="ml-2 h-4 w-4" />
+        </a>
+      </section>
+    );
+  }
+
+  const target = experiment.frequency_per_week ?? 1;
+  const targetMet = completedCount >= target;
+
+  return (
+    <section className="overflow-hidden rounded-3xl border border-[#9DCFC3] bg-white shadow-sm" aria-labelledby="today-heading">
+      <div className="bg-[#041B2D] px-6 py-5 text-white sm:px-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#8DE5D5]">Today</p>
+            <h1 id="today-heading" className="mt-1 text-2xl font-bold sm:text-3xl">Good to see you, {username}.</h1>
+          </div>
+          <p className="max-w-md text-sm leading-6 text-white/75">One useful action is enough to move this week forward.</p>
+        </div>
+      </div>
+
+      {safetyReviewCount > 0 ? (
+        <a href="/results" className="flex items-start gap-3 border-b border-amber-200 bg-amber-50 px-6 py-4 text-amber-950 hover:bg-amber-100 sm:px-8">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" />
+          <span className="text-sm leading-6">
+            <strong>{safetyReviewCount} {safetyReviewCount === 1 ? "item needs" : "items need"} safety review.</strong>{" "}
+            Keep those Blueprint notes in view before changing your stack.
+          </span>
+          <ArrowRight className="ml-auto mt-1 h-4 w-4 shrink-0" />
+        </a>
+      ) : null}
+
+      <div className="p-6 sm:p-8">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl">
+            <p className="flex items-center gap-2 text-sm font-semibold text-[#087F72]">
+              <Sparkles className="h-4 w-4" /> {identityLabel(experiment.identity_direction)}
+            </p>
+            <h2 className="mt-3 text-3xl font-bold leading-tight text-[#041B2D] sm:text-4xl">{experiment.action_label}</h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              <strong className="text-[#041B2D]">Your cue:</strong> After I {experiment.cue}
+            </p>
+          </div>
+          <a href="/onboarding" className="shrink-0 text-sm font-semibold text-[#087F72] hover:underline">Review practice</a>
+        </div>
+
+        <div className="mt-7 rounded-2xl border border-[#BCE3DA] bg-[#F4FAF8] p-4 sm:p-5">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">The version that counts on a hard day</p>
+          <p className="mt-2 text-lg font-semibold text-[#041B2D]">{experiment.minimum_version}</p>
+        </div>
+
+        <div className="mt-7" aria-live="polite">
+          {todayCompletion ? (
+            <div className="flex flex-col gap-4 rounded-2xl bg-[#EAFBF8] p-5 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <CheckCircle2 className="mt-0.5 h-6 w-6 shrink-0 text-[#087F72]" />
+                <div>
+                  <p className="font-bold text-[#041B2D]">
+                    {todayCompletion.completion_kind === "minimum" ? "Your minimum version counts." : "Today's practice is complete."}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-600">You kept the promise small and moved your identity forward.</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {todayCompletion.completion_kind === "minimum" ? (
+                  <button onClick={() => saveCompletion("full")} disabled={busy} className="rounded-lg bg-[#087F72] px-4 py-2 text-sm font-bold text-white disabled:opacity-60">
+                    Mark full version
+                  </button>
+                ) : null}
+                <button onClick={undoCompletion} disabled={busy} className="inline-flex items-center rounded-lg px-3 py-2 text-sm font-semibold text-slate-600 hover:bg-white disabled:opacity-60">
+                  <RotateCcw className="mr-2 h-4 w-4" /> Undo
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <button onClick={() => saveCompletion("full")} disabled={busy || !localDate} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#08A88A] px-6 py-3 text-base font-bold text-white shadow-sm hover:bg-[#078B74] disabled:opacity-60">
+                {busy ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : <Check className="mr-2 h-5 w-5" />} I did it today
+              </button>
+              <button onClick={() => saveCompletion("minimum")} disabled={busy || !localDate} className="min-h-12 rounded-xl border border-[#9DCFC3] px-5 py-3 text-sm font-bold text-[#087F72] hover:bg-[#F4FAF8] disabled:opacity-60">
+                I did the minimum version
+              </button>
+            </div>
+          )}
+          {error ? <p className="mt-3 text-sm font-medium text-rose-700">{error}</p> : null}
+        </div>
+
+        <div className="mt-8 border-t border-slate-200 pt-6">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">This week</p>
+              <p className="mt-1 text-lg font-bold text-[#041B2D]">{completedCount} of {target} planned reps</p>
+            </div>
+            <p className="text-sm text-slate-600">{targetMet ? "Weekly target met. Extra reps are optional." : "Small repetitions compound."}</p>
+          </div>
+          <div className="mt-4 grid grid-cols-7 gap-2" aria-label={`${completedCount} weekly completions`}>
+            {weekDays.map((day) => {
+              const completion = completions.find((item) => item.completion_date === day);
+              const isToday = day === localDate;
+              return (
+                <div key={day} className="text-center">
+                  <p className="mb-2 text-xs font-semibold text-slate-500">{weekdayLabel(day)}</p>
+                  <div className={`mx-auto flex h-9 w-9 items-center justify-center rounded-full border ${completion ? "border-[#08A88A] bg-[#08A88A] text-white" : isToday ? "border-[#087F72] bg-white text-[#087F72]" : "border-slate-200 bg-slate-50 text-slate-300"}`} title={completion ? `${completion.completion_kind} version completed` : "Not completed"}>
+                    {completion ? <Check className="h-4 w-4" /> : <Circle className="h-3 w-3" />}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {loadingState ? <p className="mt-3 text-xs text-slate-500">Loading this week's progress...</p> : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function toLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function weekdayLabel(date: string): string {
+  return new Intl.DateTimeFormat("en-US", { weekday: "narrow", timeZone: "UTC" }).format(new Date(`${date}T12:00:00.000Z`));
+}

--- a/src/lib/today.ts
+++ b/src/lib/today.ts
@@ -1,0 +1,37 @@
+export type CompletionKind = "full" | "minimum";
+
+export type DailyPracticeCompletion = {
+  completion_date: string;
+  completion_kind: CompletionKind;
+};
+
+const LOCAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 86_400_000;
+
+export function parseLocalDate(value: unknown, now = new Date()): string | null {
+  if (typeof value !== "string" || !LOCAL_DATE_PATTERN.test(value)) return null;
+  const parsed = new Date(`${value}T12:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) return null;
+
+  const serverDay = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const requestedDay = Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+  return Math.abs(requestedDay - serverDay) <= DAY_MS ? value : null;
+}
+
+export function isCompletionKind(value: unknown): value is CompletionKind {
+  return value === "full" || value === "minimum";
+}
+
+export function weekBounds(localDate: string): { start: string; end: string; days: string[] } {
+  const date = new Date(`${localDate}T12:00:00.000Z`);
+  const mondayOffset = (date.getUTCDay() + 6) % 7;
+  const startDate = new Date(date.getTime() - mondayOffset * DAY_MS);
+  const days = Array.from({ length: 7 }, (_, index) => {
+    return new Date(startDate.getTime() + index * DAY_MS).toISOString().slice(0, 10);
+  });
+  return { start: days[0], end: days[6], days };
+}
+
+export function completionCount(completions: DailyPracticeCompletion[]): number {
+  return new Set(completions.map((completion) => completion.completion_date)).size;
+}

--- a/supabase/migrations/20260722020824_today_dashboard_v1.sql
+++ b/supabase/migrations/20260722020824_today_dashboard_v1.sql
@@ -1,0 +1,30 @@
+create table if not exists public.daily_practice_completions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on update cascade on delete cascade,
+  experiment_id uuid not null references public.weekly_experiments(id) on update cascade on delete cascade,
+  completion_date date not null,
+  completion_kind text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint daily_practice_completions_kind check (completion_kind in ('full', 'minimum')),
+  constraint daily_practice_completions_one_per_day unique (user_id, experiment_id, completion_date)
+);
+
+create index if not exists daily_practice_completions_user_date_idx
+  on public.daily_practice_completions (user_id, completion_date desc);
+
+create index if not exists daily_practice_completions_experiment_date_idx
+  on public.daily_practice_completions (experiment_id, completion_date);
+
+alter table public.daily_practice_completions enable row level security;
+
+create policy "daily_practice_completions: select own"
+  on public.daily_practice_completions for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+grant select on public.daily_practice_completions to authenticated;
+grant select, insert, update, delete on public.daily_practice_completions to service_role;
+
+comment on table public.daily_practice_completions is
+  'One privacy-minimized completion state per member, active lifestyle practice, and local calendar day. Writes are handled by the paid Today API.';

--- a/supabase/migrations/20260722021418_lock_down_today_writes.sql
+++ b/supabase/migrations/20260722021418_lock_down_today_writes.sql
@@ -1,0 +1,5 @@
+revoke all on table public.daily_practice_completions from public, anon;
+revoke insert, update, delete on table public.daily_practice_completions from authenticated;
+
+grant select on table public.daily_practice_completions to authenticated;
+grant select, insert, update, delete on table public.daily_practice_completions to service_role;


### PR DESCRIPTION
## Purpose

Make the paid dashboard useful the moment a member opens it. Today now starts with one identity-based lifestyle practice, its cue, the version that counts on a hard day, and one clear completion action.

## What changed

- replaces the crowded dashboard opening with a focused Today experience
- keeps one primary action above the fold and makes the minimum version a clear secondary choice
- shows the member's identity direction, active practice, cue, weekly frequency, and minimum version
- persists one full or minimum completion per active practice and local calendar day
- shows weekly repetitions without punitive streak language
- keeps the quick sleep, energy, weight, and notes check-in visible
- moves supplement tracking, trends, and coaching behind progressive disclosure
- keeps detected safety-review flags visible above the primary action
- preserves the current stack, refill workflow, progress charts, and coaching data

## Data and security

- adds `daily_practice_completions` with one row per member, practice, and local date
- accepts only `full` or `minimum` completion states
- validates that the requested local date is today within the normal timezone boundary
- requires an authenticated premium or trial member for every Today API request
- enables owner-only RLS reads
- removes anonymous access and direct client write privileges
- permits writes only through the paid server API
- applies explicit grants for Supabase's current Data API exposure model
- both migrations are additive and have been applied to the live project

## Verification

- `npm run typecheck`
- focused Today date, completion-kind, week-boundary, and idempotent-count assertions
- existing activation assertions
- production build with safe placeholder configuration
- local browser render check for primary-action hierarchy and interaction readiness
- unauthenticated `/api/today` request returns HTTP 401
- live schema inspection confirms RLS is enabled and the owner policy exists
- live privilege inspection confirms anonymous users have no access, authenticated clients are read-only, and only the service role can write
- Supabase security advisor reports no new Today-table findings

## Not yet verified

- full completion, minimum completion, upgrade-to-full, and undo with a real paid account in the Vercel preview
- mobile placement in the deployed preview
- safety-review count against representative paid beta stacks
- local `qa:env` could not run because this checkout intentionally has no local environment file; Vercel preview checks the configured environment

## Risks and rollback

The application change can be reverted without affecting the Blueprint, activation flow, logs, or supplement data. The new completion table is additive and can remain dormant during an application rollback. Do not drop it after members have recorded completions.

## Follow-up

The next retention PR should add the weekly review and next-week reset around this daily loop.