### PR TITLE
Audit PR 12.2: Make reminder preference lookup fail-safe

### DIFF
--- a/app/api/cron/reminders/route.ts
+++ b/app/api/cron/reminders/route.ts
@@ -41,23 +41,46 @@ export async function GET(req: NextRequest) {
   let skipped = 0;
   let failed = 0;
   const skipReasons: Record<string, number> = {};
+  const failureReasons: Record<string, number> = {};
   const countSkip = (reason: string) => {
     skipped += 1;
     skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
   };
+  const countFailure = (reason: string) => {
+    failed += 1;
+    failureReasons[reason] = (failureReasons[reason] ?? 0) + 1;
+  };
 
   for (const experiment of (experiments ?? []) as ExperimentRow[]) {
     try {
-      const [{ data: preference }, { data: profile }] = await Promise.all([
+      const [
+        { data: preferences, error: preferenceError },
+        { data: profiles, error: profileError },
+      ] = await Promise.all([
         admin
           .from("user_preferences")
           .select("reminder_preference, timezone, cue_hour, quiet_start_hour, quiet_end_hour")
           .eq("user_id", experiment.user_id)
-          .maybeSingle(),
-        admin.from("users").select("email, tier").eq("id", experiment.user_id).maybeSingle(),
+          .limit(1),
+        admin.from("users").select("email, tier").eq("id", experiment.user_id).limit(1),
       ]);
+      if (preferenceError || profileError) {
+        countFailure(preferenceError ? "preference_lookup_failed" : "profile_lookup_failed");
+        console.error("[reminders] member context load failed", {
+          experimentId: experiment.id,
+          preferenceCode: preferenceError?.code,
+          profileCode: profileError?.code,
+        });
+        continue;
+      }
+      const preference = preferences?.[0];
+      const profile = profiles?.[0];
+      if (!preference) {
+        countSkip("missing_preference");
+        continue;
+      }
       if (
-        preference?.reminder_preference !== "email"
+        preference.reminder_preference !== "email"
         || !profile?.email
         || (profile.tier !== "premium" && profile.tier !== "trial")
       ) {
@@ -72,7 +95,10 @@ export async function GET(req: NextRequest) {
       }
 
       const weekEnd = addDays(experiment.week_start, 6);
-      const [{ data: completions }, { data: review }] = await Promise.all([
+      const [
+        { data: completions, error: completionsError },
+        { data: review, error: reviewError },
+      ] = await Promise.all([
         admin
           .from("daily_practice_completions")
           .select("completion_date")
@@ -87,6 +113,9 @@ export async function GET(req: NextRequest) {
           .eq("status", "completed")
           .maybeSingle(),
       ]);
+      if (completionsError || reviewError) {
+        throw completionsError ?? reviewError;
+      }
 
       const evaluation = evaluateReminder({
         now,
@@ -147,12 +176,12 @@ export async function GET(req: NextRequest) {
         event_key: `${key}:${result.status}`,
       });
       if (result.status === "sent") sent += 1;
-      else failed += 1;
+      else countFailure(`email_${result.reason}`);
     } catch (dispatchError) {
-      failed += 1;
+      countFailure("dispatch_error");
       console.error("[reminders] dispatch failed", { experimentId: experiment.id, dispatchError });
     }
   }
 
-  return NextResponse.json({ ok: true, sent, skipped, failed, skipReasons });
+  return NextResponse.json({ ok: true, sent, skipped, failed, skipReasons, failureReasons });
 }

--- a/src/_tests_/reminders.assert.mjs
+++ b/src/_tests_/reminders.assert.mjs
@@ -12,6 +12,9 @@ assert.match(cron, /authorization.*Bearer/si, "Cron route must require CRON_SECR
 assert.match(cron, /reminderIdempotencyKey/, "Cron route must deduplicate reminder sends");
 assert.match(cron, /weekly_review/, "Cron route must support the exact review path");
 assert.match(cron, /skipReasons/, "Cron route must report non-sensitive skip reasons");
+assert.match(cron, /failureReasons/, "Cron route must distinguish lookup failures from opt-outs");
+assert.match(cron, /preference_lookup_failed/, "Preference query failures must not be treated as opt-outs");
+assert.match(cron, /user_preferences[\s\S]*limit\(1\)/, "Preference lookup must use a bounded collection result");
 assert.match(reminders, /evaluateReminder/, "Reminder decisions must expose a testable reason");
 assert.match(reminders, /Missing a day is information, not failure/, "Recovery language must be nonjudgmental");
 assert.match(reminders, /isQuietHour/, "Dispatcher must respect quiet hours");


### PR DESCRIPTION
## What changed

- replaces singular preference and profile lookups with bounded collection reads against primary-key filters
- checks preference, profile, completion, and review query errors explicitly
- distinguishes real opt-outs, missing preference rows, lookup failures, dispatch failures, and email-provider failures
- keeps all scheduler diagnostics aggregate and free of member data
- extends reminder QA assertions for the fail-safe lookup contract

## Why

The first production run after PR #61 returned `skipReasons.account_opted_out=1`, while Supabase contained exactly one `user_preferences` row with `reminder_preference=email`. Vercel's `SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_URL` also point to the same production project.

The scheduler previously treated a null result from `.maybeSingle()` the same as an explicit account opt-out and discarded the accompanying query error. This change removes that ambiguous singular-response boundary and ensures database failures cannot masquerade as consent choices.

## Validation

- `npm run typecheck`
- `npm run qa:reminders`
- branch is one commit ahead of current `main`
- diff is limited to the scheduler route and reminder QA assertion file

## Production verification after merge

Run the Reminder dispatcher once during the configured 6 PM Mountain cue hour. Success requires `sent=1`, `failed=0`, a `sent` reminder ledger row with provider ID, and an idempotent skip on a repeat run.