### PR TITLE
Audit PR 11: Improve intake clarity without increasing burden

### DIFF
--- a/app/api/analytics/event/route.ts
+++ b/app/api/analytics/event/route.ts
@@ -10,6 +10,7 @@ const CLIENT_EVENTS = new Set([
   "homepage_viewed",
   "pricing_viewed",
   "intake_started",
+  "intake_page_viewed",
   "blueprint_viewed",
   "blueprint_action_selected",
   "checkout_started",

--- a/app/api/tally-webhook/route.ts
+++ b/app/api/tally-webhook/route.ts
@@ -10,6 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin as supa } from "@/lib/supabaseAdmin";
 import { TALLY_KEYS, NormalizedSubmissionSchema } from "@/types/tally-normalized";
 import { parseList, parseSupplements } from "@/lib/parseLists";
+import { normalizeHeight, normalizeWeightPounds } from "@/lib/intakeNormalization";
 import crypto from "crypto";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
 
@@ -177,12 +178,13 @@ export async function POST(req: NextRequest) {
       user_email: cleanSingle(getByKeyOrLabel(src, TALLY_KEYS.user_email, ["email"])),
       name: cleanSingle(getByKeyOrLabel(src, TALLY_KEYS.name, ["name", "nickname"])),
       dob: cleanSingle(getByKeyOrLabel(src, TALLY_KEYS.dob, ["dob", "date of birth"])),
-      height: cleanSingle(getByKeyOrLabel(src, TALLY_KEYS.height, ["height"])),
+      height: normalizeHeight(
+        getByKeyOrLabel(src, TALLY_KEYS.height, ["height"])
+      )?.display,
       weight: (() => {
-        const val = getByKeyOrLabel(src, TALLY_KEYS.weight, ["weight"]);
-        if (typeof val === "number") return val;
-        if (typeof val === "string") return val.replace(/[^0-9.]/g, "");
-        return undefined;
+        return normalizeWeightPounds(
+          getByKeyOrLabel(src, TALLY_KEYS.weight, ["weight", "weight (lbs)"])
+        );
       })(),
       sex: cleanSingle(getByKeyOrLabel(src, TALLY_KEYS.sex, ["sex"])),
       gender: cleanSingle(getByKeyOrLabel(src, TALLY_KEYS.gender, ["gender"])),
@@ -353,6 +355,10 @@ const submissionRow = {
           "07b6d212-c844-47f2-96bf-6ea906c933b9": "Longevity",
           "d284f391-71a1-49b0-bddc-467ae8de7cee": "Increase Energy",
           "d1ae4ecf-eb17-4308-93ff-b78bed426f0b": "Better Skin/Nails/Hair",
+          "fe7acb91-78e0-4472-8413-0f682e03ebb6": "Emotional health and relationships",
+          "fbb243b9-3b5b-40d4-93ec-d5ad18287e5e": "Healthy eating and nutrition",
+          "1ef089e2-3bce-4f45-aaac-009a23b3d348": "Career focus and performance",
+          "63f72695-b77b-4f4f-a454-63894d59254c": "Overall wellbeing and happiness",
           "7894b6c9-c199-4108-bb2f-c998c7265164": "Other",
         };
     

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,47 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
+import IntakeModal from "@/components/intake/IntakeModal";
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
-
-const intakeUrl = "https://tally.so/r/mOqRBk?hideTitle=1&transparentBackground=1&dynamicHeight=1";
-
-function IntakeModal({ onClose }: { onClose: () => void }) {
-  const modalRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => event.key === "Escape" && onClose();
-    const onPointerDown = (event: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(event.target as Node)) onClose();
-    };
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", onKeyDown);
-    document.addEventListener("mousedown", onPointerDown);
-    return () => {
-      document.body.style.overflow = originalOverflow;
-      window.removeEventListener("keydown", onKeyDown);
-      document.removeEventListener("mousedown", onPointerDown);
-    };
-  }, [onClose]);
-
-  return (
-    <motion.div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur-sm sm:p-8"
-      initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} role="dialog" aria-modal="true"
-    >
-      <motion.div
-        ref={modalRef}
-        className="relative flex max-h-full w-full max-w-5xl flex-col overflow-hidden rounded-3xl bg-white shadow-2xl"
-        initial={{ opacity: 0, scale: 0.96 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.96 }}
-      >
-        <button onClick={onClose} className="absolute right-4 top-3 z-10 rounded-full px-3 py-1 text-xl text-slate-500 hover:bg-slate-100 hover:text-slate-900" aria-label="Close intake">×</button>
-        <iframe src={intakeUrl} title="LVE360 intake" className="min-h-[84vh] w-full bg-white" />
-      </motion.div>
-    </motion.div>
-  );
-}
 
 export default function Home() {
   const [showIntake, setShowIntake] = useState(false);

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,43 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import { track } from "@vercel/analytics/react";
 import CTAButton from "@/components/CTAButton";
+import IntakeModal from "@/components/intake/IntakeModal";
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
-
-const intakeUrl = "https://tally.so/r/mOqRBk?hideTitle=1&transparentBackground=1&dynamicHeight=1";
-
-function IntakeModal({ onClose }: { onClose: () => void }) {
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => event.key === "Escape" && onClose();
-    const onMouseDown = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) onClose();
-    };
-    const overflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", onKeyDown);
-    document.addEventListener("mousedown", onMouseDown);
-    return () => {
-      document.body.style.overflow = overflow;
-      window.removeEventListener("keydown", onKeyDown);
-      document.removeEventListener("mousedown", onMouseDown);
-    };
-  }, [onClose]);
-
-  return (
-    <motion.div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur-sm" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} role="dialog" aria-modal="true">
-      <motion.div ref={ref} className="relative w-full max-w-5xl overflow-hidden rounded-3xl bg-white shadow-2xl" initial={{ scale: 0.96 }} animate={{ scale: 1 }} exit={{ scale: 0.96 }}>
-        <button onClick={onClose} className="absolute right-4 top-3 z-10 rounded-full px-3 py-1 text-xl text-slate-500 hover:bg-slate-100" aria-label="Close intake">×</button>
-        <iframe src={intakeUrl} title="LVE360 intake" className="min-h-[84vh] w-full" />
-      </motion.div>
-    </motion.div>
-  );
-}
 
 export default function Pricing() {
   const router = useRouter();

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -3,22 +3,10 @@
 
 "use client";
 
-import { useEffect } from "react";
 import { motion } from "framer-motion";
+import IntakeEmbed from "@/components/intake/IntakeEmbed";
 
 export default function QuizPage() {
-  useEffect(() => {
-    // Dynamically adjust iframe height from Tally
-    function handleTallyMessage(event: MessageEvent) {
-      if (event.origin.includes("tally.so") && event.data?.height) {
-        const iframe = document.querySelector<HTMLIFrameElement>("#tally-embed");
-        if (iframe) iframe.style.height = `${event.data.height}px`;
-      }
-    }
-    window.addEventListener("message", handleTallyMessage);
-    return () => window.removeEventListener("message", handleTallyMessage);
-  }, []);
-
   return (
     <main
       className="relative min-h-screen flex flex-col items-center justify-start
@@ -57,20 +45,9 @@ export default function QuizPage() {
         className="relative z-10 w-full max-w-5xl rounded-3xl overflow-hidden
                    shadow-xl ring-1 ring-gray-200 bg-white/95 backdrop-blur"
       >
-      {/* Quiz Embed — with subtle mask to hide bottom badge */}
+      {/* Shared intake embed */}
       <div className="relative w-full overflow-hidden rounded-3xl">
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-gradient-to-t from-white/95 via-white/60 to-transparent z-10 pointer-events-none" />
-        <iframe
-          id="tally-embed"
-          src="https://tally.so/embed/mOqRBk?alignLeft=1&hideTitle=1&transparentBackground=1"
-          title="LVE360 Quiz"
-          width="100%"
-          height="1200"
-          frameBorder="0"
-          marginHeight={0}
-          marginWidth={0}
-          className="w-full min-h-[900px] sm:min-h-[1200px]"
-        />
+        <IntakeEmbed className="min-h-[640px] w-full bg-white" />
       </div>
       </motion.div>
     </main>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "qa:build": "npm run typecheck && npm run build",
     "qa:canonical-host": "node src/_tests_/canonicalHost.assert.mjs",
     "qa:settings": "node src/_tests_/settingsPrivacy.assert.mjs",
+    "qa:intake": "node src/_tests_/intakeClarity.assert.mjs",
     "qa:all": "npm run qa:env && npm run qa:build"
   },
   "dependencies": {

--- a/src/_tests_/intakeClarity.assert.mjs
+++ b/src/_tests_/intakeClarity.assert.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+
+const embed = read("src/components/intake/IntakeEmbed.tsx");
+const modal = read("src/components/intake/IntakeModal.tsx");
+const home = read("app/page.tsx");
+const pricing = read("app/pricing/page.tsx");
+const quiz = read("app/quiz/page.tsx");
+const types = read("src/lib/productAnalyticsTypes.ts");
+const route = read("app/api/analytics/event/route.ts");
+const webhook = read("app/api/tally-webhook/route.ts");
+const tallyTypes = read("src/types/tally-normalized.ts");
+
+assert.match(embed, /Tally\.FormPageView/);
+assert.match(embed, /intake_page_viewed/);
+assert.match(embed, /We do not sell your health/);
+assert.match(embed, /Privacy Policy/);
+assert.match(modal, /IntakeEmbed/);
+assert.match(home, /components\/intake\/IntakeModal/);
+assert.match(pricing, /components\/intake\/IntakeModal/);
+assert.match(quiz, /components\/intake\/IntakeEmbed/);
+assert.match(types, /intake_page_viewed/);
+assert.match(route, /intake_page_viewed/);
+assert.match(webhook, /normalizeHeight/);
+assert.match(webhook, /normalizeWeightPounds/);
+for (const fieldId of [
+  "question_7K5g10",
+  "question_a4oPKX",
+  "question_2KO5bg",
+  "question_Pzk8r1",
+  "question_O7k8ka",
+  "question_o2lQ0N",
+  "question_Vzoy96",
+  "question_Bx8JON",
+]) {
+  assert.match(tallyTypes, new RegExp(fieldId));
+}
+for (const newGoalId of [
+  "fe7acb91-78e0-4472-8413-0f682e03ebb6",
+  "fbb243b9-3b5b-40d4-93ec-d5ad18287e5e",
+  "1ef089e2-3bce-4f45-aaac-009a23b3d348",
+  "63f72695-b77b-4f4f-a454-63894d59254c",
+]) {
+  assert.match(webhook, new RegExp(newGoalId));
+}
+
+console.log("Intake clarity assertions passed.");

--- a/src/components/intake/IntakeEmbed.tsx
+++ b/src/components/intake/IntakeEmbed.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef } from "react";
+
+import { trackProductEvent } from "@/lib/productAnalyticsClient";
+
+const FORM_ID = "mOqRBk";
+const TALLY_URL = `https://tally.so/embed/${FORM_ID}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1`;
+
+type TallyEvent = {
+  event?: string;
+  payload?: {
+    formId?: string;
+    page?: number;
+  };
+};
+
+function readTallyEvent(data: unknown): TallyEvent | null {
+  if (typeof data !== "string" || !data.includes("Tally.")) return null;
+  try {
+    return JSON.parse(data) as TallyEvent;
+  } catch {
+    return null;
+  }
+}
+
+export default function IntakeEmbed({
+  className = "min-h-[78vh] w-full bg-white",
+  showPrivacyNotice = true,
+}: {
+  className?: string;
+  showPrivacyNotice?: boolean;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const viewedPages = useRef(new Set<number>());
+
+  useEffect(() => {
+    function handleTallyMessage(event: MessageEvent) {
+      if (event.origin !== "https://tally.so") return;
+
+      if (event.data && typeof event.data === "object" && "height" in event.data) {
+        const height = Number((event.data as { height?: unknown }).height);
+        if (iframeRef.current && Number.isFinite(height) && height > 0) {
+          iframeRef.current.style.height = `${height}px`;
+        }
+      }
+
+      const tallyEvent = readTallyEvent(event.data);
+      if (
+        tallyEvent?.event !== "Tally.FormPageView" ||
+        tallyEvent.payload?.formId !== FORM_ID
+      ) return;
+
+      const page = Number(tallyEvent.payload.page);
+      if (!Number.isInteger(page) || page < 1 || page > 6 || viewedPages.current.has(page)) return;
+      viewedPages.current.add(page);
+      trackProductEvent({ event_name: "intake_page_viewed", source: "tally", step: page });
+    }
+
+    window.addEventListener("message", handleTallyMessage);
+    return () => window.removeEventListener("message", handleTallyMessage);
+  }, []);
+
+  return (
+    <div className="bg-white">
+      {showPrivacyNotice ? <IntakePrivacyNotice /> : null}
+      <iframe
+        ref={iframeRef}
+        src={TALLY_URL}
+        title="LVE360 health and lifestyle intake"
+        width="100%"
+        height="1100"
+        frameBorder="0"
+        marginHeight={0}
+        marginWidth={0}
+        className={className}
+      />
+    </div>
+  );
+}
+
+export function IntakePrivacyNotice() {
+  return (
+    <div className="border-b border-slate-200 bg-slate-50 px-6 py-4 pr-14 text-sm leading-6 text-slate-600">
+      <p>
+        <strong className="text-slate-900">Why we ask:</strong> Your answers help create your
+        personalized Blueprint and identify items that may need clinician or pharmacist review.
+      </p>
+      <p className="mt-1">
+        We use this information to provide your LVE360 experience. We do not sell your health
+        information. Read our{" "}
+        <Link className="font-semibold text-teal-700 underline underline-offset-2" href="/privacy">
+          Privacy Policy
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/src/components/intake/IntakeModal.tsx
+++ b/src/components/intake/IntakeModal.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useRef } from "react";
+
+import IntakeEmbed, { IntakePrivacyNotice } from "@/components/intake/IntakeEmbed";
+
+export default function IntakeModal({ onClose }: { onClose: () => void }) {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => event.key === "Escape" && onClose();
+    const onPointerDown = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) onClose();
+    };
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", onKeyDown);
+    document.addEventListener("mousedown", onPointerDown);
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      window.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("mousedown", onPointerDown);
+    };
+  }, [onClose]);
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur-sm sm:p-8"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="LVE360 intake"
+    >
+      <motion.div
+        ref={modalRef}
+        className="relative flex max-h-full w-full max-w-5xl flex-col overflow-hidden rounded-3xl bg-white shadow-2xl"
+        initial={{ opacity: 0, scale: 0.96 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.96 }}
+      >
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-3 z-10 rounded-full bg-white/90 px-3 py-1 text-xl text-slate-500 shadow-sm hover:bg-slate-100 hover:text-slate-900"
+          aria-label="Close intake"
+        >
+          ×
+        </button>
+        <IntakePrivacyNotice />
+        <div className="flex-1 overflow-auto">
+          <IntakeEmbed showPrivacyNotice={false} />
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/lib/intakeNormalization.ts
+++ b/src/lib/intakeNormalization.ts
@@ -1,0 +1,65 @@
+export type NormalizedHeight = {
+  display: string;
+  feet: number;
+  inches: number;
+  totalInches: number;
+  centimeters: number;
+};
+
+export function normalizeHeight(value: unknown): NormalizedHeight | undefined {
+  if (value == null) return undefined;
+  const raw = String(value).trim().toLowerCase();
+  if (!raw) return undefined;
+
+  const normalized = raw
+    .replace(/[’′]/g, "'")
+    .replace(/[“”″]/g, '"')
+    .replace(/\s+/g, " ");
+
+  let totalInches: number | undefined;
+  const feetAndInches = normalized.match(
+    /^(\d{1,2})(?:\s*(?:ft|feet|foot|'))(?:\s*[-,]?\s*)(\d{1,2})(?:\s*(?:in|inch|inches|"))?$/
+  );
+  const dashed = normalized.match(/^(\d{1,2})\s*-\s*(\d{1,2})$/);
+  const inchesOnly = normalized.match(/^(\d{2,3}(?:\.\d+)?)\s*(?:in|inch|inches|")$/);
+  const centimeters = normalized.match(/^(\d{2,3}(?:\.\d+)?)\s*(?:cm|centimeter|centimeters)$/);
+
+  if (feetAndInches || dashed) {
+    const match = feetAndInches ?? dashed;
+    const feet = Number(match?.[1]);
+    const inches = Number(match?.[2]);
+    if (feet >= 3 && feet <= 8 && inches >= 0 && inches < 12) {
+      totalInches = feet * 12 + inches;
+    }
+  } else if (inchesOnly) {
+    totalInches = Number(inchesOnly[1]);
+  } else if (centimeters) {
+    totalInches = Number(centimeters[1]) / 2.54;
+  }
+
+  if (!totalInches || totalInches < 36 || totalInches > 100) return undefined;
+
+  const roundedInches = Math.round(totalInches);
+  const feet = Math.floor(roundedInches / 12);
+  const inches = roundedInches % 12;
+  return {
+    display: `${feet}' ${inches}"`,
+    feet,
+    inches,
+    totalInches: roundedInches,
+    centimeters: Number((roundedInches * 2.54).toFixed(1)),
+  };
+}
+
+export function normalizeWeightPounds(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const raw = String(value).trim().toLowerCase();
+  if (!raw) return undefined;
+
+  const number = Number(raw.replace(/[^0-9.]/g, ""));
+  if (!Number.isFinite(number) || number <= 0) return undefined;
+
+  const pounds = /\bkg\b|kilogram/.test(raw) ? number * 2.20462 : number;
+  if (pounds < 50 || pounds > 1_500) return undefined;
+  return Number(pounds.toFixed(1));
+}

--- a/src/lib/mapTallyToEngine.ts
+++ b/src/lib/mapTallyToEngine.ts
@@ -1,4 +1,5 @@
 // src/lib/mapTallyToEngine.ts
+import { normalizeHeight, normalizeWeightPounds } from "@/lib/intakeNormalization";
 
 // ---------- Public types ----------
 export type EngineInput = {
@@ -166,13 +167,13 @@ export function mapTallyToEngine(
   // Profile basics
   const dob = getValue(fields, ['Date of Birth (used . to . . calculate age)', 'Date of Birth']) as string | undefined;
   const heightRaw = getValue(fields, ['Height']) as string | undefined;
-  const weightLb = getValue(fields, ['Weight (lbs)']) as number | undefined;
+  const weightLb = normalizeWeightPounds(getValue(fields, ['Weight (lbs)']));
 
   // Sex at birth
   const sexText = getSingleOptionText(fields, 'Sex at Birth');
   const sexAtBirth =
-    sexText?.toLowerCase().includes('male') ? 'M'
-    : sexText?.toLowerCase().includes('female') ? 'F'
+    sexText?.toLowerCase().includes('female') ? 'F'
+    : sexText?.toLowerCase().includes('male') ? 'M'
     : undefined;
 
   // Gender identity
@@ -225,7 +226,9 @@ export function mapTallyToEngine(
   pushMed(med2Name,  med2Purpose,  med2Dose,  med2Freq);
 
   // Height parsing + derived metrics
-  const { ft: height_ft, in: height_in } = parseHeightUS(heightRaw);
+  const normalizedHeight = normalizeHeight(heightRaw);
+  const height_ft = normalizedHeight?.feet;
+  const height_in = normalizedHeight?.inches;
   const profile: EngineInput['profile'] = {
     dob,
     sexAtBirth,

--- a/src/lib/productAnalyticsTypes.ts
+++ b/src/lib/productAnalyticsTypes.ts
@@ -2,6 +2,7 @@ export const PRODUCT_EVENT_NAMES = [
   "homepage_viewed",
   "pricing_viewed",
   "intake_started",
+  "intake_page_viewed",
   "intake_completed",
   "blueprint_viewed",
   "blueprint_action_selected",

--- a/supabase/migrations/20260726214727_intake_page_analytics.sql
+++ b/supabase/migrations/20260726214727_intake_page_analytics.sql
@@ -1,0 +1,14 @@
+alter table public.product_events
+  drop constraint if exists product_events_name;
+
+alter table public.product_events
+  add constraint product_events_name check (event_name in (
+    'homepage_viewed', 'pricing_viewed', 'intake_started', 'intake_page_viewed',
+    'intake_completed', 'blueprint_viewed', 'blueprint_action_selected',
+    'checkout_started', 'checkout_completed', 'activation_started',
+    'activation_completed', 'practice_completed', 'check_in_completed',
+    'weekly_review_opened', 'weekly_review_completed', 'subscription_cancelled'
+  ));
+
+comment on column public.product_events.step is
+  'Small ordinal step for bounded flows. For intake_page_viewed this is the Tally page number.';


### PR DESCRIPTION
## Summary

Improves the free intake experience without adding required questions or changing the four-page flow.

## What changed

- Replaced duplicated homepage, pricing, and quiz embeds with one shared intake component.
- Added clear purpose, privacy, and clinician-review context before users enter health information.
- Added privacy-minimized `intake_page_viewed` events so abandonment can be measured by Tally page number.
- Normalized height and weight values while preserving the canonical Tally field IDs and label fallbacks.
- Added compatibility assertions for the existing webhook contract and new lifestyle goal IDs.
- Added the Supabase constraint migration required for the new analytics event.
- Corrected sex-at-birth mapping so `Female` cannot be misclassified by the substring `male`.

## Live Tally update

The existing four-page form was updated and published without adding required steps. Copy now sets a realistic five-minute expectation, explains how answers are used, replaces vague completion language, and explicitly covers nutrition, relationships, career focus, and overall wellbeing.

## User impact

Users get a clearer explanation of why LVE360 asks for health context, broader alignment with the longevity and lifestyle thesis, and a more direct bridge from intake to the Blueprint and first weekly action. Existing webhook mappings remain compatible.

## Validation

- `npm run qa:intake`
- `npm run typecheck`
- Production `next build` with non-secret placeholder build variables
- Browser verification of `/quiz` and the homepage intake modal
- Live public Tally verification across pages 1 and 2
- Read-only verification of the existing Supabase analytics constraints and migration sequence

## Deployment note

Apply `20260726214727_intake_page_analytics.sql` before expecting page-view analytics to persist. Functional intake and webhook completion remain unaffected if the event write is temporarily unavailable.