### PR TITLE
Audit PR 12.1: Add reminder dispatch diagnostics

### DIFF
--- a/app/api/cron/reminders/route.ts
+++ b/app/api/cron/reminders/route.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
 import {
   addDays,
-  decideReminder,
+  evaluateReminder,
   reminderIdempotencyKey,
   sendReminderEmail,
 } from "@/lib/reminders";
@@ -40,6 +40,11 @@ export async function GET(req: NextRequest) {
   let sent = 0;
   let skipped = 0;
   let failed = 0;
+  const skipReasons: Record<string, number> = {};
+  const countSkip = (reason: string) => {
+    skipped += 1;
+    skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
+  };
 
   for (const experiment of (experiments ?? []) as ExperimentRow[]) {
     try {
@@ -56,7 +61,13 @@ export async function GET(req: NextRequest) {
         || !profile?.email
         || (profile.tier !== "premium" && profile.tier !== "trial")
       ) {
-        skipped += 1;
+        countSkip(
+          preference?.reminder_preference !== "email"
+            ? "account_opted_out"
+            : !profile?.email
+              ? "missing_email"
+              : "ineligible_tier",
+        );
         continue;
       }
 
@@ -77,7 +88,7 @@ export async function GET(req: NextRequest) {
           .maybeSingle(),
       ]);
 
-      const decision = decideReminder({
+      const evaluation = evaluateReminder({
         now,
         timezone: preference.timezone,
         cueHour: preference.cue_hour,
@@ -87,10 +98,11 @@ export async function GET(req: NextRequest) {
         completedDates: (completions ?? []).map((item) => item.completion_date),
         reviewCompleted: review?.status === "completed",
       });
-      if (!decision) {
-        skipped += 1;
+      if (!evaluation.decision) {
+        countSkip(evaluation.reason);
         continue;
       }
+      const decision = evaluation.decision;
 
       const key = reminderIdempotencyKey(decision.kind, experiment.id, decision.localDate);
       const { data: delivery, error: claimError } = await admin
@@ -105,7 +117,7 @@ export async function GET(req: NextRequest) {
         .select("id")
         .single();
       if (claimError?.code === "23505") {
-        skipped += 1;
+        countSkip("already_delivered");
         continue;
       }
       if (claimError || !delivery) throw claimError ?? new Error("delivery_claim_failed");
@@ -142,5 +154,5 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  return NextResponse.json({ ok: true, sent, skipped, failed });
+  return NextResponse.json({ ok: true, sent, skipped, failed, skipReasons });
 }

--- a/src/_tests_/reminders.assert.mjs
+++ b/src/_tests_/reminders.assert.mjs
@@ -11,6 +11,8 @@ const workflow = fs.readFileSync(".github/workflows/reminders.yml", "utf8");
 assert.match(cron, /authorization.*Bearer/si, "Cron route must require CRON_SECRET authorization");
 assert.match(cron, /reminderIdempotencyKey/, "Cron route must deduplicate reminder sends");
 assert.match(cron, /weekly_review/, "Cron route must support the exact review path");
+assert.match(cron, /skipReasons/, "Cron route must report non-sensitive skip reasons");
+assert.match(reminders, /evaluateReminder/, "Reminder decisions must expose a testable reason");
 assert.match(reminders, /Missing a day is information, not failure/, "Recovery language must be nonjudgmental");
 assert.match(reminders, /isQuietHour/, "Dispatcher must respect quiet hours");
 assert.match(reminders, /weekly_review[\s\S]*:due/, "A weekly review cue must only send once per experiment");

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -3,6 +3,12 @@ import "server-only";
 import { Resend } from "resend";
 
 export type ReminderKind = "practice" | "recovery" | "weekly_review";
+export type ReminderSkipReason =
+  | "wrong_hour"
+  | "quiet_hours"
+  | "before_week"
+  | "review_complete"
+  | "completed_today";
 
 type LocalClock = {
   date: string;
@@ -47,20 +53,34 @@ export function addDays(date: string, amount: number): string {
   return value.toISOString().slice(0, 10);
 }
 
-export function decideReminder(input: ReminderDecisionInput): { kind: ReminderKind; localDate: string } | null {
+export function evaluateReminder(input: ReminderDecisionInput):
+  | { decision: { kind: ReminderKind; localDate: string }; reason: null }
+  | { decision: null; reason: ReminderSkipReason } {
   const clock = localClock(input.now, input.timezone);
-  if (clock.hour !== input.cueHour || isQuietHour(clock.hour, input.quietStartHour, input.quietEndHour)) return null;
+  if (clock.hour !== input.cueHour) return { decision: null, reason: "wrong_hour" };
+  if (isQuietHour(clock.hour, input.quietStartHour, input.quietEndHour)) {
+    return { decision: null, reason: "quiet_hours" };
+  }
 
   const weekEnd = addDays(input.weekStart, 6);
-  if (clock.date < input.weekStart) return null;
+  if (clock.date < input.weekStart) return { decision: null, reason: "before_week" };
   if (clock.date >= weekEnd) {
-    return input.reviewCompleted ? null : { kind: "weekly_review", localDate: clock.date };
+    return input.reviewCompleted
+      ? { decision: null, reason: "review_complete" }
+      : { decision: { kind: "weekly_review", localDate: clock.date }, reason: null };
   }
-  if (input.completedDates.includes(clock.date)) return null;
+  if (input.completedDates.includes(clock.date)) return { decision: null, reason: "completed_today" };
 
   const yesterday = addDays(clock.date, -1);
   const missedYesterday = yesterday >= input.weekStart && !input.completedDates.includes(yesterday);
-  return { kind: missedYesterday ? "recovery" : "practice", localDate: clock.date };
+  return {
+    decision: { kind: missedYesterday ? "recovery" : "practice", localDate: clock.date },
+    reason: null,
+  };
+}
+
+export function decideReminder(input: ReminderDecisionInput): { kind: ReminderKind; localDate: string } | null {
+  return evaluateReminder(input).decision;
 }
 
 export function reminderIdempotencyKey(kind: ReminderKind, experimentId: string, localDate: string): string {


### PR DESCRIPTION
## What changed

- reports privacy-safe aggregate reasons whenever the reminder scheduler skips an eligible experiment
- separates reminder decision evaluation from the compatibility wrapper so decisions and reasons remain explicit
- identifies account opt-out, missing email, ineligible tier, wrong cue hour, quiet hours, pre-week timing, completed review, completed daily practice, and duplicate delivery cases
- extends reminder QA coverage for the diagnostic contract

## Why

Production scheduler runs #3 and #4 both returned `sent=0, skipped=1, failed=0` even though the production member record was premium, email-enabled, inside the configured 6 PM Mountain cue hour, due for a weekly review, and had no delivery ledger entry. The current aggregate response does not identify which guard caused the skip.

This follow-up adds non-sensitive reason counts so the next controlled production run can isolate the failing branch without logging member data. It preserves the existing delivery and idempotency behavior.

## Validation

- `npm run typecheck`
- `npm run qa:reminders`
- branch comparison confirms one commit and only three reminder-related files against current `main`

The full local Next.js build compiles successfully but cannot finish page-data collection because `OPENAI_API_KEY` is not present in the local environment. Production environment configuration is unchanged.