### PR TITLE
Audit PR 07: Add weekly review and experiment adjustment

### DIFF
--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from "next/navigation";
+
+import { requireTier } from "@/app/_auth/requireTier";
+import WeeklyReviewClient from "@/components/review/WeeklyReviewClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function WeeklyReviewPage({ searchParams }: { searchParams: { experiment?: string } }) {
+  await requireTier(["premium", "trial"], { next: "/review" });
+  if (!searchParams.experiment) redirect("/dashboard");
+  return <WeeklyReviewClient experimentId={searchParams.experiment} />;
+}

--- a/app/api/today/route.ts
+++ b/app/api/today/route.ts
@@ -50,13 +50,13 @@ async function activeExperiment(userId: string): Promise<WeeklyExperiment | null
   return (data as WeeklyExperiment | null) ?? null;
 }
 
-async function loadWeek(userId: string, experimentId: string, localDate: string) {
-  const bounds = weekBounds(localDate);
+async function loadWeek(userId: string, experiment: WeeklyExperiment) {
+  const bounds = weekBounds(experiment.week_start);
   const { data, error } = await getSupabaseAdmin()
     .from("daily_practice_completions")
     .select("completion_date, completion_kind")
     .eq("user_id", userId)
-    .eq("experiment_id", experimentId)
+    .eq("experiment_id", experiment.id)
     .gte("completion_date", bounds.start)
     .lte("completion_date", bounds.end)
     .order("completion_date", { ascending: true });
@@ -75,7 +75,7 @@ export async function GET(req: NextRequest) {
 
     const experiment = await activeExperiment(auth.user.id);
     if (!experiment) return NextResponse.json({ ok: true, experiment: null, completions: [], completed: 0 });
-    const week = await loadWeek(auth.user.id, experiment.id, localDate);
+    const week = await loadWeek(auth.user.id, experiment);
     return NextResponse.json({ ok: true, experiment, ...week });
   } catch (error) {
     console.error("[today] load failed", error);
@@ -96,6 +96,10 @@ export async function PUT(req: NextRequest) {
 
     const experiment = await activeExperiment(auth.user.id);
     if (!experiment) return NextResponse.json({ ok: false, error: "activation_required" }, { status: 409 });
+    const experimentWeek = weekBounds(experiment.week_start);
+    if (localDate < experimentWeek.start || localDate > experimentWeek.end) {
+      return NextResponse.json({ ok: false, error: "date_outside_active_week" }, { status: 409 });
+    }
 
     const admin = getSupabaseAdmin();
     const { error } = await admin.from("daily_practice_completions").upsert({
@@ -107,7 +111,7 @@ export async function PUT(req: NextRequest) {
     }, { onConflict: "user_id,experiment_id,completion_date" });
     if (error) throw error;
 
-    const week = await loadWeek(auth.user.id, experiment.id, localDate);
+    const week = await loadWeek(auth.user.id, experiment);
     return NextResponse.json({ ok: true, experiment, ...week });
   } catch (error) {
     console.error("[today] save failed", error);
@@ -125,6 +129,10 @@ export async function DELETE(req: NextRequest) {
 
     const experiment = await activeExperiment(auth.user.id);
     if (!experiment) return NextResponse.json({ ok: false, error: "activation_required" }, { status: 409 });
+    const experimentWeek = weekBounds(experiment.week_start);
+    if (localDate < experimentWeek.start || localDate > experimentWeek.end) {
+      return NextResponse.json({ ok: false, error: "date_outside_active_week" }, { status: 409 });
+    }
 
     const { error } = await getSupabaseAdmin()
       .from("daily_practice_completions")
@@ -134,7 +142,7 @@ export async function DELETE(req: NextRequest) {
       .eq("completion_date", localDate);
     if (error) throw error;
 
-    const week = await loadWeek(auth.user.id, experiment.id, localDate);
+    const week = await loadWeek(auth.user.id, experiment);
     return NextResponse.json({ ok: true, experiment, ...week });
   } catch (error) {
     console.error("[today] undo failed", error);

--- a/app/api/weekly-review/route.ts
+++ b/app/api/weekly-review/route.ts
@@ -1,0 +1,127 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+import type { WeeklyExperiment } from "@/lib/activation";
+import { isReviewDecision, isReviewDue, validateNextPlan } from "@/lib/weeklyReview";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+async function requirePaidUser() {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user?.id) return { error: "unauthorized" as const, user: null };
+  const { data: profile } = await getSupabaseAdmin().from("users").select("tier").eq("id", user.id).maybeSingle();
+  if (profile?.tier !== "premium" && profile?.tier !== "trial") return { error: "premium_required" as const, user: null };
+  return { error: null, user };
+}
+
+function authErrorResponse(error: "unauthorized" | "premium_required") {
+  return NextResponse.json({ ok: false, error }, { status: error === "unauthorized" ? 401 : 403 });
+}
+
+async function loadExperiment(userId: string, experimentId: string): Promise<WeeklyExperiment | null> {
+  const { data, error } = await getSupabaseAdmin()
+    .from("weekly_experiments")
+    .select("*")
+    .eq("id", experimentId)
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .maybeSingle();
+  if (error) throw error;
+  return (data as WeeklyExperiment | null) ?? null;
+}
+
+async function countCompletions(userId: string, experiment: WeeklyExperiment): Promise<number> {
+  const { count, error } = await getSupabaseAdmin()
+    .from("daily_practice_completions")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("experiment_id", experiment.id)
+    .gte("completion_date", experiment.week_start)
+    .lte("completion_date", addDays(experiment.week_start, 6));
+  if (error) throw error;
+  return count ?? 0;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const auth = await requirePaidUser();
+    if (auth.error || !auth.user) return authErrorResponse(auth.error ?? "unauthorized");
+    const experimentId = req.nextUrl.searchParams.get("experiment");
+    if (!experimentId) return NextResponse.json({ ok: false, error: "experiment_required" }, { status: 400 });
+    const experiment = await loadExperiment(auth.user.id, experimentId);
+    if (!experiment) return NextResponse.json({ ok: false, error: "experiment_not_found" }, { status: 404 });
+    if (!isReviewDue(experiment.week_start, todayUtc())) {
+      return NextResponse.json({ ok: false, error: "review_not_due" }, { status: 409 });
+    }
+    const completed = await countCompletions(auth.user.id, experiment);
+    const admin = getSupabaseAdmin();
+    const { error } = await admin.from("weekly_experiment_reviews").upsert({
+      user_id: auth.user.id,
+      experiment_id: experiment.id,
+      completion_count: completed,
+      target_count: experiment.frequency_per_week ?? 1,
+      opened_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }, { onConflict: "experiment_id", ignoreDuplicates: true });
+    if (error) throw error;
+    return NextResponse.json({ ok: true, experiment, completed, target: experiment.frequency_per_week ?? 1 });
+  } catch (error) {
+    console.error("[weekly-review] load failed", error);
+    return NextResponse.json({ ok: false, error: "review_unavailable" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const auth = await requirePaidUser();
+    if (auth.error || !auth.user) return authErrorResponse(auth.error ?? "unauthorized");
+    const body = await req.json().catch(() => null) as Record<string, unknown> | null;
+    const experimentId = typeof body?.experiment_id === "string" ? body.experiment_id : "";
+    const decision = body?.decision;
+    const difficulty = Number(body?.difficulty);
+    const valueRating = Number(body?.value_rating);
+    if (!experimentId || !isReviewDecision(decision) || !Number.isInteger(difficulty) || difficulty < 1 || difficulty > 5 || !Number.isInteger(valueRating) || valueRating < 1 || valueRating > 5) {
+      return NextResponse.json({ ok: false, error: "invalid_review" }, { status: 400 });
+    }
+    const experiment = await loadExperiment(auth.user.id, experimentId);
+    if (!experiment) return NextResponse.json({ ok: false, error: "experiment_not_found" }, { status: 404 });
+    if (!isReviewDue(experiment.week_start, todayUtc())) return NextResponse.json({ ok: false, error: "review_not_due" }, { status: 409 });
+    const nextPlan = decision === "pause" ? null : validateNextPlan(body?.next_plan);
+    if (decision !== "pause" && !nextPlan) return NextResponse.json({ ok: false, error: "invalid_next_plan" }, { status: 400 });
+
+    const { data, error } = await getSupabaseAdmin().rpc("complete_weekly_review", {
+      p_user_id: auth.user.id,
+      p_experiment_id: experiment.id,
+      p_difficulty: difficulty,
+      p_value_rating: valueRating,
+      p_decision: decision,
+      p_action_label: nextPlan?.action_label ?? null,
+      p_cue: nextPlan?.cue ?? null,
+      p_frequency_per_week: nextPlan?.frequency_per_week ?? null,
+      p_minimum_version: nextPlan?.minimum_version ?? null,
+    });
+    if (error) {
+      if (/already_completed/i.test(error.message)) return NextResponse.json({ ok: false, error: "review_already_completed" }, { status: 409 });
+      throw error;
+    }
+    return NextResponse.json({ ok: true, next_experiment_id: data ?? null });
+  } catch (error) {
+    console.error("[weekly-review] save failed", error);
+    return NextResponse.json({ ok: false, error: "review_unavailable" }, { status: 500 });
+  }
+}
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDays(date: string, days: number): string {
+  const value = new Date(`${date}T12:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+}

--- a/src/_tests_/weeklyReview.assert.ts
+++ b/src/_tests_/weeklyReview.assert.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+
+import type { WeeklyExperiment } from "../lib/activation";
+import { isReviewDue, reviewDueDate, suggestedNextPlan, validateNextPlan } from "../lib/weeklyReview";
+
+const experiment: WeeklyExperiment = {
+  id: "experiment-1",
+  user_id: "user-1",
+  source_stack_id: null,
+  source_action_id: null,
+  identity_direction: "movement",
+  action_label: "Take a 10-minute walk after lunch",
+  cue: "finish lunch",
+  frequency_per_week: 4,
+  minimum_version: "Walk for two minutes",
+  reminder_preference: "none",
+  onboarding_step: 6,
+  status: "active",
+  week_start: "2026-07-20",
+  activated_at: "2026-07-20T12:00:00.000Z",
+  created_at: "2026-07-20T12:00:00.000Z",
+  updated_at: "2026-07-20T12:00:00.000Z",
+};
+
+assert.equal(reviewDueDate(experiment.week_start), "2026-07-26");
+assert.equal(isReviewDue(experiment.week_start, "2026-07-25"), false);
+assert.equal(isReviewDue(experiment.week_start, "2026-07-26"), true);
+assert.equal(suggestedNextPlan(experiment, "shrink")?.frequency_per_week, 3);
+assert.equal(suggestedNextPlan(experiment, "advance")?.frequency_per_week, 5);
+assert.equal(suggestedNextPlan(experiment, "pause"), null);
+assert.deepEqual(validateNextPlan({
+  action_label: "  Take a short walk after lunch  ",
+  cue: "  finish lunch ",
+  frequency_per_week: 3,
+  minimum_version: " Walk for one minute ",
+}), {
+  action_label: "Take a short walk after lunch",
+  cue: "finish lunch",
+  frequency_per_week: 3,
+  minimum_version: "Walk for one minute",
+});
+assert.equal(validateNextPlan({
+  action_label: "Change my medication dose",
+  cue: "finish lunch",
+  frequency_per_week: 3,
+  minimum_version: "Take half the medication",
+}), null);
+
+console.log("weekly review assertions passed");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -14,6 +14,7 @@ import {
 
 import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
 import type { CompletionKind, DailyPracticeCompletion } from "@/lib/today";
+import { isReviewDue, reviewDueDate } from "@/lib/weeklyReview";
 
 type TodayResponse = {
   ok: boolean;
@@ -137,6 +138,9 @@ export default function TodayExperience({
 
   const target = experiment.frequency_per_week ?? 1;
   const targetMet = completedCount >= target;
+  const reviewDue = !!localDate && isReviewDue(experiment.week_start, localDate);
+  const weekEnded = !!localDate && localDate > reviewDueDate(experiment.week_start);
+  const weekNotStarted = !!localDate && localDate < experiment.week_start;
 
   return (
     <section className="overflow-hidden rounded-3xl border border-[#9DCFC3] bg-white shadow-sm" aria-labelledby="today-heading">
@@ -161,6 +165,14 @@ export default function TodayExperience({
         </a>
       ) : null}
 
+      {reviewDue ? (
+        <a href={`/review?experiment=${encodeURIComponent(experiment.id)}`} className="flex items-start gap-3 border-b border-[#9DCFC3] bg-[#EAFBF8] px-6 py-4 text-[#041B2D] hover:bg-[#DDF7F1] sm:px-8">
+          <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#087F72]" />
+          <span className="text-sm leading-6"><strong>Your weekly review is ready.</strong> Notice what worked and shape your next focused week.</span>
+          <ArrowRight className="ml-auto mt-1 h-4 w-4 shrink-0" />
+        </a>
+      ) : null}
+
       <div className="p-6 sm:p-8">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-2xl">
@@ -181,7 +193,17 @@ export default function TodayExperience({
         </div>
 
         <div className="mt-7" aria-live="polite">
-          {todayCompletion ? (
+          {weekEnded ? (
+            <div className="rounded-2xl bg-[#EAFBF8] p-5">
+              <p className="font-bold text-[#041B2D]">Review this week before recording another repetition.</p>
+              <a href={`/review?experiment=${encodeURIComponent(experiment.id)}`} className="mt-3 inline-flex items-center text-sm font-bold text-[#087F72] hover:underline">Open weekly review <ArrowRight className="ml-2 h-4 w-4" /></a>
+            </div>
+          ) : weekNotStarted ? (
+            <div className="rounded-2xl bg-[#EAFBF8] p-5">
+              <p className="font-bold text-[#041B2D]">Your next focused week is ready.</p>
+              <p className="mt-1 text-sm text-slate-600">Come back when the new week begins to record your first repetition.</p>
+            </div>
+          ) : todayCompletion ? (
             <div className="flex flex-col gap-4 rounded-2xl bg-[#EAFBF8] p-5 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-start gap-3">
                 <CheckCircle2 className="mt-0.5 h-6 w-6 shrink-0 text-[#087F72]" />

--- a/src/components/review/WeeklyReviewClient.tsx
+++ b/src/components/review/WeeklyReviewClient.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ArrowRight, Check, Loader2, Pause, RefreshCw, Repeat2, TrendingUp } from "lucide-react";
+
+import type { WeeklyExperiment } from "@/lib/activation";
+import { suggestedNextPlan, type NextWeekPlan, type ReviewDecision } from "@/lib/weeklyReview";
+
+type ReviewResponse = {
+  ok: boolean;
+  experiment?: WeeklyExperiment;
+  completed?: number;
+  target?: number;
+  error?: string;
+};
+
+const decisions: Array<{ value: ReviewDecision; title: string; description: string; icon: typeof Check }> = [
+  { value: "keep", title: "Keep it", description: "Repeat the same practice next week.", icon: Repeat2 },
+  { value: "shrink", title: "Make it smaller", description: "Lower the weekly target so it is easier to repeat.", icon: ArrowLeft },
+  { value: "swap", title: "Swap it", description: "Choose a different small lifestyle practice.", icon: RefreshCw },
+  { value: "pause", title: "Pause", description: "Close this experiment without starting another.", icon: Pause },
+  { value: "advance", title: "Build on it", description: "Add one repetition next week.", icon: TrendingUp },
+];
+
+export default function WeeklyReviewClient({ experimentId }: { experimentId: string }) {
+  const [experiment, setExperiment] = useState<WeeklyExperiment | null>(null);
+  const [completed, setCompleted] = useState(0);
+  const [target, setTarget] = useState(1);
+  const [difficulty, setDifficulty] = useState(0);
+  const [valueRating, setValueRating] = useState(0);
+  const [decision, setDecision] = useState<ReviewDecision | null>(null);
+  const [nextPlan, setNextPlan] = useState<NextWeekPlan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/weekly-review?experiment=${encodeURIComponent(experimentId)}`, { cache: "no-store" })
+      .then(async (response) => {
+        const json = await response.json().catch(() => null) as ReviewResponse | null;
+        if (!response.ok || !json?.ok || !json.experiment) throw new Error(reviewError(json?.error));
+        return json;
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setExperiment(json.experiment ?? null);
+        setCompleted(json.completed ?? 0);
+        setTarget(json.target ?? 1);
+      })
+      .catch((loadError: Error) => { if (!cancelled) setError(loadError.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [experimentId]);
+
+  const ready = useMemo(() => difficulty > 0 && valueRating > 0 && !!decision && (decision === "pause" || !!nextPlan), [difficulty, valueRating, decision, nextPlan]);
+
+  function chooseDecision(value: ReviewDecision) {
+    setDecision(value);
+    setNextPlan(experiment ? suggestedNextPlan(experiment, value) : null);
+  }
+
+  async function finishReview() {
+    if (!ready || !decision) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/weekly-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ experiment_id: experimentId, difficulty, value_rating: valueRating, decision, next_plan: nextPlan }),
+      });
+      const json = await response.json().catch(() => null) as ReviewResponse | null;
+      if (!response.ok || !json?.ok) throw new Error(reviewError(json?.error));
+      window.location.assign("/dashboard");
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Your review was not saved.");
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <ReviewShell><div className="flex min-h-72 items-center justify-center"><Loader2 className="h-7 w-7 animate-spin text-[#087F72]" /></div></ReviewShell>;
+  if (!experiment) return <ReviewShell><p className="rounded-2xl bg-rose-50 p-5 text-rose-800">{error ?? "This review is not available."}</p></ReviewShell>;
+
+  return (
+    <ReviewShell>
+      <a href="/dashboard" className="inline-flex items-center text-sm font-semibold text-[#087F72] hover:underline"><ArrowLeft className="mr-2 h-4 w-4" /> Back to Today</a>
+      <p className="mt-8 text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">Your weekly review</p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight text-[#041B2D] sm:text-4xl">Notice what worked. Shape the next week.</h1>
+      <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">This is a short experiment review, not a health outcome assessment. Use it to make your practice easier to repeat.</p>
+
+      <section className="mt-8 rounded-3xl bg-[#041B2D] p-6 text-white sm:p-8">
+        <p className="text-sm font-semibold text-[#8DE5D5]">This week</p>
+        <h2 className="mt-2 text-2xl font-bold">{experiment.action_label}</h2>
+        <p className="mt-5 text-4xl font-bold">{completed} <span className="text-lg font-medium text-white/70">of {target} planned reps</span></p>
+        <p className="mt-2 text-sm text-white/70">Every completed repetition counts, including the minimum version.</p>
+      </section>
+
+      <Rating title="How difficult was this practice to repeat?" low="Very easy" high="Very hard" value={difficulty} onChange={setDifficulty} />
+      <Rating title="How useful did this practice feel?" low="Not useful" high="Very useful" value={valueRating} onChange={setValueRating} />
+
+      <section className="mt-10">
+        <h2 className="text-2xl font-bold text-[#041B2D]">What should happen next?</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {decisions.map((item) => {
+            const Icon = item.icon;
+            const selected = decision === item.value;
+            return (
+              <button key={item.value} type="button" onClick={() => chooseDecision(item.value)} className={`rounded-2xl border p-5 text-left transition ${selected ? "border-[#087F72] bg-[#EAFBF8] ring-2 ring-[#087F72]/20" : "border-slate-200 bg-white hover:border-[#9DCFC3]"}`}>
+                <Icon className="h-5 w-5 text-[#087F72]" />
+                <span className="mt-3 block font-bold text-[#041B2D]">{item.title}</span>
+                <span className="mt-1 block text-sm leading-6 text-slate-600">{item.description}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {decision && nextPlan ? <NextPlanEditor plan={nextPlan} onChange={setNextPlan} swap={decision === "swap"} /> : null}
+      {decision === "pause" ? <p className="mt-6 rounded-2xl bg-[#F4FAF8] p-5 text-sm leading-6 text-slate-700">Your completed week will stay in your history. You can start a new focused week from Today whenever you are ready.</p> : null}
+      {error ? <p className="mt-5 text-sm font-semibold text-rose-700">{error}</p> : null}
+      <button onClick={finishReview} disabled={!ready || saving} className="mt-8 inline-flex min-h-12 items-center rounded-xl bg-[#08A88A] px-6 py-3 font-bold text-white hover:bg-[#078B74] disabled:cursor-not-allowed disabled:opacity-50">
+        {saving ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : <Check className="mr-2 h-5 w-5" />} Finish review <ArrowRight className="ml-2 h-4 w-4" />
+      </button>
+    </ReviewShell>
+  );
+}
+
+function Rating({ title, low, high, value, onChange }: { title: string; low: string; high: string; value: number; onChange: (value: number) => void }) {
+  return (
+    <fieldset className="mt-9">
+      <legend className="text-xl font-bold text-[#041B2D]">{title}</legend>
+      <div className="mt-4 flex max-w-md gap-2">
+        {[1, 2, 3, 4, 5].map((rating) => <button key={rating} type="button" aria-label={`${title} ${rating} out of 5`} aria-pressed={value === rating} onClick={() => onChange(rating)} className={`h-12 flex-1 rounded-xl border font-bold ${value === rating ? "border-[#087F72] bg-[#087F72] text-white" : "border-slate-200 bg-white text-slate-700 hover:border-[#9DCFC3]"}`}>{rating}</button>)}
+      </div>
+      <div className="mt-2 flex max-w-md justify-between text-xs text-slate-500"><span>{low}</span><span>{high}</span></div>
+    </fieldset>
+  );
+}
+
+function NextPlanEditor({ plan, onChange, swap }: { plan: NextWeekPlan; onChange: (plan: NextWeekPlan) => void; swap: boolean }) {
+  return (
+    <section className="mt-8 rounded-3xl border border-[#BCE3DA] bg-[#F4FAF8] p-6 sm:p-8">
+      <h2 className="text-xl font-bold text-[#041B2D]">{swap ? "Choose next week's practice" : "Your next week"}</h2>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Practice<input value={plan.action_label} onChange={(event) => onChange({ ...plan, action_label: event.target.value })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal" /></label>
+      <label className="mt-4 block text-sm font-bold text-[#041B2D]">After I...<input value={plan.cue} onChange={(event) => onChange({ ...plan, cue: event.target.value })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal" /></label>
+      <div className="mt-4 grid gap-4 sm:grid-cols-[160px_1fr]">
+        <label className="block text-sm font-bold text-[#041B2D]">Reps per week<input type="number" min={1} max={7} value={plan.frequency_per_week} onChange={(event) => onChange({ ...plan, frequency_per_week: Number(event.target.value) })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal" /></label>
+        <label className="block text-sm font-bold text-[#041B2D]">Minimum version<input value={plan.minimum_version} onChange={(event) => onChange({ ...plan, minimum_version: event.target.value })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal" /></label>
+      </div>
+    </section>
+  );
+}
+
+function ReviewShell({ children }: { children: React.ReactNode }) {
+  return <main className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB] px-4 py-8 sm:px-6"><div className="mx-auto max-w-3xl rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-10">{children}</div></main>;
+}
+
+function reviewError(error?: string): string {
+  if (error === "review_not_due") return "Your weekly review opens on the final day of this focused week.";
+  if (error === "review_already_completed") return "This week has already been reviewed.";
+  if (error === "invalid_next_plan") return "Check your next practice, cue, target, and minimum version.";
+  return "Your weekly review is unavailable right now. Please try again.";
+}

--- a/src/lib/weeklyReview.ts
+++ b/src/lib/weeklyReview.ts
@@ -1,0 +1,49 @@
+import { cleanText, isSafeLifestyleAction, type WeeklyExperiment } from "./activation";
+
+export const REVIEW_DECISIONS = ["keep", "shrink", "swap", "pause", "advance"] as const;
+export type ReviewDecision = (typeof REVIEW_DECISIONS)[number];
+
+export type NextWeekPlan = {
+  action_label: string;
+  cue: string;
+  frequency_per_week: number;
+  minimum_version: string;
+};
+
+const DAY_MS = 86_400_000;
+
+export function reviewDueDate(weekStart: string): string {
+  const start = new Date(`${weekStart}T12:00:00.000Z`);
+  return new Date(start.getTime() + 6 * DAY_MS).toISOString().slice(0, 10);
+}
+
+export function isReviewDue(weekStart: string, date: string): boolean {
+  return date >= reviewDueDate(weekStart);
+}
+
+export function isReviewDecision(value: unknown): value is ReviewDecision {
+  return typeof value === "string" && REVIEW_DECISIONS.includes(value as ReviewDecision);
+}
+
+export function suggestedNextPlan(experiment: WeeklyExperiment, decision: ReviewDecision): NextWeekPlan | null {
+  if (decision === "pause") return null;
+  const frequency = experiment.frequency_per_week ?? 1;
+  return {
+    action_label: experiment.action_label ?? "",
+    cue: experiment.cue ?? "",
+    frequency_per_week: decision === "shrink" ? Math.max(1, frequency - 1) : decision === "advance" ? Math.min(7, frequency + 1) : frequency,
+    minimum_version: experiment.minimum_version ?? "",
+  };
+}
+
+export function validateNextPlan(value: unknown): NextWeekPlan | null {
+  if (!value || typeof value !== "object") return null;
+  const plan = value as Record<string, unknown>;
+  const action = cleanText(plan.action_label, 240);
+  const cue = cleanText(plan.cue, 160);
+  const minimum = cleanText(plan.minimum_version, 160);
+  const frequency = Number(plan.frequency_per_week);
+  if (!isSafeLifestyleAction(action) || !cue || cue.length < 2 || !isSafeLifestyleAction(minimum)) return null;
+  if (!Number.isInteger(frequency) || frequency < 1 || frequency > 7) return null;
+  return { action_label: action, cue, frequency_per_week: frequency, minimum_version: minimum };
+}

--- a/supabase/migrations/20260722030000_weekly_review_rollover.sql
+++ b/supabase/migrations/20260722030000_weekly_review_rollover.sql
@@ -1,0 +1,148 @@
+create table if not exists public.weekly_experiment_reviews (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on update cascade on delete cascade,
+  experiment_id uuid not null references public.weekly_experiments(id) on update cascade on delete cascade,
+  completion_count smallint not null,
+  target_count smallint not null,
+  difficulty smallint,
+  value_rating smallint,
+  decision text,
+  status text not null default 'draft',
+  next_experiment_id uuid references public.weekly_experiments(id) on update cascade on delete set null,
+  opened_at timestamptz not null default now(),
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint weekly_experiment_reviews_one_per_experiment unique (experiment_id),
+  constraint weekly_experiment_reviews_completion_count check (completion_count between 0 and 7),
+  constraint weekly_experiment_reviews_target_count check (target_count between 1 and 7),
+  constraint weekly_experiment_reviews_difficulty check (difficulty is null or difficulty between 1 and 5),
+  constraint weekly_experiment_reviews_value check (value_rating is null or value_rating between 1 and 5),
+  constraint weekly_experiment_reviews_decision check (decision is null or decision in ('keep', 'shrink', 'swap', 'pause', 'advance')),
+  constraint weekly_experiment_reviews_status check (status in ('draft', 'completed')),
+  constraint weekly_experiment_reviews_completed_fields check (
+    status <> 'completed' or (difficulty is not null and value_rating is not null and decision is not null and completed_at is not null)
+  )
+);
+
+create index if not exists weekly_experiment_reviews_user_completed_idx
+  on public.weekly_experiment_reviews (user_id, completed_at desc);
+
+alter table public.weekly_experiment_reviews enable row level security;
+
+create policy "weekly_experiment_reviews: select own"
+  on public.weekly_experiment_reviews for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.weekly_experiment_reviews from public, anon, authenticated;
+grant select on table public.weekly_experiment_reviews to authenticated;
+grant select, insert, update, delete on table public.weekly_experiment_reviews to service_role;
+
+create or replace function public.complete_weekly_review(
+  p_user_id uuid,
+  p_experiment_id uuid,
+  p_difficulty smallint,
+  p_value_rating smallint,
+  p_decision text,
+  p_action_label text default null,
+  p_cue text default null,
+  p_frequency_per_week smallint default null,
+  p_minimum_version text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_experiment public.weekly_experiments%rowtype;
+  next_id uuid;
+  completed_reps smallint;
+begin
+  if p_difficulty not between 1 and 5
+    or p_value_rating not between 1 and 5
+    or p_decision not in ('keep', 'shrink', 'swap', 'pause', 'advance') then
+    raise exception 'invalid_review';
+  end if;
+
+  select * into current_experiment
+  from public.weekly_experiments
+  where id = p_experiment_id and user_id = p_user_id and status = 'active'
+  for update;
+
+  if not found then
+    raise exception 'active_experiment_not_found';
+  end if;
+
+  if current_date < current_experiment.week_start + 6 then
+    raise exception 'review_not_due';
+  end if;
+
+  if exists (
+    select 1 from public.weekly_experiment_reviews
+    where experiment_id = p_experiment_id and status = 'completed'
+  ) then
+    raise exception 'review_already_completed';
+  end if;
+
+  select count(distinct completion_date)::smallint into completed_reps
+  from public.daily_practice_completions
+  where user_id = p_user_id
+    and experiment_id = p_experiment_id
+    and completion_date between current_experiment.week_start and current_experiment.week_start + 6;
+
+  update public.weekly_experiments
+  set status = 'completed', completed_at = now(), updated_at = now()
+  where id = p_experiment_id;
+
+  if p_decision <> 'pause' then
+    if p_action_label is null or char_length(btrim(p_action_label)) not between 4 and 240
+      or p_cue is null or char_length(btrim(p_cue)) not between 2 and 160
+      or p_frequency_per_week not between 1 and 7
+      or p_minimum_version is null or char_length(btrim(p_minimum_version)) not between 2 and 160 then
+      raise exception 'invalid_next_experiment';
+    end if;
+
+    insert into public.weekly_experiments (
+      user_id, identity_direction, action_label, cue, frequency_per_week,
+      minimum_version, reminder_preference, onboarding_step, status,
+      week_start, activated_at
+    ) values (
+      p_user_id, current_experiment.identity_direction, btrim(p_action_label), btrim(p_cue),
+      p_frequency_per_week, btrim(p_minimum_version), current_experiment.reminder_preference,
+      6, 'active', (current_experiment.week_start + 7), now()
+    ) returning id into next_id;
+  end if;
+
+  insert into public.weekly_experiment_reviews (
+    user_id, experiment_id, completion_count, target_count, difficulty,
+    value_rating, decision, status, next_experiment_id, completed_at, updated_at
+  ) values (
+    p_user_id, p_experiment_id, completed_reps, current_experiment.frequency_per_week,
+    p_difficulty, p_value_rating, p_decision, 'completed', next_id, now(), now()
+  ) on conflict (experiment_id) do update set
+    completion_count = excluded.completion_count,
+    target_count = excluded.target_count,
+    difficulty = excluded.difficulty,
+    value_rating = excluded.value_rating,
+    decision = excluded.decision,
+    status = 'completed',
+    next_experiment_id = excluded.next_experiment_id,
+    completed_at = excluded.completed_at,
+    updated_at = excluded.updated_at;
+
+  return next_id;
+end;
+$$;
+
+revoke all on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  from public, anon, authenticated;
+grant execute on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  to service_role;
+
+comment on table public.weekly_experiment_reviews is
+  'Privacy-minimized weekly review outcomes. Freeform health notes are intentionally excluded.';
+
+comment on function public.complete_weekly_review is
+  'Atomically completes a due weekly lifestyle experiment, stores its review, and optionally creates the next active week.';

--- a/supabase/migrations/20260722032000_weekly_review_late_rollover.sql
+++ b/supabase/migrations/20260722032000_weekly_review_late_rollover.sql
@@ -1,0 +1,99 @@
+create or replace function public.complete_weekly_review(
+  p_user_id uuid,
+  p_experiment_id uuid,
+  p_difficulty smallint,
+  p_value_rating smallint,
+  p_decision text,
+  p_action_label text default null,
+  p_cue text default null,
+  p_frequency_per_week smallint default null,
+  p_minimum_version text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_experiment public.weekly_experiments%rowtype;
+  next_id uuid;
+  completed_reps smallint;
+  next_week_start date;
+begin
+  if p_difficulty not between 1 and 5
+    or p_value_rating not between 1 and 5
+    or p_decision not in ('keep', 'shrink', 'swap', 'pause', 'advance') then
+    raise exception 'invalid_review';
+  end if;
+
+  select * into current_experiment
+  from public.weekly_experiments
+  where id = p_experiment_id and user_id = p_user_id and status = 'active'
+  for update;
+
+  if not found then raise exception 'active_experiment_not_found'; end if;
+  if current_date < current_experiment.week_start + 6 then raise exception 'review_not_due'; end if;
+  if exists (
+    select 1 from public.weekly_experiment_reviews
+    where experiment_id = p_experiment_id and status = 'completed'
+  ) then raise exception 'review_already_completed'; end if;
+
+  select count(distinct completion_date)::smallint into completed_reps
+  from public.daily_practice_completions
+  where user_id = p_user_id
+    and experiment_id = p_experiment_id
+    and completion_date between current_experiment.week_start and current_experiment.week_start + 6;
+
+  update public.weekly_experiments
+  set status = 'completed', completed_at = now(), updated_at = now()
+  where id = p_experiment_id;
+
+  if p_decision <> 'pause' then
+    if p_action_label is null or char_length(btrim(p_action_label)) not between 4 and 240
+      or p_cue is null or char_length(btrim(p_cue)) not between 2 and 160
+      or p_frequency_per_week not between 1 and 7
+      or p_minimum_version is null or char_length(btrim(p_minimum_version)) not between 2 and 160 then
+      raise exception 'invalid_next_experiment';
+    end if;
+
+    next_week_start := greatest(
+      current_experiment.week_start + 7,
+      date_trunc('week', current_date)::date
+    );
+
+    insert into public.weekly_experiments (
+      user_id, identity_direction, action_label, cue, frequency_per_week,
+      minimum_version, reminder_preference, onboarding_step, status,
+      week_start, activated_at
+    ) values (
+      p_user_id, current_experiment.identity_direction, btrim(p_action_label), btrim(p_cue),
+      p_frequency_per_week, btrim(p_minimum_version), current_experiment.reminder_preference,
+      6, 'active', next_week_start, now()
+    ) returning id into next_id;
+  end if;
+
+  insert into public.weekly_experiment_reviews (
+    user_id, experiment_id, completion_count, target_count, difficulty,
+    value_rating, decision, status, next_experiment_id, completed_at, updated_at
+  ) values (
+    p_user_id, p_experiment_id, completed_reps, current_experiment.frequency_per_week,
+    p_difficulty, p_value_rating, p_decision, 'completed', next_id, now(), now()
+  ) on conflict (experiment_id) do update set
+    completion_count = excluded.completion_count,
+    target_count = excluded.target_count,
+    difficulty = excluded.difficulty,
+    value_rating = excluded.value_rating,
+    decision = excluded.decision,
+    status = 'completed',
+    next_experiment_id = excluded.next_experiment_id,
+    completed_at = excluded.completed_at,
+    updated_at = excluded.updated_at;
+
+  return next_id;
+end;
+$$;
+
+revoke all on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  from public, anon, authenticated;
+grant execute on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  to service_role;

--- a/supabase/migrations/20260722033000_weekly_review_indexes.sql
+++ b/supabase/migrations/20260722033000_weekly_review_indexes.sql
@@ -1,0 +1,3 @@
+create index if not exists weekly_experiment_reviews_next_experiment_idx
+  on public.weekly_experiment_reviews (next_experiment_id)
+  where next_experiment_id is not null;


### PR DESCRIPTION
## What changed

- Adds an end-of-week review with completion summary, difficulty and usefulness ratings
- Lets members keep, shrink, swap, pause, or build on the current practice
- Creates the next active week atomically while preserving the completed week and daily history
- Adds an in-app review reminder with a stable deep link from Today
- Records privacy-minimized review open and completion analytics
- Prevents practice completions outside the active experiment week

## Why

The paid dashboard needs a repeatable learning loop, not only a daily checkbox. This review turns each focused week into a small experiment and helps members adjust the system without making causal health claims.

## Validation

- TypeScript typecheck passed
- Production Next.js build passed
- Weekly review rule assertions passed
- Unauthenticated API returns 401 and protected page redirects to login
- Supabase RLS and role grants verified
- On-time and late atomic rollover transaction tests passed with rollback
- Supabase security advisor reports no new PR07 finding
- New foreign-key index added after performance advisor review

## QA focus

1. Open the review from Today at the end of a practice week
2. Confirm the completion summary matches the daily dots
3. Test each decision path, especially Swap and Pause
4. Finish a review and confirm Today shows the correct next-week state
5. Check mobile layout and keyboard navigation