### PR TITLE
Fix production reminder scheduler endpoint validation

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -22,6 +22,15 @@ jobs:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
           test -n "$CRON_SECRET"
-          curl --fail-with-body --retry 2 \
-            --header "Authorization: Bearer $CRON_SECRET" \
-            https://lve360.com/api/cron/reminders
+          response="$(
+            curl --fail-with-body --retry 2 \
+              --header "Authorization: Bearer $CRON_SECRET" \
+              https://app.lve360.com/api/cron/reminders
+          )"
+          echo "$response"
+          echo "$response" | jq -e '
+            .ok == true
+            and (.sent | type == "number")
+            and (.skipped | type == "number")
+            and (.failed | type == "number")
+          ' > /dev/null

--- a/src/_tests_/reminders.assert.mjs
+++ b/src/_tests_/reminders.assert.mjs
@@ -22,5 +22,7 @@ assert.match(migration, /enable row level security/i, "Reminder ledger must enab
 assert.match(migration, /idempotency_key text not null unique/i, "Reminder ledger must prevent duplicates");
 assert.match(workflow, /cron: "5 \* \* \* \*"/, "Reminder workflow must run hourly");
 assert.match(workflow, /secrets\.CRON_SECRET/, "Reminder workflow must authenticate with a repository secret");
+assert.match(workflow, /https:\/\/app\.lve360\.com\/api\/cron\/reminders/, "Reminder workflow must call the canonical production host directly");
+assert.match(workflow, /jq -e[\s\S]*\.ok == true/, "Reminder workflow must reject redirects and invalid dispatcher responses");
 
 console.log("reminder assertions passed");


### PR DESCRIPTION
## What changed

- Call the canonical production endpoint at `https://app.lve360.com/api/cron/reminders`
- Capture the dispatcher response and require `ok: true`
- Require numeric `sent`, `skipped`, and `failed` counters
- Add regression assertions for the canonical host and response validation

## Root cause

The scheduler called `https://lve360.com/api/cron/reminders`, which returns a 308 redirect to `app.lve360.com`. Curl treated the redirect as a successful HTTP response without executing the protected API route, producing a false-green workflow run and no delivery records.

## Validation

- `npm run qa:reminders`
- `npm run typecheck`
- `git diff --check`

After merge and production availability, manually run the Reminder dispatcher workflow and verify its JSON result plus the Supabase delivery ledger.