### PR TITLE
Fix intake status permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "qa:settings": "node src/_tests_/settingsPrivacy.assert.mjs",
     "qa:legal": "node src/_tests_/legalCompliance.assert.mjs",
     "qa:intake": "node src/_tests_/intakeClarity.assert.mjs",
+    "qa:intake-permissions": "node src/_tests_/intakePermissions.assert.mjs",
     "qa:reminders": "node src/_tests_/reminders.assert.mjs",
     "qa:journey": "node src/_tests_/journey.assert.mjs",
     "qa:gating": "node src/_tests_/premiumGating.assert.mjs",

--- a/src/_tests_/intakePermissions.assert.mjs
+++ b/src/_tests_/intakePermissions.assert.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260729210709_grant_authenticated_intake_events_select.sql"
+);
+
+assert.match(
+  migration,
+  /alter table public\.intake_events enable row level security/i,
+  "Intake events must keep row-level security enabled."
+);
+assert.match(
+  migration,
+  /revoke all on table public\.intake_events from public, anon/i,
+  "Anonymous roles must not receive intake-event table access."
+);
+assert.match(
+  migration,
+  /revoke insert, update, delete on table public\.intake_events from authenticated/i,
+  "Authenticated clients must not write intake events directly."
+);
+assert.match(
+  migration,
+  /grant select on table public\.intake_events to authenticated/i,
+  "Authenticated members need table-level read access before owner RLS can run."
+);
+assert.doesNotMatch(
+  migration,
+  /grant\s+(?:select,\s*)?(?:insert|update|delete)[^;]*to authenticated/i,
+  "Authenticated members must not gain direct write privileges."
+);
+
+const statusRoute = read("app/api/intake/status/route.ts");
+assert.match(statusRoute, /requirePaidApi/, "Intake status must remain paid-gated.");
+assert.match(statusRoute, /\.eq\("user_id", userId\)/, "Status reads must remain user-scoped.");
+
+const setRoute = read("app/api/intake/set/route.ts");
+assert.match(setRoute, /requirePaidApi/, "Intake writes must remain paid-gated.");
+assert.match(setRoute, /getSupabaseAdmin/, "Intake writes must remain server-controlled.");
+assert.match(
+  setRoute,
+  /\{\s*user_id:\s*userId,\s*item_id:\s*itemId,\s*intake_date:\s*today,\s*taken\s*\}/,
+  "Server writes must bind the authenticated user ID."
+);
+
+console.log("Intake permission assertions passed.");

--- a/supabase/migrations/20260729210709_grant_authenticated_intake_events_select.sql
+++ b/supabase/migrations/20260729210709_grant_authenticated_intake_events_select.sql
@@ -1,0 +1,10 @@
+alter table public.intake_events enable row level security;
+
+revoke all on table public.intake_events from public, anon;
+revoke insert, update, delete on table public.intake_events from authenticated;
+
+grant select on table public.intake_events to authenticated;
+grant select, insert, update, delete on table public.intake_events to service_role;
+
+comment on table public.intake_events is
+  'Owner-scoped daily supplement completion records. Authenticated members may read their own rows through RLS; writes remain server-only.';


### PR DESCRIPTION
## What changed

- Added the missing table-level `SELECT` grant for authenticated members on `public.intake_events`.
- Kept row-level security enabled and preserved the existing owner-only policies.
- Explicitly blocked anonymous access and direct authenticated writes.
- Kept writes behind the existing paid server route using the service role.
- Added focused regression assertions for grants, paid gating, user scoping, and server-controlled writes.

## Root cause

The table already had correct owner-only RLS policies, but the authenticated Postgres role had no table privilege. Supabase evaluates table grants before RLS, so `/api/intake/status` returned Postgres error `42501: permission denied for table intake_events` before the owner policy could run.

## Production verification

The migration was applied to the connected Supabase project and verified:

- RLS enabled: yes
- Authenticated `SELECT`: yes
- Authenticated `INSERT`, `UPDATE`, `DELETE`: no
- Anonymous `SELECT`: no
- Service-role access: retained
- Owner policies: retained
- Supabase security advisor: no `intake_events` finding

## Validation

- `npm run qa:intake-permissions`: passed
- `npm run qa:gating`: passed
- `npm run qa:intake`: passed
- `npm run qa:journey`: passed
- `npm run qa:settings`: passed
- `npm run qa:legal`: passed
- `npm run typecheck`: passed
- Next.js 15.5.21 production build: passed
- `npm audit`: 0 vulnerabilities
- `git diff --check`: passed

Stripe remains in sandbox mode and is not changed by this PR.