### PR TITLE
Audit PR 10: Build launch-ready Settings and privacy controls

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,155 +1,402 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
-import { motion } from "framer-motion";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle, Clock } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  CircleHelp,
+  CreditCard,
+  Download,
+  Loader2,
+  LockKeyhole,
+  Save,
+  Trash2,
+  UserRound,
+} from "lucide-react";
+
+import type { AccountSettings } from "@/lib/accountSettings";
+
+type AccountResponse = {
+  ok: boolean;
+  account?: AccountSettings;
+  error?: string;
+};
+
+const supportEmail = "support@lve360.com";
 
 export default function SettingsPage() {
-  const [user, setUser] = useState<any>(null);
+  const [account, setAccount] = useState<AccountSettings | null>(null);
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [notice, setNotice] = useState<{ tone: "success" | "error"; message: string } | null>(null);
 
-  // 🧩 Fetch user info
   useEffect(() => {
-    (async () => {
-      try {
-        const res = await fetch("/api/account");
-        if (!res.ok) throw new Error("Failed to fetch account info");
-        const data = await res.json();
-        setUser(data);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    })();
+    void loadAccount();
   }, []);
 
-  // 🧾 Open Stripe billing portal
-  async function openBillingPortal() {
-    if (!user?.email) return alert("No email found for this account.");
-    setPortalLoading(true);
+  async function loadAccount() {
     try {
-      const res = await fetch("/api/stripe/portal", {
-        method: "POST",
-      });
-      const data = await res.json();
-      if (data?.url) window.location.href = data.url;
-      else alert(data?.error || "Could not open billing portal.");
-    } catch (err) {
-      console.error("Portal error:", err);
-      alert("Error opening billing portal.");
+      const response = await fetch("/api/account", { cache: "no-store" });
+      if (response.status === 401) {
+        window.location.assign("/login");
+        return;
+      }
+      const body = (await response.json()) as AccountResponse;
+      if (!response.ok || !body.account) throw new Error(body.error ?? "account_unavailable");
+      setAccount(body.account);
+    } catch {
+      setNotice({ tone: "error", message: "We could not load your settings. Please refresh and try again." });
     } finally {
+      setLoading(false);
+    }
+  }
+
+  async function savePreferences() {
+    if (!account) return;
+    setSaving(true);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/account", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          preferred_name: account.preferred_name,
+          weight_unit: account.weight_unit,
+          reminder_preference: account.reminder_preference,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body?.error ?? "preferences_unavailable");
+      window.localStorage.setItem("lve360_weight_unit", account.weight_unit);
+      setNotice({ tone: "success", message: "Your preferences are saved." });
+    } catch {
+      setNotice({ tone: "error", message: "We could not save your preferences. Please try again." });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function openBillingPortal() {
+    setPortalLoading(true);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/stripe/portal", { method: "POST" });
+      const body = await response.json();
+      if (!response.ok || !body?.url) throw new Error(body?.error ?? "portal_unavailable");
+      window.location.assign(body.url);
+    } catch {
+      setNotice({ tone: "error", message: "We could not open billing. Please try again or contact support." });
       setPortalLoading(false);
     }
   }
 
-  // 🌀 Loading state
+  async function deleteAccount() {
+    if (!account || deleteConfirmation.trim().toLowerCase() !== account.email.toLowerCase()) return;
+    setDeleting(true);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/account/delete", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmation: deleteConfirmation }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body?.error ?? "deletion_unavailable");
+      window.location.assign("/?account=deleted");
+    } catch {
+      setNotice({
+        tone: "error",
+        message: "We could not complete account deletion. Your subscription may have been canceled. Please contact support now.",
+      });
+      setDeleting(false);
+    }
+  }
+
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-screen">
-        <Loader2 className="w-6 h-6 animate-spin text-purple-600" />
+      <div className="flex min-h-[60vh] items-center justify-center" aria-live="polite">
+        <Loader2 className="h-6 w-6 animate-spin text-[#047F6D]" />
+        <span className="ml-3 text-sm text-slate-600">Loading settings</span>
       </div>
     );
   }
 
-  // 🚪 Not logged in
-  if (!user) {
+  if (!account) {
     return (
-      <div className="flex flex-col justify-center items-center h-screen text-center">
-        <p className="text-gray-600 mb-4">
-          Please log in to view your account.
-        </p>
-        <Button onClick={() => (window.location.href = "/login")}>
-          Go to Login
-        </Button>
+      <div className="mx-auto max-w-xl rounded-2xl border border-rose-200 bg-white p-8 text-center shadow-sm">
+        <h1 className="text-2xl font-bold text-[#041B2D]">Settings are unavailable</h1>
+        <p className="mt-2 text-slate-600">Refresh the page or contact support if this continues.</p>
+        <button onClick={() => void loadAccount()} className="mt-5 rounded-xl bg-[#047F6D] px-4 py-2 font-semibold text-white">
+          Try again
+        </button>
       </div>
     );
   }
 
-  // 🧾 Derived info
-  const tierLabel =
-    user.tier === "premium"
-      ? "Premium"
-      : user.tier === "concierge"
-      ? "Concierge"
-      : "Free";
+  const paid = account.tier === "premium" || account.tier === "trial";
+  const planName = account.tier === "premium" ? "LVE360 Member" : account.tier === "trial" ? "LVE360 Trial" : "Free";
+  const billingLabel =
+    account.billing_interval === "annual" ? "Annual billing" :
+    account.billing_interval === "monthly" ? "Monthly billing" :
+    "No paid billing plan";
 
-  const interval =
-    user.billing_interval === "annual"
-      ? "Annual"
-      : user.billing_interval === "monthly"
-      ? "Monthly"
-      : "Not set";
-
-  const endDate = user.subscription_end_date
-    ? new Date(user.subscription_end_date).toLocaleDateString()
-    : null;
-
-  // ✨ Unified LVE360 dashboard look
   return (
-    <div className="max-w-6xl mx-auto p-6 space-y-6">
-      {/* Greeting header (animated, matches dashboard style) */}
-      <motion.h1
-        initial={{ opacity: 0, y: -10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-        className="text-4xl font-extrabold text-center mb-8"
-      >
-        <span className="bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] bg-clip-text text-transparent">
-          Settings
-        </span>
-      </motion.h1>
-
-      {/* Main card */}
-      <div className="bg-white/80 backdrop-blur-xl rounded-2xl shadow-xl ring-1 ring-purple-100 p-6 transition space-y-8">
-        <Card className="bg-gradient-to-r from-purple-50 to-yellow-50 shadow-md border-0">
-          <CardContent className="p-6 space-y-4">
-            <div className="flex justify-between items-center">
-              <div>
-                <h2 className="text-xl font-semibold text-purple-800">
-                  {tierLabel} Plan
-                </h2>
-                <p className="text-sm text-gray-600">
-                  Billing interval: <strong>{interval}</strong>
-                </p>
-                {endDate && (
-                  <p className="text-sm text-gray-600">
-                    Ends on: <strong>{endDate}</strong>
-                  </p>
-                )}
-              </div>
-              {user.tier === "free" ? (
-                <Clock className="text-yellow-500 w-8 h-8" />
-              ) : (
-                <CheckCircle className="text-green-500 w-8 h-8" />
-              )}
-            </div>
-
-            <div className="flex justify-end mt-4">
-              {user.tier === "free" ? (
-                <Button
-                  className="bg-purple-600 hover:bg-purple-700 text-white"
-                  onClick={() => (window.location.href = "/upgrade")}
-                >
-                  Upgrade Plan
-                </Button>
-              ) : (
-                <Button
-                  className="bg-yellow-400 hover:bg-yellow-500 text-purple-900 font-semibold"
-                  onClick={openBillingPortal}
-                  disabled={portalLoading}
-                >
-                  {portalLoading ? "Opening..." : "Manage Billing"}
-                </Button>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
+    <div className="mx-auto max-w-4xl space-y-7 pb-12">
+      <div>
+        <p className="text-sm font-bold uppercase tracking-[0.16em] text-[#047F6D]">Your account</p>
+        <h1 className="mt-2 text-3xl font-extrabold tracking-tight text-[#041B2D] sm:text-4xl">Settings</h1>
+        <p className="mt-2 max-w-2xl text-slate-600">
+          Keep LVE360 useful for your real life. Choose how we address you, how progress appears, and whether you want weekly email cues.
+        </p>
       </div>
+
+      {notice && (
+        <div
+          role="status"
+          className={`flex items-start gap-2 rounded-xl border px-4 py-3 text-sm ${
+            notice.tone === "success"
+              ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+              : "border-rose-200 bg-rose-50 text-rose-800"
+          }`}
+        >
+          {notice.tone === "success" && <Check className="mt-0.5 h-4 w-4 shrink-0" />}
+          {notice.message}
+        </div>
+      )}
+
+      <Section icon={UserRound} title="Profile and preferences" description="Small choices that make your weekly experience feel like yours.">
+        <div className="grid gap-5 sm:grid-cols-2">
+          <Field label="Preferred name" hint="Used in your dashboard greeting.">
+            <input
+              value={account.preferred_name}
+              maxLength={80}
+              onChange={(event) => setAccount({ ...account, preferred_name: event.target.value })}
+              placeholder="What should we call you?"
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-[#041B2D] shadow-sm focus:border-[#047F6D] focus:ring-2 focus:ring-teal-100"
+            />
+          </Field>
+          <Field label="Account email" hint="Your sign-in and report delivery address.">
+            <input
+              value={account.email}
+              readOnly
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-slate-600"
+            />
+          </Field>
+          <Field label="Weight units" hint="Used throughout progress tracking.">
+            <select
+              value={account.weight_unit}
+              onChange={(event) => setAccount({ ...account, weight_unit: event.target.value as "lb" | "kg" })}
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-[#041B2D] shadow-sm focus:border-[#047F6D] focus:ring-2 focus:ring-teal-100"
+            >
+              <option value="lb">Pounds (lb)</option>
+              <option value="kg">Kilograms (kg)</option>
+            </select>
+          </Field>
+          <Field label="Weekly email cue" hint="A simple prompt to return to your current practice.">
+            <select
+              value={account.reminder_preference}
+              onChange={(event) => setAccount({ ...account, reminder_preference: event.target.value as "none" | "email" })}
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-[#041B2D] shadow-sm focus:border-[#047F6D] focus:ring-2 focus:ring-teal-100"
+            >
+              <option value="email">Send a weekly email cue</option>
+              <option value="none">No email cue</option>
+            </select>
+          </Field>
+        </div>
+        <div className="mt-6 flex justify-end">
+          <button
+            onClick={() => void savePreferences()}
+            disabled={saving}
+            className="inline-flex items-center rounded-xl bg-[#047F6D] px-4 py-2.5 font-semibold text-white shadow-sm transition hover:bg-[#036c5d] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+            Save preferences
+          </button>
+        </div>
+      </Section>
+
+      <Section icon={CreditCard} title="Membership" description="See your plan and manage billing securely through Stripe.">
+        <div className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-bold text-[#041B2D]">{planName}</p>
+            <p className="mt-1 text-sm text-slate-600">{billingLabel}</p>
+            {account.subscription_end_date && (
+              <p className="mt-1 text-sm text-slate-600">
+                Current access through {new Date(account.subscription_end_date).toLocaleDateString()}
+              </p>
+            )}
+          </div>
+          {paid ? (
+            <button
+              onClick={() => void openBillingPortal()}
+              disabled={portalLoading}
+              className="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-2.5 font-semibold text-[#041B2D] shadow-sm hover:bg-slate-50 disabled:opacity-60"
+            >
+              {portalLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CreditCard className="mr-2 h-4 w-4" />}
+              Manage billing
+            </button>
+          ) : (
+            <Link href="/upgrade" className="inline-flex items-center justify-center rounded-xl bg-[#6D36C9] px-4 py-2.5 font-semibold text-white hover:bg-[#5b2caf]">
+              View membership
+              <ChevronRight className="ml-1 h-4 w-4" />
+            </Link>
+          )}
+        </div>
+      </Section>
+
+      <Section icon={LockKeyhole} title="Data and privacy" description="Understand what is stored and stay in control of your account.">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <InfoCard
+            title="What LVE360 stores"
+            body="Your account, intake answers, Blueprint, supplement stack, goals, check-ins, and weekly practice history are stored to provide your experience."
+          />
+          <InfoCard
+            title="How long it is kept"
+            body="Account data is kept while your account is active. You can download it or permanently delete it from this page."
+          />
+        </div>
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+          <a
+            href="/api/account/export"
+            download
+            className="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-2.5 font-semibold text-[#041B2D] shadow-sm hover:bg-slate-50"
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Download my data
+          </a>
+          <Link href="/privacy" className="inline-flex items-center justify-center rounded-xl px-4 py-2.5 font-semibold text-[#047F6D] hover:bg-teal-50">
+            Read the Privacy Policy
+            <ChevronRight className="ml-1 h-4 w-4" />
+          </Link>
+        </div>
+      </Section>
+
+      <Section icon={CircleHelp} title="Help and corrections" description="Health context changes. Your information should be easy to correct.">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <SupportLink
+            href={`mailto:${supportEmail}?subject=${encodeURIComponent("LVE360 report correction")}`}
+            title="Correct my report"
+            body="Tell us which part of your Blueprint needs attention. Do not include sensitive health details in the email subject."
+          />
+          <SupportLink
+            href={`mailto:${supportEmail}?subject=${encodeURIComponent("LVE360 account support")}`}
+            title="Contact support"
+            body="Get help with your account, billing, delivery, or dashboard."
+          />
+        </div>
+      </Section>
+
+      <section className="rounded-2xl border border-rose-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start gap-3">
+          <div className="rounded-xl bg-rose-50 p-2 text-rose-700"><Trash2 className="h-5 w-5" /></div>
+          <div className="flex-1">
+            <h2 className="text-lg font-bold text-[#041B2D]">Delete account</h2>
+            <p className="mt-1 text-sm leading-6 text-slate-600">
+              This permanently deletes your LVE360 account and connected data. Any active subscription is canceled immediately.
+            </p>
+            {!deleteOpen ? (
+              <button onClick={() => setDeleteOpen(true)} className="mt-4 font-semibold text-rose-700 hover:text-rose-800">
+                Start account deletion
+              </button>
+            ) : (
+              <div className="mt-5 rounded-xl border border-rose-200 bg-rose-50 p-4">
+                <p className="text-sm font-semibold text-rose-900">This cannot be undone.</p>
+                <p className="mt-1 text-sm text-rose-800">
+                  Download your data first if you want a copy. Then type <strong>{account.email}</strong> to confirm.
+                </p>
+                <input
+                  value={deleteConfirmation}
+                  onChange={(event) => setDeleteConfirmation(event.target.value)}
+                  autoComplete="off"
+                  className="mt-3 w-full rounded-xl border border-rose-300 bg-white px-3 py-2.5 text-[#041B2D]"
+                  aria-label="Type your email to confirm account deletion"
+                />
+                <div className="mt-3 flex flex-wrap gap-3">
+                  <button
+                    onClick={() => void deleteAccount()}
+                    disabled={deleting || deleteConfirmation.trim().toLowerCase() !== account.email.toLowerCase()}
+                    className="inline-flex items-center rounded-xl bg-rose-700 px-4 py-2.5 font-semibold text-white hover:bg-rose-800 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {deleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Permanently delete my account
+                  </button>
+                  <button
+                    onClick={() => {
+                      setDeleteOpen(false);
+                      setDeleteConfirmation("");
+                    }}
+                    disabled={deleting}
+                    className="rounded-xl px-4 py-2.5 font-semibold text-slate-700 hover:bg-white"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
     </div>
+  );
+}
+
+function Section({
+  icon: Icon,
+  title,
+  description,
+  children,
+}: {
+  icon: typeof UserRound;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-7">
+      <div className="mb-6 flex items-start gap-3">
+        <div className="rounded-xl bg-[#EAFBF8] p-2 text-[#047F6D]"><Icon className="h-5 w-5" /></div>
+        <div>
+          <h2 className="text-lg font-bold text-[#041B2D]">{title}</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, hint, children }: { label: string; hint: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold text-[#041B2D]">{label}</span>
+      <span className="mb-2 mt-0.5 block text-xs text-slate-500">{hint}</span>
+      {children}
+    </label>
+  );
+}
+
+function InfoCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <p className="font-semibold text-[#041B2D]">{title}</p>
+      <p className="mt-1 text-sm leading-6 text-slate-600">{body}</p>
+    </div>
+  );
+}
+
+function SupportLink({ href, title, body }: { href: string; title: string; body: string }) {
+  return (
+    <a href={href} className="group rounded-xl border border-slate-200 bg-slate-50 p-4 transition hover:border-teal-300 hover:bg-teal-50">
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-semibold text-[#041B2D]">{title}</p>
+        <ChevronRight className="h-4 w-4 text-slate-400 transition group-hover:translate-x-0.5 group-hover:text-[#047F6D]" />
+      </div>
+      <p className="mt-1 text-sm leading-6 text-slate-600">{body}</p>
+    </a>
   );
 }

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -1,0 +1,110 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const cancellableStatuses = new Set<Stripe.Subscription.Status>([
+  "active",
+  "trialing",
+  "past_due",
+  "unpaid",
+  "incomplete",
+]);
+
+function uniqueIds(rows: Array<{ id: string }> | null | undefined) {
+  return [...new Set((rows ?? []).map((row) => row.id))];
+}
+
+export async function DELETE(req: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id || !user.email) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  if (typeof body?.confirmation !== "string" || body.confirmation.trim().toLowerCase() !== user.email.toLowerCase()) {
+    return NextResponse.json({ ok: false, error: "confirmation_required" }, { status: 400 });
+  }
+
+  const admin = getSupabaseAdmin();
+  const { data: profile, error: profileError } = await admin
+    .from("users")
+    .select("stripe_customer_id")
+    .eq("id", user.id)
+    .maybeSingle();
+  if (profileError) {
+    return NextResponse.json({ ok: false, error: "account_unavailable" }, { status: 500 });
+  }
+
+  try {
+    if (profile?.stripe_customer_id) {
+      const stripeSecret = process.env.STRIPE_SECRET_KEY;
+      if (!stripeSecret) {
+        return NextResponse.json({ ok: false, error: "billing_unavailable" }, { status: 503 });
+      }
+      const stripe = new Stripe(stripeSecret, { apiVersion: "2024-06-20" });
+      const subscriptions = await stripe.subscriptions.list({
+        customer: profile.stripe_customer_id,
+        status: "all",
+        limit: 100,
+      });
+      await Promise.all(
+        subscriptions.data
+          .filter((subscription) => cancellableStatuses.has(subscription.status))
+          .map((subscription) => stripe.subscriptions.cancel(subscription.id))
+      );
+    }
+
+    const [
+      { data: submissionsByUser, error: submissionsByUserError },
+      { data: submissionsByEmail, error: submissionsByEmailError },
+      { data: stacksByUser, error: stacksByUserError },
+      { data: stacksByEmail, error: stacksByEmailError },
+    ] =
+      await Promise.all([
+        admin.from("submissions").select("id").eq("user_id", user.id),
+        admin.from("submissions").select("id").eq("user_email", user.email),
+        admin.from("stacks").select("id").eq("user_id", user.id),
+        admin.from("stacks").select("id").eq("user_email", user.email),
+      ]);
+    const lookupError = submissionsByUserError ?? submissionsByEmailError ?? stacksByUserError ?? stacksByEmailError;
+    if (lookupError) throw lookupError;
+    const submissionIds = uniqueIds([...(submissionsByUser ?? []), ...(submissionsByEmail ?? [])]);
+    const stackIds = uniqueIds([...(stacksByUser ?? []), ...(stacksByEmail ?? [])]);
+
+    if (submissionIds.length) {
+      const { error } = await admin.from("link_clicks").delete().in("submission_id", submissionIds);
+      if (error) throw error;
+    }
+    if (stackIds.length) {
+      const { error } = await admin.from("link_clicks").delete().in("stack_id", stackIds);
+      if (error) throw error;
+    }
+
+    const { error: eventsError } = await admin.from("product_events").delete().eq("user_id", user.id);
+    if (eventsError) throw eventsError;
+
+    const { error: ownedStacksError } = await admin.from("stacks").delete().eq("user_id", user.id);
+    if (ownedStacksError) throw ownedStacksError;
+    const { error: emailStacksError } = await admin.from("stacks").delete().eq("user_email", user.email);
+    if (emailStacksError) throw emailStacksError;
+    const { error: ownedSubmissionsError } = await admin.from("submissions").delete().eq("user_id", user.id);
+    if (ownedSubmissionsError) throw ownedSubmissionsError;
+    const { error: emailSubmissionsError } = await admin.from("submissions").delete().eq("user_email", user.email);
+    if (emailSubmissionsError) throw emailSubmissionsError;
+
+    const { error: publicUserError } = await admin.from("users").delete().eq("id", user.id);
+    if (publicUserError) throw publicUserError;
+
+    const { error: authError } = await admin.auth.admin.deleteUser(user.id);
+    if (authError) throw authError;
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[account-delete] failed", error instanceof Error ? error.message : error);
+    return NextResponse.json({ ok: false, error: "deletion_unavailable" }, { status: 500 });
+  }
+}

--- a/app/api/account/export/route.ts
+++ b/app/api/account/export/route.ts
@@ -1,0 +1,92 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+
+type ExportQuery = {
+  label: string;
+  table: string;
+  column: string;
+  value: string;
+};
+
+export async function GET() {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id || !user.email) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const admin = getSupabaseAdmin();
+  const queries: ExportQuery[] = [
+    { label: "profile", table: "users", column: "id", value: user.id },
+    { label: "preferences", table: "user_preferences", column: "user_id", value: user.id },
+    { label: "submissions", table: "submissions", column: "user_id", value: user.id },
+    { label: "supplements", table: "submission_supplements", column: "user_id", value: user.id },
+    { label: "medications", table: "submission_medications", column: "user_id", value: user.id },
+    { label: "hormones", table: "submission_hormones", column: "user_id", value: user.id },
+    { label: "blueprints", table: "stacks", column: "user_id", value: user.id },
+    { label: "stack_items", table: "stacks_items", column: "user_id", value: user.id },
+    { label: "goals", table: "goals", column: "user_id", value: user.id },
+    { label: "check_ins", table: "logs", column: "user_id", value: user.id },
+    { label: "ai_summaries", table: "ai_summaries", column: "user_id", value: user.id },
+    { label: "weekly_experiments", table: "weekly_experiments", column: "user_id", value: user.id },
+    { label: "weekly_reviews", table: "weekly_experiment_reviews", column: "user_id", value: user.id },
+    { label: "practice_completions", table: "daily_practice_completions", column: "user_id", value: user.id },
+    { label: "activation_events", table: "activation_events", column: "user_id", value: user.id },
+    { label: "intake_events", table: "intake_events", column: "user_id", value: user.id },
+    { label: "product_events", table: "product_events", column: "user_id", value: user.id },
+  ];
+
+  const results = await Promise.all(
+    queries.map(async ({ label, table, column, value }) => {
+      const { data, error } = await admin.from(table).select("*").eq(column, value);
+      if (error) throw new Error(`${label}: ${error.message}`);
+      return [label, data ?? []] as const;
+    })
+  ).catch((error) => {
+    console.error("[account-export] failed", error instanceof Error ? error.message : error);
+    return null;
+  });
+
+  if (!results) {
+    return NextResponse.json({ ok: false, error: "export_unavailable" }, { status: 500 });
+  }
+
+  const resultMap = Object.fromEntries(results) as Record<string, Array<{ id?: string }>>;
+  const submissionIds = (resultMap.submissions ?? []).flatMap((row) => row.id ? [row.id] : []);
+  const stackIds = (resultMap.blueprints ?? []).flatMap((row) => row.id ? [row.id] : []);
+  const linkClickQueries = [
+    submissionIds.length ? admin.from("link_clicks").select("*").in("submission_id", submissionIds) : Promise.resolve({ data: [], error: null }),
+    stackIds.length ? admin.from("link_clicks").select("*").in("stack_id", stackIds) : Promise.resolve({ data: [], error: null }),
+  ];
+  const [clicksBySubmission, clicksByStack] = await Promise.all(linkClickQueries);
+  if (clicksBySubmission.error || clicksByStack.error) {
+    console.error("[account-export] link history failed");
+    return NextResponse.json({ ok: false, error: "export_unavailable" }, { status: 500 });
+  }
+  const linkClicks = [
+    ...(clicksBySubmission.data ?? []),
+    ...(clicksByStack.data ?? []),
+  ].filter((row, index, rows) => rows.findIndex((candidate) => candidate.id === row.id) === index);
+
+  const exportedAt = new Date().toISOString();
+  const payload = {
+    export_version: "1.0",
+    exported_at: exportedAt,
+    account_email: user.email,
+    data: { ...resultMap, link_clicks: linkClicks },
+  };
+  const date = exportedAt.slice(0, 10);
+
+  return new NextResponse(JSON.stringify(payload, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Disposition": `attachment; filename="lve360-data-${date}.json"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,17 +1,89 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+import {
+  isReminderPreference,
+  isWeightUnit,
+  normalizePreferredName,
+} from "@/lib/accountSettings";
 
 export async function GET() {
   const supabase = createRouteHandlerClient({ cookies });
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json(null);
+  if (!user?.id || !user.email) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
 
-  const { data } = await supabase
+  const [{ data: profile, error: profileError }, { data: preferences, error: preferencesError }] = await Promise.all([
+    supabase
     .from("users")
     .select("email, tier, billing_interval, subscription_end_date")
     .eq("id", user.id)
-    .maybeSingle();
+      .maybeSingle(),
+    supabase
+      .from("user_preferences")
+      .select("preferred_name, weight_unit, reminder_preference")
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
 
-  return NextResponse.json(data);
+  if (profileError || preferencesError) {
+    console.error("[account] load failed", profileError?.message ?? preferencesError?.message);
+    return NextResponse.json({ ok: false, error: "account_unavailable" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    account: {
+      email: profile?.email ?? user.email,
+      tier: profile?.tier ?? "free",
+      billing_interval: profile?.billing_interval ?? null,
+      subscription_end_date: profile?.subscription_end_date ?? null,
+      preferred_name: preferences?.preferred_name ?? "",
+      weight_unit: preferences?.weight_unit === "kg" ? "kg" : "lb",
+      reminder_preference: preferences?.reminder_preference === "email" ? "email" : "none",
+    },
+  });
+}
+
+export async function PATCH(req: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const preferredName = normalizePreferredName(body?.preferred_name);
+  if (preferredName === undefined || !isWeightUnit(body?.weight_unit) || !isReminderPreference(body?.reminder_preference)) {
+    return NextResponse.json({ ok: false, error: "invalid_preferences" }, { status: 400 });
+  }
+
+  const payload = {
+    user_id: user.id,
+    preferred_name: preferredName,
+    weight_unit: body.weight_unit,
+    reminder_preference: body.reminder_preference,
+    updated_at: new Date().toISOString(),
+  };
+  const { error } = await supabase
+    .from("user_preferences")
+    .upsert(payload, { onConflict: "user_id" });
+
+  if (error) {
+    console.error("[account] save failed", error.message);
+    return NextResponse.json({ ok: false, error: "preferences_unavailable" }, { status: 500 });
+  }
+
+  const { error: experimentError } = await supabase
+    .from("weekly_experiments")
+    .update({ reminder_preference: body.reminder_preference, updated_at: new Date().toISOString() })
+    .eq("user_id", user.id)
+    .in("status", ["draft", "active"]);
+  if (experimentError) {
+    console.error("[account] reminder sync failed", experimentError.message);
+    return NextResponse.json({ ok: false, error: "preferences_unavailable" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, preferences: payload });
 }

--- a/app/api/activation/route.ts
+++ b/app/api/activation/route.ts
@@ -228,6 +228,18 @@ export async function PUT(req: NextRequest) {
       });
     }
 
+    if (step === 5) {
+      const { error: preferenceError } = await admin.from("user_preferences").upsert(
+        {
+          user_id: auth.user.id,
+          reminder_preference: body?.reminder_preference,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id" }
+      );
+      if (preferenceError) throw preferenceError;
+    }
+
     return NextResponse.json({ ok: true, experiment: data });
   } catch (error) {
     console.error("[activation] save failed", error);

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "How LVE360 collects, uses, stores, exports, and deletes account and wellness information.",
+};
+
+const updated = "July 26, 2026";
+
+export default function PrivacyPage() {
+  return (
+    <div className="bg-gradient-to-b from-[#EAFBF8] via-white to-white px-5 pb-20 pt-32">
+      <article className="mx-auto max-w-3xl rounded-3xl border border-slate-200 bg-white p-7 shadow-sm sm:p-10">
+        <p className="text-sm font-bold uppercase tracking-[0.16em] text-[#047F6D]">LVE360</p>
+        <h1 className="mt-3 text-4xl font-extrabold tracking-tight text-[#041B2D]">Privacy Policy</h1>
+        <p className="mt-3 text-sm text-slate-500">Last updated {updated}</p>
+        <p className="mt-7 leading-7 text-slate-700">
+          LVE360 uses the information you provide to create and deliver your Blueprint, maintain your account,
+          personalize your weekly experience, process membership payments, and support you. This page explains
+          the information involved and the controls available to you.
+        </p>
+
+        <PolicySection title="Information we collect">
+          <ul>
+            <li>Account information, including your name and email address.</li>
+            <li>Intake answers about your goals, routines, supplements, medications, and relevant health context.</li>
+            <li>Your generated Blueprint, supplement stack, weekly practices, goals, check-ins, and review history.</li>
+            <li>Membership and transaction references. Stripe processes your payment card details.</li>
+            <li>Basic technical and product-use information used for security, delivery, and product improvement.</li>
+          </ul>
+        </PolicySection>
+
+        <PolicySection title="How we use information">
+          <ul>
+            <li>Generate and deliver the personalized experience you request.</li>
+            <li>Operate account, reminder, progress, support, and billing features.</li>
+            <li>Protect the service, diagnose problems, and understand whether core product flows work.</li>
+            <li>Meet legal obligations and enforce our terms.</li>
+          </ul>
+          <p>
+            LVE360 does not use your health information for targeted advertising. LVE360 provides educational
+            wellness information and is not a substitute for medical care.
+          </p>
+        </PolicySection>
+
+        <PolicySection title="Service providers">
+          <p>
+            We use service providers to operate LVE360, including Tally for intake, Vercel for application hosting,
+            Supabase for account and database services, Stripe for payments, OpenAI for supported generation,
+            and email delivery providers for reports and account communications. They receive information only
+            as needed to provide their services to LVE360.
+          </p>
+        </PolicySection>
+
+        <PolicySection title="Retention and deletion">
+          <p>
+            Account information and connected product data are kept while your account is active. You can download
+            a copy or permanently delete your account from Settings. Account deletion also cancels an active LVE360
+            subscription. Limited records may be retained when required for fraud prevention, security, tax,
+            accounting, dispute resolution, or other legal obligations.
+          </p>
+        </PolicySection>
+
+        <PolicySection title="Your choices">
+          <ul>
+            <li>Change your preferred name, units, and reminder choice in Settings.</li>
+            <li>Download a machine-readable copy of connected account data.</li>
+            <li>Permanently delete your account after explicit email confirmation.</li>
+            <li>Ask us to correct a report or help with a privacy request.</li>
+          </ul>
+        </PolicySection>
+
+        <PolicySection title="Security and children">
+          <p>
+            We use technical and organizational safeguards designed to protect information. No online service can
+            guarantee absolute security. LVE360 is intended for adults and is not directed to children under 18.
+          </p>
+        </PolicySection>
+
+        <PolicySection title="Contact us">
+          <p>
+            Email <a className="font-semibold text-[#047F6D] underline" href="mailto:support@lve360.com">support@lve360.com</a> for
+            privacy questions, access requests, corrections, or deletion help.
+          </p>
+        </PolicySection>
+
+        <div className="mt-10 border-t border-slate-200 pt-6">
+          <Link href="/settings" className="font-semibold text-[#047F6D] hover:underline">
+            Return to Settings
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+function PolicySection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-9">
+      <h2 className="text-xl font-bold text-[#041B2D]">{title}</h2>
+      <div className="mt-3 space-y-3 leading-7 text-slate-700 [&_li]:ml-5 [&_li]:list-disc [&_ul]:space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "qa:env": "node scripts/check-env.mjs",
     "qa:build": "npm run typecheck && npm run build",
     "qa:canonical-host": "node src/_tests_/canonicalHost.assert.mjs",
+    "qa:settings": "node src/_tests_/settingsPrivacy.assert.mjs",
     "qa:all": "npm run qa:env && npm run qa:build"
   },
   "dependencies": {

--- a/src/_tests_/settingsPrivacy.assert.mjs
+++ b/src/_tests_/settingsPrivacy.assert.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const settings = fs.readFileSync("app/(app)/settings/page.tsx", "utf8");
+const accountRoute = fs.readFileSync("app/api/account/route.ts", "utf8");
+const deleteRoute = fs.readFileSync("app/api/account/delete/route.ts", "utf8");
+const exportRoute = fs.readFileSync("app/api/account/export/route.ts", "utf8");
+const migration = fs.readFileSync("supabase/migrations/20260726090000_account_preferences.sql", "utf8");
+
+assert.match(settings, /\/api\/account\/export/, "Settings must provide a data download");
+assert.match(settings, /deleteConfirmation\.trim\(\)\.toLowerCase\(\)/, "Deletion must require typed confirmation");
+assert.match(settings, /support@lve360\.com/, "Settings must provide a support path");
+assert.match(accountRoute, /supabase\.auth\.getUser\(\)/, "Preferences must require an authenticated user");
+assert.match(deleteRoute, /confirmation\.trim\(\)\.toLowerCase\(\) !== user\.email\.toLowerCase\(\)/, "The API must verify the account email");
+assert.match(deleteRoute, /admin\.auth\.admin\.deleteUser\(user\.id\)/, "Deletion must remove the authentication account");
+assert.match(exportRoute, /Cache-Control": "private, no-store"/, "Exports must not be cached");
+assert.match(migration, /enable row level security/, "Preferences must have RLS enabled");
+assert.match(migration, /revoke all on public\.user_preferences from anon/, "Anonymous access must be revoked");
+
+console.log("settings and privacy assertions passed");

--- a/src/components/dashboard/ProgressTracker.tsx
+++ b/src/components/dashboard/ProgressTracker.tsx
@@ -106,6 +106,15 @@ export default function ProgressTracker() {
         .maybeSingle();
       setTier((u?.tier || "free") as string);
 
+      const { data: preferences } = await supabase
+        .from("user_preferences")
+        .select("weight_unit")
+        .eq("user_id", uid)
+        .maybeSingle();
+      if (preferences?.weight_unit === "lb" || preferences?.weight_unit === "kg") {
+        setWeightUnit(preferences.weight_unit);
+      }
+
       setLoading(false);
       // reset confetti on range switch
       setConfetti({ weight: false, sleep: false, energy: false });
@@ -272,7 +281,15 @@ export default function ProgressTracker() {
             rightEl={
               <button
                 className="text-xs rounded-full border px-2 py-0.5 hover:bg-white"
-                onClick={() => setWeightUnit((u) => (u === "lb" ? "kg" : "lb"))}
+                onClick={() => {
+                  const nextUnit = weightUnit === "lb" ? "kg" : "lb";
+                  setWeightUnit(nextUnit);
+                  if (userId) {
+                    void supabase
+                      .from("user_preferences")
+                      .upsert({ user_id: userId, weight_unit: nextUnit }, { onConflict: "user_id" });
+                  }
+                }}
                 aria-label="Toggle weight units"
                 title={`Switch to ${weightUnit === "lb" ? "kg" : "lb"}`}
               >

--- a/src/lib/accountSettings.ts
+++ b/src/lib/accountSettings.ts
@@ -1,0 +1,28 @@
+export type WeightUnit = "lb" | "kg";
+export type ReminderPreference = "none" | "email";
+
+export type AccountSettings = {
+  email: string;
+  tier: string;
+  billing_interval: string | null;
+  subscription_end_date: string | null;
+  preferred_name: string;
+  weight_unit: WeightUnit;
+  reminder_preference: ReminderPreference;
+};
+
+export function normalizePreferredName(value: unknown): string | null | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().replace(/\s+/g, " ");
+  if (!normalized) return null;
+  if (normalized.length > 80) return undefined;
+  return normalized;
+}
+
+export function isWeightUnit(value: unknown): value is WeightUnit {
+  return value === "lb" || value === "kg";
+}
+
+export function isReminderPreference(value: unknown): value is ReminderPreference {
+  return value === "none" || value === "email";
+}

--- a/supabase/migrations/20260726090000_account_preferences.sql
+++ b/supabase/migrations/20260726090000_account_preferences.sql
@@ -1,0 +1,37 @@
+create table if not exists public.user_preferences (
+  user_id uuid primary key references public.users(id) on update cascade on delete cascade,
+  preferred_name text,
+  weight_unit text not null default 'lb',
+  reminder_preference text not null default 'none',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint user_preferences_name_length check (
+    preferred_name is null or char_length(preferred_name) between 1 and 80
+  ),
+  constraint user_preferences_weight_unit check (weight_unit in ('lb', 'kg')),
+  constraint user_preferences_reminder check (reminder_preference in ('none', 'email'))
+);
+
+alter table public.user_preferences enable row level security;
+
+create policy "user_preferences: select own"
+  on public.user_preferences for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+create policy "user_preferences: insert own"
+  on public.user_preferences for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+create policy "user_preferences: update own"
+  on public.user_preferences for update
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+revoke all on public.user_preferences from anon;
+grant select, insert, update on public.user_preferences to authenticated;
+
+comment on table public.user_preferences is
+  'User-controlled display and reminder preferences. No health measurements are stored here.';


### PR DESCRIPTION
## Purpose

Turn Settings from a billing-only screen into a trustworthy account control center for launch.

## What changed

- Rebuilt Settings around profile, preferences, membership, data and privacy, support, and confirmed account deletion.
- Added persisted preferred-name, weight-unit, and weekly-reminder preferences.
- Kept weight units synchronized with Progress and reminder choices synchronized with the active weekly practice.
- Added authenticated JSON account export across profile, intake, Blueprint, stack, goals, check-ins, weekly practices, reviews, and connected product history.
- Added permanent account deletion that requires typing the signed-in email, cancels active Stripe subscriptions, removes connected application data, and deletes the Supabase authentication user.
- Added a public Privacy Policy with clear collection, use, provider, retention, export, correction, and deletion language.
- Removed sensitive account and health details from support email subjects.
- Added focused settings and privacy safeguard assertions.
- Added a row-level-secured `user_preferences` table. Anonymous access is revoked.

## Why

The launch audit found that the paid dashboard needed a credible, user-controlled account layer. Members must be able to personalize the experience, understand their membership, correct information, export their data, and leave safely. These controls also make the weekly lifestyle system more coherent because units and reminder choices now persist across sessions.

## Validation

- `npm run qa:settings`
- `npm run typecheck`
- `npm run build` with inert build-only public placeholders
- `git diff --check`
- Supabase migration applied successfully
- Verified `user_preferences` RLS is enabled
- Verified anonymous SELECT is blocked
- Verified authenticated SELECT is granted
- Verified three owner-only RLS policies are present

## Manual preview QA

1. Sign in and open Settings.
2. Save a preferred name, switch weight units, and choose an email reminder.
3. Refresh Settings and confirm each choice persists.
4. Open Journey and confirm the saved weight unit appears in Progress.
5. Open Stripe billing management and return to Settings.
6. Download account data and confirm a JSON file is produced.
7. Open the Privacy Policy from Settings and from the site footer.
8. Open account deletion and confirm the button stays disabled until the full account email is typed.
9. Do not complete deletion on a valuable test account. Use a disposable account for the destructive end-to-end check.
10. Use both support links and confirm no health details appear in the email subject.

## Not yet verified

- Real Stripe portal return from the Vercel Preview.
- Export contents against a representative production member account.
- Full deletion against a disposable account with a test Stripe subscription.
- Legal review of the Privacy Policy language.
- Weekly reminder delivery itself. This PR persists the preference but does not add a scheduler.

## Risk and rollback

Account deletion is intentionally irreversible and cancels active subscriptions immediately. It requires authenticated server verification plus exact email confirmation. The service-role key remains server-only.

To roll back the application, revert this commit. The additive `user_preferences` table may remain safely in place. Dropping it would delete saved preferences and is not recommended during rollback.

## Follow-up

- Complete signed-in preview QA with a disposable account.
- Obtain legal review of the Privacy Policy before public launch.
- Implement the weekly reminder scheduler in its dedicated retention PR.
- Upgrade Next.js from 14.2.32 to a currently patched release in a separate dependency PR.