### PR TITLE
PR14 follow-up: Fix Blueprint hydration and refresh delivery

### DIFF
--- a/app/(app)/blueprints/BlueprintsClient.tsx
+++ b/app/(app)/blueprints/BlueprintsClient.tsx
@@ -159,5 +159,10 @@ function formatDate(value: string | null | undefined): string | null {
   if (!value) return null;
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -608,7 +608,12 @@ function formatDate(value: string | null): string {
   const date = new Date(value);
   return Number.isNaN(date.getTime())
     ? "date unavailable"
-    : date.toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" });
+    : date.toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "UTC",
+      });
 }
 
 function messageForSupplementError(value: unknown): string {

--- a/src/_tests_/interactiveBlueprints.assert.mjs
+++ b/src/_tests_/interactiveBlueprints.assert.mjs
@@ -47,6 +47,22 @@ const workspace = read("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.
 assert.match(workspace, /Refresh Blueprint and safety review/, "Stale reports need one honest refresh action.");
 assert.match(workspace, /Mark an item stopped to preserve the history/, "Stopping a supplement must preserve its history.");
 assert.match(workspace, /Start this weekly practice/, "Lifestyle guidance must connect to the existing practice loop.");
+assert.match(workspace, /timeZone: "UTC"/, "Blueprint dates must render consistently during hydration.");
 assert.doesNotMatch(workspace, /\bNo safety issues detected\b/i, "Customer-facing copy must not make an absolute safety claim.");
+
+const blueprintLibrary = read("app/(app)/blueprints/BlueprintsClient.tsx");
+assert.match(blueprintLibrary, /timeZone: "UTC"/, "Blueprint library dates must render consistently during hydration.");
+
+const reportEmail = read("src/lib/reportEmail.ts");
+assert.match(
+  reportEmail,
+  /blueprintEmailIdempotencyKey\(submissionId: string, stackId: string\)/,
+  "Each immutable Blueprint version must have its own delivery idempotency key."
+);
+assert.match(
+  reportEmail,
+  /blueprint-email-\$\{submissionId\}-\$\{stackId\}/,
+  "Refresh delivery must not reuse the original Blueprint email key."
+);
 
 console.log("Interactive Blueprint assertions passed.");

--- a/src/lib/reportEmail.ts
+++ b/src/lib/reportEmail.ts
@@ -18,8 +18,8 @@ type SendReportEmailInput = {
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function blueprintEmailIdempotencyKey(submissionId: string): string {
-  return `blueprint-email-${submissionId}`;
+export function blueprintEmailIdempotencyKey(submissionId: string, stackId: string): string {
+  return `blueprint-email-${submissionId}-${stackId}`;
 }
 
 function escapeHtml(value: string): string {
@@ -84,7 +84,7 @@ export async function sendGeneratedBlueprintEmail(input: SendReportEmailInput): 
     const pdf = await renderReportPdf(report.canonicalMarkdown, REPORT_DISCLAIMER_TEXT);
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL?.trim() || "https://app.lve360.com").replace(/\/$/, "");
     const reportUrl = `${appUrl}/results?submission_id=${encodeURIComponent(input.submissionId)}`;
-    const idempotencyKey = blueprintEmailIdempotencyKey(input.submissionId);
+    const idempotencyKey = blueprintEmailIdempotencyKey(input.submissionId, input.stackId);
     const resend = new Resend(apiKey);
     console.info("[report-email] send attempt", {
       submissionId: input.submissionId,


### PR DESCRIPTION
## What changed

- Formats Blueprint dates with an explicit locale and UTC timezone so server and browser output remain identical during hydration.
- Makes report-email idempotency version-specific by including the immutable stack ID.
- Adds regression assertions for both production QA findings.

## Why

Production QA after PR #65 successfully generated a refreshed Blueprint, historical version, PDF target, and email. It also exposed repeated React hydration errors when the server date and the member's local date fell on different calendar days. The previous email key was submission-specific, which could suppress a legitimate email for a newly generated version during the provider's idempotency window.

## Impact

Blueprint pages hydrate cleanly across timezones, and each immutable Blueprint version can send exactly one delivery email without colliding with another version for the same submission.

## Validation

- `npm run qa:blueprints`
- `npm run qa:gating`
- `npm run typecheck`
- `npm run build` with inert build-only environment placeholders
- `git diff --check`
- Production refresh confirmed new version creation, preserved history, and provider-accepted email delivery