### PR TITLE
Complete launch legal and support pages

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+
+import { LegalPage } from "@/components/legal/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description: "Contact LVE360 for account, billing, privacy, or Blueprint support.",
+};
+
+const updated = "July 29, 2026";
+
+export default function ContactPage() {
+  return (
+    <LegalPage
+      title="Contact LVE360"
+      updated={updated}
+      description="Use the support address below for account, billing, privacy, or Blueprint questions. Please do not send payment card numbers or highly sensitive medical documents by email."
+    >
+      <section>
+        <h2>General and account support</h2>
+        <p>
+          Email <a href="mailto:support@lve360.com">support@lve360.com</a>. Include the email address
+          connected to your account and a short description of the issue. Do not include passwords,
+          payment card numbers, or access codes.
+        </p>
+      </section>
+
+      <section>
+        <h2>Billing</h2>
+        <p>
+          Members can open Settings and choose Manage Billing for subscription changes. If checkout,
+          access, or a charge does not look right, email support with the date and a brief description.
+          Stripe payment card details should not be sent to LVE360.
+        </p>
+      </section>
+
+      <section>
+        <h2>Privacy requests</h2>
+        <p>
+          You can download or delete connected account data through Settings. For access,
+          correction, deletion, or privacy questions, email support with &quot;Privacy Request&quot;
+          in the subject line.
+        </p>
+      </section>
+
+      <section>
+        <h2>Blueprint safety or accuracy concern</h2>
+        <p>
+          If your Blueprint appears to use the wrong personal information or contains a potentially
+          unsafe statement, stop relying on that section and email support with &quot;Blueprint
+          Review&quot; in the subject line. Do not use this channel for urgent medical needs.
+        </p>
+      </section>
+
+      <section>
+        <h2>Medical emergencies</h2>
+        <p>
+          LVE360 does not provide emergency services. Contact local emergency services if you
+          believe you may have a medical emergency.
+        </p>
+      </section>
+    </LegalPage>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -86,6 +86,9 @@ export default function RootLayout({ children }) {
               <Link href="/privacy" className="hover:text-purple-600 transition-colors">
                 Privacy
               </Link>
+              <Link href="/medical-disclaimer" className="hover:text-purple-600 transition-colors">
+                Medical Disclaimer
+              </Link>
               <Link href="/contact" className="hover:text-purple-600 transition-colors">
                 Contact
               </Link>

--- a/app/medical-disclaimer/page.tsx
+++ b/app/medical-disclaimer/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+
+import { LegalPage } from "@/components/legal/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Medical Disclaimer",
+  description: "Important limitations on LVE360 wellness, supplement, and lifestyle information.",
+};
+
+const updated = "July 29, 2026";
+
+export default function MedicalDisclaimerPage() {
+  return (
+    <LegalPage
+      eyebrow="Important health information"
+      title="Medical Disclaimer"
+      updated={updated}
+      description="LVE360 is an educational wellness service. It is designed to help you organize information, notice questions, and prepare for better-informed decisions. It is not medical care."
+    >
+      <section>
+        <h2>Not a medical professional relationship</h2>
+        <p>
+          Using LVE360 does not create a physician-patient, pharmacist-patient, therapist-client, or
+          other healthcare professional relationship. LVE360 does not diagnose, treat, cure, prevent,
+          or manage any disease or medical condition.
+        </p>
+      </section>
+
+      <section>
+        <h2>Do not rely on LVE360 for emergencies</h2>
+        <p>
+          If you believe you may have a medical emergency, contact local emergency services now.
+          LVE360 and its support email are not monitored or designed for urgent medical needs.
+        </p>
+      </section>
+
+      <section>
+        <h2>Supplement and medication decisions</h2>
+        <p>
+          Supplements can cause side effects and may interact with medications, procedures, health
+          conditions, pregnancy, nursing, allergies, or each other. Do not start, stop, or change a
+          medication or prescribed treatment based on LVE360. Discuss supplement changes with a
+          qualified clinician or pharmacist when appropriate.
+        </p>
+      </section>
+
+      <section>
+        <h2>Limits of personalized information</h2>
+        <p>
+          A Blueprint is based on the details you provide and the information available when it is
+          generated. It may not include every relevant risk, interaction, contraindication, or new
+          piece of evidence. A statement that no material concern was identified does not mean a
+          product or combination is safe for every person.
+        </p>
+        <p>
+          Update your health context when your medications, supplements, conditions, symptoms,
+          pregnancy status, procedures, laboratory results, or goals change. Older Blueprints may no
+          longer reflect your current circumstances.
+        </p>
+      </section>
+
+      <section>
+        <h2>Evidence and outcomes</h2>
+        <p>
+          Wellness and supplement evidence varies in quality and may change. LVE360 may summarize
+          evidence, but it does not guarantee accuracy, completeness, effectiveness, or a particular
+          outcome. Individual results vary.
+        </p>
+      </section>
+
+      <section>
+        <h2>Third-party products</h2>
+        <p>
+          A product link is not a guarantee of quality, safety, availability, or suitability.
+          Review product labels and independent seller terms. LVE360 may receive affiliate
+          compensation from some links, but a purchase is not required to use your Blueprint.
+        </p>
+      </section>
+
+      <section>
+        <h2>Questions or corrections</h2>
+        <p>
+          If a Blueprint appears to contain incorrect personal information or an unsafe statement,
+          stop relying on that section and contact{" "}
+          <a href="mailto:support@lve360.com">support@lve360.com</a>.
+        </p>
+      </section>
+    </LegalPage>
+  );
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -119,7 +119,12 @@ export default function Pricing() {
         </div>
         <div className="mt-9 rounded-2xl bg-white/10 p-5 text-sm leading-6 text-slate-200">
           <p><strong className="text-white">Your health information stays out of checkout.</strong> Stripe receives the account and billing details needed to process payment. Your supplement, medication, and health-profile answers are not sent to Stripe.</p>
-          <p className="mt-3">You can cancel from <strong className="text-white">Settings &gt; Manage Billing</strong>. Read our <Link href="/privacy" className="font-semibold text-teal-300 underline decoration-teal-300/50 underline-offset-4">Privacy Policy</Link>.</p>
+          <p className="mt-3">
+            You can cancel from <strong className="text-white">Settings &gt; Manage Billing</strong>. Before joining,
+            review our <Link href="/terms" className="font-semibold text-teal-300 underline decoration-teal-300/50 underline-offset-4">Terms</Link>,{" "}
+            <Link href="/privacy" className="font-semibold text-teal-300 underline decoration-teal-300/50 underline-offset-4">Privacy Policy</Link>, and{" "}
+            <Link href="/medical-disclaimer" className="font-semibold text-teal-300 underline decoration-teal-300/50 underline-offset-4">Medical Disclaimer</Link>.
+          </p>
         </div>
       </section>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   description: "How LVE360 collects, uses, stores, exports, and deletes account and wellness information.",
 };
 
-const updated = "July 26, 2026";
+const updated = "July 29, 2026";
 
 export default function PrivacyPage() {
   return (
@@ -27,7 +27,8 @@ export default function PrivacyPage() {
             <li>Intake answers about your goals, routines, supplements, medications, and relevant health context.</li>
             <li>Your generated Blueprint, supplement stack, weekly practices, goals, check-ins, and review history.</li>
             <li>Membership and transaction references. Stripe processes your payment card details.</li>
-            <li>Basic technical and product-use information used for security, delivery, and product improvement.</li>
+            <li>Messages and support information you choose to send to us.</li>
+            <li>Basic device, browser, referral, security, and product-use information used for delivery and improvement.</li>
           </ul>
         </PolicySection>
 
@@ -51,6 +52,19 @@ export default function PrivacyPage() {
             and email delivery providers for reports and account communications. They receive information only
             as needed to provide their services to LVE360.
           </p>
+          <p>
+            LVE360 does not sell your health information or use it for targeted advertising. We may disclose
+            information when required by law, to protect users or the service, or as part of a business transaction
+            subject to appropriate safeguards and notice.
+          </p>
+        </PolicySection>
+
+        <PolicySection title="Generation and analytics">
+          <p>
+            Information needed to generate or refresh your Blueprint may be processed by supported generation
+            providers. Product analytics are designed to record events such as whether a flow started or completed,
+            not the names of your supplements, medications, conditions, or other health answers.
+          </p>
         </PolicySection>
 
         <PolicySection title="Retention and deletion">
@@ -59,6 +73,10 @@ export default function PrivacyPage() {
             a copy or permanently delete your account from Settings. Account deletion also cancels an active LVE360
             subscription. Limited records may be retained when required for fraud prevention, security, tax,
             accounting, dispute resolution, or other legal obligations.
+          </p>
+          <p>
+            Backup copies and provider records may take additional time to expire after a deletion request. We keep
+            information only as long as reasonably needed for the purposes described here.
           </p>
         </PolicySection>
 
@@ -69,6 +87,10 @@ export default function PrivacyPage() {
             <li>Permanently delete your account after explicit email confirmation.</li>
             <li>Ask us to correct a report or help with a privacy request.</li>
           </ul>
+          <p>
+            Depending on where you live, applicable law may provide additional access, correction, deletion,
+            portability, or appeal rights. We may need to verify your identity before completing a request.
+          </p>
         </PolicySection>
 
         <PolicySection title="Security and children">
@@ -78,16 +100,28 @@ export default function PrivacyPage() {
           </p>
         </PolicySection>
 
+        <PolicySection title="International processing and policy changes">
+          <p>
+            LVE360 and its service providers may process information in the United States and other locations where
+            they operate. We may update this policy as the product or legal requirements change. The revised date
+            will appear at the top, and we will provide additional notice when required.
+          </p>
+        </PolicySection>
+
         <PolicySection title="Contact us">
           <p>
             Email <a className="font-semibold text-[#047F6D] underline" href="mailto:support@lve360.com">support@lve360.com</a> for
             privacy questions, access requests, corrections, or deletion help.
           </p>
+          <p>
+            Also review the <Link className="font-semibold text-[#047F6D] underline" href="/terms">Terms of Use</Link> and{" "}
+            <Link className="font-semibold text-[#047F6D] underline" href="/medical-disclaimer">Medical Disclaimer</Link>.
+          </p>
         </PolicySection>
 
         <div className="mt-10 border-t border-slate-200 pt-6">
-          <Link href="/settings" className="font-semibold text-[#047F6D] hover:underline">
-            Return to Settings
+          <Link href="/" className="font-semibold text-[#047F6D] hover:underline">
+            Return to LVE360
           </Link>
         </div>
       </article>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+
+import { LegalPage } from "@/components/legal/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Terms of Use",
+  description: "Terms that apply when you use LVE360 and its membership features.",
+};
+
+const updated = "July 29, 2026";
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of Use"
+      updated={updated}
+      description="These Terms govern your use of the LVE360 website, Blueprint, member dashboard, emails, and related services. By creating an account, submitting an intake, or using LVE360, you agree to these Terms."
+    >
+      <section>
+        <h2>1. Who may use LVE360</h2>
+        <p>
+          You must be at least 18 years old and legally able to enter into these Terms. You are
+          responsible for the accuracy of the information you provide and for protecting access to
+          your email account and LVE360 account.
+        </p>
+      </section>
+
+      <section>
+        <h2>2. Educational wellness service</h2>
+        <p>
+          LVE360 organizes information about wellness goals, routines, supplements, medications,
+          and lifestyle practices. It provides educational information and planning tools. It does
+          not provide medical care, diagnosis, treatment, prescribing, emergency services, or a
+          substitute for a physician, pharmacist, dietitian, therapist, or other qualified
+          professional.
+        </p>
+        <p>
+          Review the <a href="/medical-disclaimer">Medical Disclaimer</a> before acting on health or
+          supplement information.
+        </p>
+      </section>
+
+      <section>
+        <h2>3. Your decisions and information</h2>
+        <p>
+          LVE360 depends on the information you provide. Missing, outdated, or inaccurate details
+          can make a Blueprint incomplete or inappropriate for your circumstances. You are
+          responsible for confirming recommendations with a qualified professional, especially if
+          you use medication, have a health condition, are pregnant or nursing, have allergies, or
+          are planning a procedure.
+        </p>
+      </section>
+
+      <section>
+        <h2>4. Memberships and billing</h2>
+        <ul>
+          <li>LVE360 may offer monthly and annual memberships at the prices shown before checkout.</li>
+          <li>Memberships renew automatically until canceled unless checkout states otherwise.</li>
+          <li>You can manage or cancel future renewals through Settings and Stripe&apos;s billing portal.</li>
+          <li>Stripe will show the effective cancellation date and the billing terms for your plan.</li>
+          <li>If you believe a charge was made in error, contact support. Rights provided by law remain unaffected.</li>
+        </ul>
+        <p>
+          We may change future pricing or plan features after giving notice required by applicable
+          law. A price change does not apply retroactively to a completed billing period.
+        </p>
+      </section>
+
+      <section>
+        <h2>5. Acceptable use</h2>
+        <p>You may not:</p>
+        <ul>
+          <li>Use LVE360 for unlawful, deceptive, abusive, or harmful activity.</li>
+          <li>Attempt to access another person&apos;s account, Blueprint, or private information.</li>
+          <li>Probe, disrupt, reverse engineer, or bypass security or access controls.</li>
+          <li>Use automated methods to copy or extract the service beyond normal personal use.</li>
+          <li>Present LVE360 output as professional medical advice or use it to provide clinical care.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>6. Your content and our materials</h2>
+        <p>
+          You retain rights in information you submit. You allow LVE360 to process that information
+          as needed to provide, secure, support, and improve the service, as described in the{" "}
+          <a href="/privacy">Privacy Policy</a>.
+        </p>
+        <p>
+          LVE360&apos;s software, design, branding, generated presentation, and original service
+          materials are protected by applicable intellectual property laws. These Terms grant you
+          a limited, personal, nonexclusive right to use the service while your access is active.
+        </p>
+      </section>
+
+      <section>
+        <h2>7. Third-party services and links</h2>
+        <p>
+          LVE360 relies on third-party services for intake, hosting, data storage, generation,
+          payments, and email. Product or affiliate links may lead to independent sellers. LVE360
+          does not control their products, availability, content, privacy practices, or fulfillment.
+          An affiliate link may generate compensation for LVE360 at no added cost to you.
+        </p>
+      </section>
+
+      <section>
+        <h2>8. Beta features and service changes</h2>
+        <p>
+          Some features may be identified as beta or testing features. They may change, contain
+          errors, or become unavailable. We may modify, suspend, or discontinue features when
+          reasonably necessary to improve or protect the service.
+        </p>
+      </section>
+
+      <section>
+        <h2>9. Disclaimers and limitation of liability</h2>
+        <p>
+          To the maximum extent permitted by law, LVE360 is provided on an &quot;as is&quot; and
+          &quot;as available&quot; basis. We do not guarantee uninterrupted access, a particular
+          health result, complete identification of every interaction, or that generated information
+          will be error-free.
+        </p>
+        <p>
+          To the maximum extent permitted by law, LVE360 and its operators will not be liable for
+          indirect, incidental, special, consequential, or punitive damages arising from use of the
+          service. Nothing in these Terms excludes liability or consumer rights that cannot legally
+          be excluded.
+        </p>
+      </section>
+
+      <section>
+        <h2>10. Suspension and termination</h2>
+        <p>
+          You may stop using LVE360 at any time and may delete your account through Settings. We may
+          restrict or end access if necessary to address fraud, security risks, unlawful conduct,
+          material violations of these Terms, or risks to other users or the service.
+        </p>
+      </section>
+
+      <section>
+        <h2>11. Changes and contact</h2>
+        <p>
+          We may update these Terms as the service changes. We will post the revised date and provide
+          additional notice when required. Continued use after an update means the revised Terms
+          apply to future use.
+        </p>
+        <p>
+          Questions can be sent to <a href="mailto:support@lve360.com">support@lve360.com</a>.
+        </p>
+      </section>
+    </LegalPage>
+  );
+}

--- a/app/upgrade/UpgradeClient.tsx
+++ b/app/upgrade/UpgradeClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { Suspense, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { track } from "@vercel/analytics/react";
@@ -244,6 +245,12 @@ function Inner() {
 
         <p className="mt-4 text-sm text-gray-500">Secure checkout through Stripe. Cancel anytime from Settings &gt; Manage Billing.</p>
         <p className="mt-2 text-xs leading-5 text-gray-500">Stripe receives your account email and billing details, not your supplement, medication, or health-profile answers.</p>
+        <p className="mt-2 text-xs leading-5 text-gray-500">
+          By continuing to checkout, you agree to the{" "}
+          <Link href="/terms" className="font-semibold text-indigo-700 underline">Terms</Link> and acknowledge the{" "}
+          <Link href="/privacy" className="font-semibold text-indigo-700 underline">Privacy Policy</Link> and{" "}
+          <Link href="/medical-disclaimer" className="font-semibold text-indigo-700 underline">Medical Disclaimer</Link>.
+        </p>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-10 text-left">
           {[

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "qa:build": "npm run typecheck && npm run build",
     "qa:canonical-host": "node src/_tests_/canonicalHost.assert.mjs",
     "qa:settings": "node src/_tests_/settingsPrivacy.assert.mjs",
+    "qa:legal": "node src/_tests_/legalCompliance.assert.mjs",
     "qa:intake": "node src/_tests_/intakeClarity.assert.mjs",
     "qa:reminders": "node src/_tests_/reminders.assert.mjs",
     "qa:journey": "node src/_tests_/journey.assert.mjs",

--- a/src/_tests_/legalCompliance.assert.mjs
+++ b/src/_tests_/legalCompliance.assert.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(path, "utf8");
+
+const layout = read("app/layout.js");
+const pricing = read("app/pricing/page.tsx");
+const upgrade = read("app/upgrade/UpgradeClient.tsx");
+const intake = read("src/components/intake/IntakeEmbed.tsx");
+const terms = read("app/terms/page.tsx");
+const privacy = read("app/privacy/page.tsx");
+const disclaimer = read("app/medical-disclaimer/page.tsx");
+const contact = read("app/contact/page.tsx");
+
+for (const href of ["/terms", "/privacy", "/medical-disclaimer", "/contact"]) {
+  assert.match(layout, new RegExp(`href=["']${href}["']`), `Footer must link to ${href}`);
+}
+
+for (const surface of [pricing, upgrade, intake]) {
+  assert.match(surface, /\/terms/, "Conversion and intake surfaces must link to the Terms");
+  assert.match(surface, /\/privacy/, "Conversion and intake surfaces must link to the Privacy Policy");
+  assert.match(surface, /\/medical-disclaimer/, "Conversion and intake surfaces must link to the Medical Disclaimer");
+}
+
+assert.match(terms, /renew automatically/i, "Terms must explain subscription renewal");
+assert.match(terms, /billing portal/i, "Terms must explain how to cancel future renewals");
+assert.match(privacy, /does not sell your health information/i, "Privacy must state the health-data sale policy");
+assert.match(privacy, /download[\s\S]*permanently delete your account/i, "Privacy must explain account controls");
+assert.match(disclaimer, /does not diagnose, treat, cure, prevent/i, "Disclaimer must describe the medical boundary");
+assert.match(disclaimer, /no material concern was identified/i, "Disclaimer must reject absolute safety conclusions");
+assert.match(contact, /support@lve360\.com/, "Contact page must provide the support address");
+assert.match(contact, /Medical emergencies/i, "Contact page must distinguish emergency needs");
+
+console.log("legal and compliance assertions passed");

--- a/src/components/intake/IntakeEmbed.tsx
+++ b/src/components/intake/IntakeEmbed.tsx
@@ -93,6 +93,14 @@ export function IntakePrivacyNotice() {
         <Link className="font-semibold text-teal-700 underline underline-offset-2" href="/privacy">
           Privacy Policy
         </Link>
+        ,{" "}
+        <Link className="font-semibold text-teal-700 underline underline-offset-2" href="/terms">
+          Terms
+        </Link>
+        , and{" "}
+        <Link className="font-semibold text-teal-700 underline underline-offset-2" href="/medical-disclaimer">
+          Medical Disclaimer
+        </Link>
         .
       </p>
     </div>

--- a/src/components/legal/LegalPage.tsx
+++ b/src/components/legal/LegalPage.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function LegalPage({
+  eyebrow = "LVE360",
+  title,
+  description,
+  updated,
+  children,
+}: {
+  eyebrow?: string;
+  title: string;
+  description: string;
+  updated: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="bg-gradient-to-b from-[#EAFBF8] via-white to-white px-5 pb-20 pt-32">
+      <article className="mx-auto max-w-3xl rounded-3xl border border-slate-200 bg-white p-7 shadow-sm sm:p-10">
+        <p className="text-sm font-bold uppercase tracking-[0.16em] text-[#047F6D]">{eyebrow}</p>
+        <h1 className="mt-3 text-4xl font-extrabold tracking-tight text-[#041B2D]">{title}</h1>
+        <p className="mt-3 text-sm text-slate-500">Last updated {updated}</p>
+        <p className="mt-7 leading-7 text-slate-700">{description}</p>
+        <div className="mt-9 space-y-9 leading-7 text-slate-700 [&_a]:font-semibold [&_a]:text-[#047F6D] [&_a]:underline [&_h2]:text-xl [&_h2]:font-bold [&_h2]:text-[#041B2D] [&_li]:ml-5 [&_li]:list-disc [&_ul]:mt-3 [&_ul]:space-y-2 [&_p+p]:mt-3">
+          {children}
+        </div>
+        <div className="mt-10 border-t border-slate-200 pt-6">
+          <Link href="/" className="font-semibold text-[#047F6D] hover:underline">
+            Return to LVE360
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
- Added public Terms of Use, Medical Disclaimer, and Contact pages.
- Expanded the Privacy Policy to cover support data, generation providers, analytics boundaries, retention, legal rights, international processing, and policy updates.
- Added all four legal/support links to the global footer.
- Added Terms, Privacy, and Medical Disclaimer links at intake, pricing, and authenticated checkout decision points.
- Added automated legal-surface assertions.

## Why
The launch audit identified incomplete and broken legal/support paths. Health-context intake and recurring membership checkout need clear disclosures before a person submits information or begins a subscription.

## User impact
People can now understand the educational boundary, recurring billing terms, data handling, account controls, affiliate relationships, and how to contact LVE360. The Medical Disclaimer explicitly avoids absolute safety claims and directs urgent needs away from product support.

## Validation
- `npm run qa:legal`: passed
- `npm run qa:settings`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- Desktop visual review: passed
- Mobile 390px review: no horizontal overflow
- Terms, Privacy, Medical Disclaimer, Contact, and Pricing routes: correct heading and footer links
- Browser console: no warnings or errors during public-page QA

## Review note
These are operational beta documents grounded in the implemented product and current checkout flow. They are not a substitute for attorney review before a broad public paid launch.

Stripe remains in sandbox/test mode. This PR does not change Stripe configuration.