### PR TITLE
Launch: enforce Free vs Premium access on the server

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { redirect } from "next/navigation";
 import { getUserAndTier } from "@/src/lib/getUserAndTier";
 import DashboardHeader from "@/components/DashboardHeader";
 
@@ -6,7 +7,8 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
-  const { tier } = await getUserAndTier(); // "free" | "trial" | "premium"
+  const { user, tier } = await getUserAndTier(); // "free" | "trial" | "premium"
+  if (!user) redirect("/login");
 
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB] text-gray-900">

--- a/app/(app)/results/premium/layout.tsx
+++ b/app/(app)/results/premium/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+import { requireTier } from "@/app/_auth/requireTier";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function PremiumResultsLayout({ children }: { children: ReactNode }) {
+  await requireTier(["premium", "trial"], { next: "/results/premium" });
+  return children;
+}

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { OpenAI } from "openai";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 // If you already have a helper in src/lib/openai.ts, you can import it instead.
 // import { openai } from "@/lib/openai";
@@ -17,6 +18,9 @@ function pct(numerator: number, denominator: number) {
 }
 
 export async function POST() {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
   const admin = getSupabaseAdmin();

--- a/app/api/debug/session/route.ts
+++ b/app/api/debug/session/route.ts
@@ -10,6 +10,10 @@ import { supabaseAdmin } from "@/lib/supabase";
 
 export async function GET() {
   try {
+    if (process.env.NODE_ENV === "production") {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+
     const supabase = createRouteHandlerClient({ cookies });
     const { data: { user }, error: authErr } = await supabase.auth.getUser();
 

--- a/app/api/env-check/route.ts
+++ b/app/api/env-check/route.ts
@@ -17,6 +17,10 @@ const DEFAULT_KEYS = [
 ];
 
 export async function GET(req: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
   const url = new URL(req.url);
   const showAll = url.searchParams.get('all') === '1';
 

--- a/app/api/export-pdf/route.ts
+++ b/app/api/export-pdf/route.ts
@@ -12,6 +12,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { renderReportPdf } from "@/lib/reportPdf";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
 import { REPORT_DISCLAIMER_TEXT, stripReportFences } from "@/lib/reportDocument";
+import { authorizeStackPayload } from "@/lib/serverEntitlements";
 
 function isUUID(id: string) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
@@ -45,6 +46,9 @@ export async function GET(req: NextRequest) {
     if (!stackRow) {
       return NextResponse.json({ ok: false, error: "Stack not found" }, { status: 404 });
     }
+
+    const authorization = await authorizeStackPayload(stackRow);
+    if (!authorization.ok) return authorization.response;
 
     const content = stripReportFences(
       (stackRow?.sections?.markdown as string | undefined) ??

--- a/app/api/fullscript/add/route.ts
+++ b/app/api/fullscript/add/route.ts
@@ -3,11 +3,15 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 // NEW: import timing helpers (you added src/lib/timing.ts earlier)
 import { bucketsForItem, collapseBucketsToString } from "@/src/lib/timing";
 
 export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
 

--- a/app/api/fullscript/search/route.ts
+++ b/app/api/fullscript/search/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 // --- Env ---
 const FULLSCRIPT_BASE = process.env.FULLSCRIPT_BASE_URL || "https://api.fullscript.com";
@@ -59,6 +60,9 @@ async function fullscriptSearch(q: string) {
 
 export async function GET(req: Request) {
   try {
+    const entitlement = await requirePaidApi();
+    if (!entitlement.ok) return entitlement.response;
+
     const { searchParams } = new URL(req.url);
     const q = (searchParams.get("q") || "").trim();
     if (!q) return NextResponse.json({ ok: true, items: [] });

--- a/app/api/generate-stack/route.ts
+++ b/app/api/generate-stack/route.ts
@@ -17,6 +17,7 @@ import type { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { generateStackForSubmission } from "@/lib/generateStack";
 import { sendGeneratedBlueprintEmail, type ReportEmailResult } from "@/lib/reportEmail";
+import { getRequestEntitlement, isPaidTier } from "@/lib/serverEntitlements";
 
 // Ensure long-running LLM work won’t time out on Vercel
 export const dynamic = "force-dynamic";
@@ -26,7 +27,7 @@ export const fetchCache = "force-no-store";
 export const revalidate = 0;
 
 // ---- local types ------------------------------------------------------------
-type Tier = "free" | "premium" | "unknown";
+type Tier = "free" | "trial" | "premium" | "unknown";
 type Mode = "free" | "premium";
 
 interface SubmissionRow {
@@ -303,9 +304,18 @@ export async function POST(req: NextRequest) {
     let tier: Tier = "free";
     if (submission.user_id) {
       const user = await fetchUserTierById(submission.user_id);
-      tier = user?.tier === "premium" ? "premium" : "free";
+      tier = user?.tier === "premium" || user?.tier === "trial" ? user.tier : "free";
     }
-    const mode: Mode = tier === "premium" ? "premium" : "free";
+    if (isPaidTier(tier)) {
+      const entitlement = await getRequestEntitlement();
+      if (!entitlement.user) {
+        return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+      }
+      if (!entitlement.paid || entitlement.user.id !== submission.user_id) {
+        return NextResponse.json({ ok: false, error: "premium_required" }, { status: 403 });
+      }
+    }
+    const mode: Mode = isPaidTier(tier) ? "premium" : "free";
 
     // Generate & persist (single source of truth in the generator)
     // Hint: cap Free stacks; Premium uncapped (or higher cap).

--- a/app/api/get-stack/route.ts
+++ b/app/api/get-stack/route.ts
@@ -6,6 +6,7 @@ export const fetchCache = "force-no-store"; // disable caching
 
 import { NextResponse, type NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
+import { authorizeStackPayload } from "@/lib/serverEntitlements";
 
 // Wait briefly for the submission row (webhook lag)
 async function waitForSubmissionByTally(
@@ -70,7 +71,7 @@ export async function GET(req: NextRequest) {
     const { data: stack, error } = await supabaseAdmin
       .from("stacks")
       .select(
-        "id, submission_id, user_id, user_email, safety_status, sections, tokens_used, prompt_tokens, completion_tokens, total_monthly_cost"
+        "id, submission_id, user_id, safety_status, summary, sections"
       )
       .eq("submission_id", submissionId)
       .maybeSingle();
@@ -94,6 +95,9 @@ export async function GET(req: NextRequest) {
       return res;
     }
 
+    const authorization = await authorizeStackPayload(stack);
+    if (!authorization.ok) return authorization.response;
+
     // Optionally count items
     let itemsCount = 0;
     try {
@@ -106,8 +110,15 @@ export async function GET(req: NextRequest) {
       // ignore count failure
     }
 
+    const publicStack = {
+      id: stack.id,
+      submission_id: stack.submission_id,
+      safety_status: stack.safety_status,
+      summary: stack.summary,
+      sections: stack.sections,
+    };
     const res = NextResponse.json(
-      { ok: true, exists: true, submission_id: submissionId, stack, itemsCount },
+      { ok: true, exists: true, submission_id: submissionId, stack: publicStack, itemsCount },
       { status: 200 }
     );
     res.headers.set("Cache-Control", "no-store, max-age=0");

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,19 +1,26 @@
 // app/api/goals/route.ts
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
 
 type Body = {
-  userId: string;
+  userId?: string;
   goals?: string[];       // e.g. ["Weight Loss","Longevity"]
   custom_goal?: string;   // free text
 };
 
 export async function GET(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const url = new URL(req.url);
-  const userId = url.searchParams.get("userId");
-  if (!userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
+  const requestedUserId = url.searchParams.get("userId");
+  if (requestedUserId && requestedUserId !== entitlement.user.id) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const userId = entitlement.user.id;
 
   const supabaseAdmin = getSupabaseAdmin();
   const { data, error } = await supabaseAdmin
@@ -27,12 +34,17 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const body = (await req.json()) as Body;
-  if (!body?.userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
+  if (body?.userId && body.userId !== entitlement.user.id) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
 
   const supabaseAdmin = getSupabaseAdmin();
   const payload = {
-    user_id: body.userId,
+    user_id: entitlement.user.id,
     goals: body.goals ?? [],
     custom_goal: body.custom_goal ?? null,
   };

--- a/app/api/goals/upsert/route.ts
+++ b/app/api/goals/upsert/route.ts
@@ -2,12 +2,16 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export async function POST(req: Request) {
   try {
+    const entitlement = await requirePaidApi();
+    if (!entitlement.ok) return entitlement.response;
+
     const cookieStore = cookies();
     const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
 

--- a/app/api/intake/set/route.ts
+++ b/app/api/intake/set/route.ts
@@ -3,9 +3,13 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 // Upsert today's intake event for (user, item)
 export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
   const admin = getSupabaseAdmin();

--- a/app/api/intake/status/route.ts
+++ b/app/api/intake/status/route.ts
@@ -2,11 +2,15 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
 export async function GET(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const supabase = createRouteHandlerClient({ cookies });
   const url = new URL(req.url);
 

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -8,8 +8,12 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export async function GET() {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { user },
@@ -38,6 +42,9 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { user },

--- a/app/api/models-healthcheck/route.ts
+++ b/app/api/models-healthcheck/route.ts
@@ -3,10 +3,10 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 import { NextResponse } from "next/server";
-import { callOpenAI } from "@/lib/openai";
-import { resolvedModels, askAny } from "@/lib/models";
 
-async function pingModel(model: string) {
+type CallOpenAI = typeof import("@/lib/openai").callOpenAI;
+
+async function pingModel(model: string, callOpenAI: CallOpenAI) {
   try {
     // Single-string input works for both families via our wrapper.
     const res = await callOpenAI(model, "Reply exactly: ok", {
@@ -37,15 +37,23 @@ async function pingModel(model: string) {
 }
 
 export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const [{ callOpenAI }, { resolvedModels }] = await Promise.all([
+    import("@/lib/openai"),
+    import("@/lib/models"),
+  ]);
   const key_present = Boolean(process.env.OPENAI_API_KEY);
   const resolved = resolvedModels();
 
   // Try 5* first, then 4o fallbacks — but report each explicitly.
   const [mini, main, fallbackMini, fallbackMain] = await Promise.all([
-    pingModel(resolved.MINI),
-    pingModel(resolved.MAIN),
-    pingModel(resolved.FALLBACK_MINI),
-    pingModel(resolved.FALLBACK_MAIN),
+    pingModel(resolved.MINI, callOpenAI),
+    pingModel(resolved.MAIN, callOpenAI),
+    pingModel(resolved.FALLBACK_MINI, callOpenAI),
+    pingModel(resolved.FALLBACK_MAIN, callOpenAI),
   ]);
 
   const ok = (mini.ok || main.ok || fallbackMini.ok || fallbackMain.ok) && key_present;

--- a/app/api/stack-items/activate/route.ts
+++ b/app/api/stack-items/activate/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const supabase = createRouteHandlerClient({ cookies });
   const { data: { user } } = await supabase.auth.getUser();
   if (!user?.id) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });

--- a/app/api/stack-items/route.ts
+++ b/app/api/stack-items/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
+import { authorizeStackPayload } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -42,6 +43,17 @@ export async function GET(req: NextRequest) {
       // Not an error: just no stack yet
       return NextResponse.json({ ok: true, items: [] }, { status: 200 });
     }
+
+    const { data: stack } = await supabaseAdmin
+      .from("stacks")
+      .select("id, user_id, sections")
+      .eq("id", stackId)
+      .maybeSingle();
+    if (!stack) {
+      return NextResponse.json({ ok: false, error: "stack_not_found" }, { status: 404 });
+    }
+    const authorization = await authorizeStackPayload(stack);
+    if (!authorization.ok) return authorization.response;
 
     const { data: items, error } = await supabaseAdmin
       .from("stacks_items")

--- a/app/api/stacks/combined/route.ts
+++ b/app/api/stacks/combined/route.ts
@@ -2,11 +2,15 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export async function GET() {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
   const supabase = createRouteHandlerClient({ cookies });
 
   // 0) Who's calling?

--- a/app/api/stacks/route.ts
+++ b/app/api/stacks/route.ts
@@ -1,9 +1,16 @@
 // app/api/stacks/route.ts
 import { NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
+import { requirePaidApi } from "@/lib/serverEntitlements";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export async function GET() {
   try {
+    const entitlement = await requirePaidApi();
+    if (!entitlement.ok) return entitlement.response;
+
     const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
     if (!supabaseUrl || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
       console.error("[API] Supabase env vars missing");
@@ -12,7 +19,8 @@ export async function GET() {
 
     const { data, error } = await supabaseAdmin
       .from("stacks")
-      .select("*")
+      .select("id, submission_id, created_at, safety_status, summary, sections")
+      .eq("user_id", entitlement.user.id)
       .order("created_at", { ascending: false })
       .limit(50);
 

--- a/app/api/stacks/update/route.ts
+++ b/app/api/stacks/update/route.ts
@@ -2,12 +2,16 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { bucketsForItem, collapseBucketsToString } from "@/src/lib/timing";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export async function POST(req: Request) {
   try {
+    const entitlement = await requirePaidApi();
+    if (!entitlement.ok) return entitlement.response;
+
     const supabase = createRouteHandlerClient({ cookies });
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });

--- a/app/api/stripe/confirm/route.ts
+++ b/app/api/stripe/confirm/route.ts
@@ -5,6 +5,8 @@ export const revalidate = false;
 
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { supabaseAdmin } from "@/lib/supabase";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2024-06-20" });
@@ -41,6 +43,14 @@ async function findUserIdByEmail(email: string | null | undefined) {
 // ---------- main ----------
 export async function GET(req: Request) {
   try {
+    const supabase = createRouteHandlerClient({ cookies });
+    const {
+      data: { user: authUser },
+    } = await supabase.auth.getUser();
+    if (!authUser?.id) {
+      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
+
     const url = new URL(req.url);
     const sessionId = url.searchParams.get("session_id");
     if (!sessionId) {
@@ -78,6 +88,14 @@ export async function GET(req: Request) {
 
     if (!targetUserId) {
       targetUserId = await findUserIdByEmail(customerEmail);
+    }
+
+    if (targetUserId !== authUser.id) {
+      console.warn("[stripe/confirm] session owner mismatch", {
+        authenticated_user_id: authUser.id,
+        resolved_user_id: targetUserId,
+      });
+      return NextResponse.json({ ok: false, error: "session_owner_mismatch" }, { status: 403 });
     }
 
     console.log("[stripe/confirm] session summary:", {

--- a/app/api/tally-last/route.ts
+++ b/app/api/tally-last/route.ts
@@ -9,9 +9,13 @@ import type { NextRequest } from "next/server";
 
 // Adjust this relative path if your central client is located elsewhere:
 import { supabaseAdmin } from "@/lib/supabase";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export async function GET(_req: NextRequest) {
   try {
+    const entitlement = await requirePaidApi();
+    if (!entitlement.ok) return entitlement.response;
+
     // Runtime env validation — return helpful JSON if missing
     const tallyUrl = process.env.TALLY_API_URL?.trim();
     if (tallyUrl) {
@@ -40,6 +44,7 @@ export async function GET(_req: NextRequest) {
       const { data, error } = await supabaseAdmin
         .from("submissions")
         .select("*")
+        .eq("user_id", entitlement.user.id)
         .order("created_at", { ascending: false })
         .limit(1);
 

--- a/app/api/test-health/route.ts
+++ b/app/api/test-health/route.ts
@@ -1,9 +1,15 @@
 import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
   return NextResponse.json({ ok: true, message: "Test-health POST works!" });
 }
 
 export async function GET(request: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
   return NextResponse.json({ ok: true, message: "Test-health GET works!" });
 }

--- a/app/api/test-stack/route.ts
+++ b/app/api/test-stack/route.ts
@@ -9,6 +9,10 @@ import { supabaseAdmin } from "@/lib/supabase";
  */
 
 export async function POST(req: NextRequest) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
   try {
     const body = await req.json().catch(() => ({}));
     const submissionId = (body.submissionId ?? body.submission_id ?? "").toString().trim();

--- a/app/api/users/tier/route.ts
+++ b/app/api/users/tier/route.ts
@@ -1,98 +1,31 @@
-// app/api/users/tier/route.ts
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 export const revalidate = false;
 
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { supabaseAdmin } from "@/lib/supabase";
 
-function isUUID(v: string) {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
-}
+import { getRequestEntitlement } from "@/lib/serverEntitlements";
 
-type Tier = "free" | "premium";
-
-function asTier(v: any): Tier {
-  return v === "premium" ? "premium" : "free";
-}
-
-export async function GET(req: Request) {
+export async function GET() {
   try {
-    const url = new URL(req.url);
-    const userIdParam = url.searchParams.get("userId");
+    const entitlement = await getRequestEntitlement();
+    if (!entitlement.user) {
+      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
 
-    // --- A) Explicit admin-style lookup: /api/users/tier?userId={uuid}
-    if (userIdParam) {
-      if (!isUUID(userIdParam)) {
-        console.warn("[users/tier] invalid userId:", userIdParam);
-        return NextResponse.json({ ok: false, error: "invalid userId" }, { status: 400 });
+    return NextResponse.json(
+      {
+        ok: true,
+        tier: entitlement.tier,
+        user_id: entitlement.user.id,
+      },
+      {
+        status: 200,
+        headers: { "Cache-Control": "private, no-store, max-age=0" },
       }
-
-      try {
-        const { data, error } = await supabaseAdmin
-          .from("users")
-          .select("id,tier")
-          .eq("id", userIdParam)
-          .maybeSingle();
-
-        if (error) {
-          console.warn("[users/tier] admin read error, falling back to free:", error.message);
-          return NextResponse.json({ ok: true, tier: "free", user_id: userIdParam }, { status: 200 });
-        }
-
-        const tier = asTier(data?.tier);
-        return NextResponse.json({ ok: true, tier, user_id: userIdParam }, { status: 200 });
-      } catch (e: any) {
-        console.warn("[users/tier] admin read exception, falling back to free:", e?.message || e);
-        return NextResponse.json({ ok: true, tier: "free", user_id: userIdParam }, { status: 200 });
-      }
-    }
-
-    // --- B) Cookie-session path: anonymous-safe (default to free)
-    const supabase = createRouteHandlerClient({ cookies });
-
-    // Use getSession (tolerates missing session) instead of getUser (which can throw)
-    const {
-      data: { session },
-      error: sessErr,
-    } = await supabase.auth.getSession();
-
-    if (sessErr) {
-      console.warn("[users/tier] getSession error, defaulting to free:", sessErr.message);
-      return NextResponse.json({ ok: true, tier: "free", user_id: null }, { status: 200 });
-    }
-
-    const userId = session?.user?.id ?? null;
-
-    // No session → anonymous visitor → free
-    if (!userId) {
-      return NextResponse.json({ ok: true, tier: "free", user_id: null }, { status: 200 });
-    }
-
-    // Has session: read user's tier (RLS-safe; tolerate failure → free)
-    try {
-      const { data, error } = await supabase
-        .from("users")
-        .select("id,tier")
-        .eq("id", userId)
-        .maybeSingle();
-
-      if (error) {
-        console.warn("[users/tier] cookie read error, defaulting to free:", error.message);
-        return NextResponse.json({ ok: true, tier: "free", user_id: userId }, { status: 200 });
-      }
-
-      const tier = asTier(data?.tier);
-      return NextResponse.json({ ok: true, tier, user_id: userId }, { status: 200 });
-    } catch (e: any) {
-      console.warn("[users/tier] cookie read exception, defaulting to free:", e?.message || e);
-      return NextResponse.json({ ok: true, tier: "free", user_id: userId }, { status: 200 });
-    }
-  } catch (e: any) {
-    // Last-resort fallback — never block UI; just report free
-    console.warn("[users/tier] unhandled, defaulting to free:", e?.message || e);
-    return NextResponse.json({ ok: true, tier: "free", user_id: null }, { status: 200 });
+    );
+  } catch (error) {
+    console.error("[users/tier] lookup failed", error);
+    return NextResponse.json({ ok: false, error: "tier_unavailable" }, { status: 500 });
   }
 }

--- a/app/upgrade/UpgradeClient.tsx
+++ b/app/upgrade/UpgradeClient.tsx
@@ -74,7 +74,7 @@ function Inner() {
         const premiumDestination = action ? "/onboarding" : "/today";
 
         console.log("[/upgrade] start check");
-        let res = await fetch("/api/users/tier", { cache: "no-store" });
+        const res = await fetch("/api/users/tier", { cache: "no-store" });
         console.log("[/upgrade] tier status:", res.status);
 
         if (res.status === 401) {
@@ -82,18 +82,6 @@ function Inner() {
           const next = requestedPlan ? `/upgrade?plan=${requestedPlan}` : "/upgrade";
           router.replace(`/login?next=${encodeURIComponent(next)}`);
           return;
-        }
-
-        // If your /api/users/tier sometimes insists on userId, try to get it
-        if (res.status === 400) {
-          console.log("[/upgrade] 400 (tier) → fetch /api/user for id fallback");
-          const who = await fetch("/api/user", { cache: "no-store" })
-            .then(r => (r.ok ? r.json() : null))
-            .catch(() => null);
-          if (who?.id) {
-            res = await fetch(`/api/users/tier?userId=${encodeURIComponent(who.id)}`, { cache: "no-store" });
-            console.log("[/upgrade] retried tier with userId, status:", res.status);
-          }
         }
 
         let data: any = null;
@@ -104,7 +92,7 @@ function Inner() {
         console.log("[/upgrade] current tier:", t);
         setTier(t);
 
-        if (t === "premium") {
+        if (t === "premium" || t === "trial") {
           setBanner(action ? "Your first-week action is ready. Opening onboarding..." : "Welcome back! Redirecting to your dashboard...");
           console.log("[/upgrade] premium destination", premiumDestination);
           setTimeout(() => router.replace(premiumDestination), 400);
@@ -125,18 +113,14 @@ function Inner() {
           const deadline = Date.now() + 9000; // up to 9s
           console.log("[/upgrade] polling for premium flip…");
           while (Date.now() < deadline) {
-            let rr = await fetch("/api/users/tier", { cache: "no-store" });
-            if (rr.status === 400) {
-              const who = await fetch("/api/user", { cache: "no-store" }).then(r => (r.ok ? r.json() : null)).catch(() => null);
-              if (who?.id) rr = await fetch(`/api/users/tier?userId=${encodeURIComponent(who.id)}`, { cache: "no-store" });
-            }
+            const rr = await fetch("/api/users/tier", { cache: "no-store" });
             if (rr.status === 401) {
               console.log("[/upgrade] lost session during poll → to login");
               router.replace("/login?next=/today");
               return;
             }
             const j = await rr.json().catch(() => null);
-            if (j?.tier === "premium") {
+            if (j?.tier === "premium" || j?.tier === "trial") {
               console.log("[/upgrade] premium flip destination", premiumDestination);
               setBanner(action ? "All set! Opening your first-week setup..." : "All set! Taking you to your dashboard...");
               setTimeout(() => router.replace(premiumDestination), 400);

--- a/app/upgrade/success/SuccessClient.tsx
+++ b/app/upgrade/success/SuccessClient.tsx
@@ -28,14 +28,18 @@ function Inner() {
         });
         const json = await res.json();
 
+        if (res.status === 401) {
+          setMsg("Almost done. Please confirm your login...");
+          router.replace(`/login?next=${encodeURIComponent(premiumDestination)}`);
+          return;
+        }
+
         if (!json?.ok) {
           setMsg("We couldn’t verify your subscription. Taking you back…");
           setTimeout(() => router.replace("/upgrade"), 1000);
           return;
         }
 
-        // Data we’ll use for polling when cookie is late
-        const targetUserId: string | null = json.user_id ?? null;
         const premium: boolean = !!json.premium;
 
         // 2) Quick cookie check: can we read tier for *current* session?
@@ -47,16 +51,15 @@ function Inner() {
           return;
         }
 
-        // 3) If server session exists but still not premium (replication lag),
-        //    poll /api/users/tier for the *target* userId for a few seconds.
-        if (!premium && targetUserId) {
+        // 3) If the webhook is still settling, poll only the signed-in account.
+        if (!premium) {
           setMsg("Finalizing your Premium access…");
           const deadline = Date.now() + 6000; // up to 6s
           let isPremium = false;
 
           while (Date.now() < deadline) {
             // use explicit userId so we don't depend on cookie yet
-            const r = await fetch(`/api/users/tier?userId=${targetUserId}`, { cache: "no-store" });
+            const r = await fetch("/api/users/tier", { cache: "no-store" });
             const j = await r.json().catch(() => null);
             if (j?.tier === "premium") {
               isPremium = true;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "qa:intake": "node src/_tests_/intakeClarity.assert.mjs",
     "qa:reminders": "node src/_tests_/reminders.assert.mjs",
     "qa:journey": "node src/_tests_/journey.assert.mjs",
+    "qa:gating": "node src/_tests_/premiumGating.assert.mjs",
     "qa:all": "npm run qa:env && npm run qa:build"
   },
   "dependencies": {

--- a/src/_tests_/premiumGating.assert.mjs
+++ b/src/_tests_/premiumGating.assert.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const entitlementHelper = read("src/lib/serverEntitlements.ts");
+assert.match(entitlementHelper, /auth\.getUser\(\)/, "Entitlements must validate the server-side user.");
+assert.match(entitlementHelper, /tier === "premium" \|\| tier === "trial"/, "Premium and trial must be paid tiers.");
+assert.match(entitlementHelper, /stackContainsPremiumPayload/, "Premium report payloads need a shared classifier.");
+assert.match(entitlementHelper, /entitlement\.user\.id !== stack\.user_id/, "Premium reports must be owner-bound.");
+
+const appLayout = read("app/(app)/layout.tsx");
+assert.match(appLayout, /getUserAndTier\(\)/, "The authenticated app shell must validate the current user on the server.");
+assert.match(appLayout, /if \(!user\) redirect\("\/login"\)/, "The authenticated app shell must reject logged-out visitors.");
+
+const premiumResultsLayout = read("app/(app)/results/premium/layout.tsx");
+assert.match(
+  premiumResultsLayout,
+  /requireTier\(\["premium", "trial"\]/,
+  "The legacy premium results route must be server-gated."
+);
+
+const dashboardHeader = read("src/components/DashboardHeader.tsx");
+assert.match(dashboardHeader, /tier === "premium" \|\| tier === "trial"/, "Paid navigation must use the shared tier boundary.");
+assert.match(dashboardHeader, /item\.href === "\/blueprints" \|\| item\.href === "\/settings"/, "Free navigation must hide paid dashboard destinations.");
+assert.match(dashboardHeader, /Join LVE360/, "Free accounts need a clear membership path instead of paid navigation.");
+
+const tierRoute = read("app/api/users/tier/route.ts");
+assert.match(tierRoute, /getRequestEntitlement/, "Tier lookup must derive identity from the signed-in request.");
+assert.doesNotMatch(tierRoute, /searchParams|getSession|supabaseAdmin/, "Tier lookup must not accept arbitrary user IDs.");
+
+const paidApiRoutes = [
+  "app/api/ai-insights/route.ts",
+  "app/api/fullscript/search/route.ts",
+  "app/api/fullscript/add/route.ts",
+  "app/api/stacks/combined/route.ts",
+  "app/api/stacks/update/route.ts",
+  "app/api/stack-items/activate/route.ts",
+  "app/api/intake/set/route.ts",
+  "app/api/intake/status/route.ts",
+  "app/api/logs/route.ts",
+  "app/api/goals/route.ts",
+  "app/api/goals/upsert/route.ts",
+  "app/api/stacks/route.ts",
+  "app/api/tally-last/route.ts",
+];
+
+for (const path of paidApiRoutes) {
+  assert.match(read(path), /requirePaidApi/, `${path} must enforce paid access on the server.`);
+}
+
+for (const path of [
+  "app/api/get-stack/route.ts",
+  "app/api/export-pdf/route.ts",
+  "app/api/stack-items/route.ts",
+]) {
+  assert.match(
+    read(path),
+    /authorizeStackPayload/,
+    `${path} must prevent non-owners from reading premium-generated report data.`
+  );
+}
+
+const getStack = read("app/api/get-stack/route.ts");
+assert.doesNotMatch(
+  getStack,
+  /user_email, safety_status|tokens_used|prompt_tokens|completion_tokens|total_monthly_cost/,
+  "The public free-Blueprint response must not expose identity or operational metadata."
+);
+
+const generateStack = read("app/api/generate-stack/route.ts");
+assert.match(generateStack, /entitlement\.user\.id !== submission\.user_id/, "Premium generation must be owner-bound.");
+assert.match(generateStack, /isPaidTier\(tier\)/, "Premium generation must use the shared paid-tier policy.");
+
+const stripeConfirm = read("app/api/stripe/confirm/route.ts");
+assert.match(stripeConfirm, /auth\.getUser\(\)/, "Checkout confirmation must require the signed-in purchaser.");
+assert.match(stripeConfirm, /targetUserId !== authUser\.id/, "Checkout confirmation must reject session-owner mismatches.");
+
+for (const path of [
+  "app/api/test-stack/route.ts",
+  "app/api/test-health/route.ts",
+  "app/api/models-healthcheck/route.ts",
+  "app/api/env-check/route.ts",
+  "app/api/debug/session/route.ts",
+]) {
+  assert.match(read(path), /NODE_ENV === "production"/, `${path} must be unavailable in production.`);
+}
+
+console.log("Premium gating assertions passed.");

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -22,6 +22,10 @@ export default function DashboardHeader({ tier = "free" }: Props) {
   const router = useRouter();
   const supabase = createClientComponentClient();
   const [menuOpen, setMenuOpen] = useState(false);
+  const paid = tier === "premium" || tier === "trial";
+  const navigationItems = paid
+    ? AUTHENTICATED_NAV_ITEMS
+    : AUTHENTICATED_NAV_ITEMS.filter((item) => item.href === "/blueprints" || item.href === "/settings");
 
   async function handleSignOut() {
     setMenuOpen(false);
@@ -34,7 +38,7 @@ export default function DashboardHeader({ tier = "free" }: Props) {
     <header className="sticky top-0 z-50 border-b border-slate-200/80 bg-white/90 shadow-[0_2px_12px_rgba(0,0,0,0.04)] backdrop-blur-xl">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
         <Link
-          href="/today"
+          href={paid ? "/today" : "/blueprints"}
           className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
           aria-label="LVE360 Today"
         >
@@ -50,13 +54,21 @@ export default function DashboardHeader({ tier = "free" }: Props) {
         </Link>
 
         <nav className="hidden items-center gap-1 text-sm font-semibold text-[#041B2D] md:flex" aria-label="Member navigation">
-          {AUTHENTICATED_NAV_ITEMS.map((item) => (
+          {navigationItems.map((item) => (
             <NavLink key={item.href} href={item.href} pathname={pathname}>
               {item.label}
             </NavLink>
           ))}
           <span className="mx-2 h-6 w-px bg-slate-200" aria-hidden="true" />
           <span className="sr-only">Current plan: {tier}</span>
+          {!paid ? (
+            <Link
+              href="/upgrade"
+              className="rounded-lg border border-[#6D36C9] px-3 py-2 text-[#6D36C9] transition hover:bg-purple-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6D36C9] focus-visible:ring-offset-2"
+            >
+              Join LVE360
+            </Link>
+          ) : null}
           <button
             type="button"
             onClick={handleSignOut}
@@ -90,7 +102,7 @@ export default function DashboardHeader({ tier = "free" }: Props) {
             className="border-t border-slate-200 bg-white md:hidden"
           >
             <nav className="mx-auto flex max-w-6xl flex-col gap-1 p-4 text-base font-semibold text-[#041B2D]" aria-label="Mobile member navigation">
-              {AUTHENTICATED_NAV_ITEMS.map((item) => (
+              {navigationItems.map((item) => (
                 <NavLink
                   key={item.href}
                   href={item.href}
@@ -101,6 +113,15 @@ export default function DashboardHeader({ tier = "free" }: Props) {
                   {item.label}
                 </NavLink>
               ))}
+              {!paid ? (
+                <Link
+                  href="/upgrade"
+                  onClick={() => setMenuOpen(false)}
+                  className="min-h-11 rounded-xl border border-[#6D36C9] px-4 py-3 text-[#6D36C9]"
+                >
+                  Join LVE360
+                </Link>
+              ) : null}
               <button
                 type="button"
                 onClick={handleSignOut}

--- a/src/lib/serverEntitlements.ts
+++ b/src/lib/serverEntitlements.ts
@@ -1,0 +1,102 @@
+import "server-only";
+
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { User } from "@supabase/supabase-js";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdmin } from "./supabaseAdmin";
+
+export type AccountTier = "free" | "trial" | "premium";
+
+export type RequestEntitlement = {
+  user: User | null;
+  tier: AccountTier;
+  paid: boolean;
+};
+
+function normalizeTier(value: unknown): AccountTier {
+  return value === "premium" || value === "trial" ? value : "free";
+}
+
+export function isPaidTier(tier: unknown): tier is "trial" | "premium" {
+  return tier === "premium" || tier === "trial";
+}
+
+export function stackContainsPremiumPayload(sections: unknown): boolean {
+  if (!sections || typeof sections !== "object") return false;
+  return (sections as { mode?: unknown }).mode === "premium";
+}
+
+export async function getRequestEntitlement(): Promise<RequestEntitlement> {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user?.id) {
+    return { user: null, tier: "free", paid: false };
+  }
+
+  const { data: profile, error: profileError } = await getSupabaseAdmin()
+    .from("users")
+    .select("tier")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error("[entitlements] profile lookup failed", {
+      userId: user.id,
+      message: profileError.message,
+    });
+  }
+
+  const tier = normalizeTier(profile?.tier);
+  return { user, tier, paid: isPaidTier(tier) };
+}
+
+export async function requirePaidApi(): Promise<
+  | { ok: true; user: User; tier: "trial" | "premium" }
+  | { ok: false; response: NextResponse }
+> {
+  const entitlement = await getRequestEntitlement();
+  if (!entitlement.user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }),
+    };
+  }
+  if (!isPaidTier(entitlement.tier)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ ok: false, error: "premium_required" }, { status: 403 }),
+    };
+  }
+  return { ok: true, user: entitlement.user, tier: entitlement.tier };
+}
+
+export async function authorizeStackPayload(stack: {
+  user_id?: string | null;
+  sections?: unknown;
+}): Promise<
+  | { ok: true }
+  | { ok: false; response: NextResponse }
+> {
+  if (!stackContainsPremiumPayload(stack.sections)) return { ok: true };
+
+  const entitlement = await getRequestEntitlement();
+  if (!entitlement.user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }),
+    };
+  }
+  if (!entitlement.paid || !stack.user_id || entitlement.user.id !== stack.user_id) {
+    return {
+      ok: false,
+      response: NextResponse.json({ ok: false, error: "premium_required" }, { status: 403 }),
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Purpose
Close the launch-critical revenue and privacy gap where older routes relied on UI-only gating or accepted caller-supplied user IDs.

## What changed
- Added one server entitlement policy for Free, Trial, and Premium accounts.
- Required authentication for the app shell and paid entitlement for Today/Journey data, AI summaries, plan edits, check-ins, goals, Fullscript actions, and refill-related stack data.
- Kept the intended anonymous Tally-to-free-Blueprint flow intact.
- Bound premium-generated report, item, PDF, and regeneration access to the signed-in Premium owner.
- Removed arbitrary `userId` tier lookups and owner-bound Stripe checkout confirmation.
- Hid paid dashboard navigation for Free accounts and added a clear membership CTA.
- Removed identity and token/cost metadata from the public free-Blueprint response.
- Disabled development diagnostics in production.
- Added focused regression assertions for route, report, navigation, and checkout boundaries.

## Verification
- `npm run typecheck`
- `npm run qa:gating`
- `npm run build` with non-secret placeholder values for required build-time environment variables
- `git diff --check`

## Not verified locally
- Real Supabase sessions for logged-out, Free, Trial, and Premium accounts
- A live Stripe checkout return and webhook reconciliation
- Production mobile behavior

These require the Vercel preview and production-connected test accounts because this checkout does not contain production secrets.

## Risk and rollback
The main risk is an older dashboard client discovering a previously unprotected endpoint and now receiving the intended `401` or `403`. Reverting this PR restores the prior behavior. No database schema or environment-variable changes are included.

## Follow-up QA
1. Logged out: protected pages redirect to login and paid APIs return `401`.
2. Free: Blueprint remains available; paid navigation is hidden; paid APIs return `403`.
3. Premium/Trial: dashboard pages and APIs succeed.
4. Direct premium report/API access from another account returns no payload.
5. Checkout confirmation succeeds only for the purchaser's session.