### PR TITLE
PR70 — Make Blueprint safety status truthful

### DIFF
--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -4,6 +4,10 @@ import { requireTier } from "@/app/_auth/requireTier";
 import { buildBlueprintActionCandidates } from "@/lib/blueprintActions";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
 import {
+  blueprintMarkdownFromStack,
+  deriveBlueprintSafetyStatus,
+} from "@/lib/blueprintSafetyStatus";
+import {
   blueprintInputSnapshotHash,
   getMemberSupplements,
 } from "@/lib/blueprintWorkspace";
@@ -15,14 +19,6 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 type PageProps = { params: Promise<{ stackId: string }> };
-
-function markdownFromStack(stack: { sections: unknown; summary: string | null }): string {
-  if (stack.sections && typeof stack.sections === "object" && "markdown" in stack.sections) {
-    const markdown = (stack.sections as { markdown?: unknown }).markdown;
-    if (typeof markdown === "string") return markdown;
-  }
-  return stack.summary ?? "";
-}
 
 export default async function BlueprintPage({ params }: PageProps) {
   const { stackId } = await params;
@@ -58,7 +54,7 @@ export default async function BlueprintPage({ params }: PageProps) {
   if (historyError) throw historyError;
   if (!submission) notFound();
 
-  const markdown = markdownFromStack(stack);
+  const markdown = blueprintMarkdownFromStack(stack);
   const report = parseBlueprintReport(markdown);
   const { supplements, hasOverride } = getMemberSupplements(submission);
   const currentInputHash = blueprintInputSnapshotHash(submission);
@@ -74,7 +70,7 @@ export default async function BlueprintPage({ params }: PageProps) {
         id: stack.id,
         submissionId: stack.submission_id,
         createdAt: stack.created_at,
-        safetyStatus: stack.safety_status,
+        safetyStatus: deriveBlueprintSafetyStatus(markdown),
         generationReason: stack.generation_reason,
       }}
       sections={Object.entries(report.sections)
@@ -89,7 +85,7 @@ export default async function BlueprintPage({ params }: PageProps) {
       history={(history ?? []).map((version) => ({
         id: version.id,
         createdAt: version.created_at,
-        safetyStatus: version.safety_status,
+        safetyStatus: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(version)),
         generationReason: version.generation_reason,
       }))}
     />

--- a/app/(app)/blueprints/page.tsx
+++ b/app/(app)/blueprints/page.tsx
@@ -2,6 +2,10 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
+import {
+  blueprintMarkdownFromStack,
+  deriveBlueprintSafetyStatus,
+} from "@/src/lib/blueprintSafetyStatus";
 import { getUserAndTier } from "@/src/lib/getUserAndTier";
 
 import BlueprintsClient from "./BlueprintsClient";
@@ -25,7 +29,10 @@ export default async function Page() {
 
   return (
     <BlueprintsClient
-      stacks={(stacks ?? []) as any}
+      stacks={(stacks ?? []).map((stack) => ({
+        ...stack,
+        safety_status: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(stack)),
+      })) as any}
       paid={tier === "premium" || tier === "trial"}
     />
   );

--- a/app/api/stacks/route.ts
+++ b/app/api/stacks/route.ts
@@ -1,6 +1,10 @@
 // app/api/stacks/route.ts
 import { NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
+import {
+  blueprintMarkdownFromStack,
+  deriveBlueprintSafetyStatus,
+} from "@/lib/blueprintSafetyStatus";
 import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export const dynamic = "force-dynamic";
@@ -29,8 +33,12 @@ export async function GET() {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    console.log("[API] GET /api/stacks - returning", data?.length ?? 0, "stacks");
-    return NextResponse.json({ ok: true, stacks: data ?? [] });
+    const stacks = (data ?? []).map((stack) => ({
+      ...stack,
+      safety_status: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(stack)),
+    }));
+    console.log("[API] GET /api/stacks - returning", stacks.length, "stacks");
+    return NextResponse.json({ ok: true, stacks });
   } catch (err: any) {
     console.error("[API] Exception in /api/stacks:", err);
     return NextResponse.json({ error: err?.message ?? String(err) }, { status: 500 });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "qa:gating": "node src/_tests_/premiumGating.assert.mjs",
     "qa:stripe-pricing": "node src/_tests_/stripePricing.assert.mjs",
     "qa:blueprints": "node src/_tests_/interactiveBlueprints.assert.mjs",
+    "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"
   },
   "dependencies": {

--- a/src/_tests_/blueprintSafetyStatus.assert.ts
+++ b/src/_tests_/blueprintSafetyStatus.assert.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import {
+  blueprintMarkdownFromStack,
+  deriveBlueprintSafetyStatus,
+} from "../lib/blueprintSafetyStatus.ts";
+
+const report = (safetyBody: string) => `
+## Intro Summary
+
+Summary.
+
+## Contraindications & Med Interactions
+
+${safetyBody}
+
+### Safety Takeaway
+
+Keep prescription instructions unchanged and recheck this section whenever your stack changes.
+
+## Current Stack
+
+Current items.
+`;
+
+assert.equal(
+  deriveBlueprintSafetyStatus(report(
+    "- **No material flags identified:** No specific interaction requiring action was identified from the reported stack.",
+  )),
+  "safe",
+  "An explicit no-material-flags finding should produce the qualified green status.",
+);
+
+assert.equal(
+  deriveBlueprintSafetyStatus(report(
+    "- Monitor magnesium glycinate with Lisinopril in relation to blood pressure control.",
+  )),
+  "warning",
+  "A displayed caution must prevent a green safety status.",
+);
+
+assert.equal(
+  deriveBlueprintSafetyStatus(report([
+    "- **No material flags identified:** No specific interaction requiring action was identified.",
+    "- Review a possible timing conflict with a pharmacist.",
+  ].join("\n"))),
+  "warning",
+  "A no-flags sentence must not override another displayed caution.",
+);
+
+assert.equal(
+  deriveBlueprintSafetyStatus("## Intro Summary\n\nSummary only."),
+  "error",
+  "A missing safety section must fail closed.",
+);
+
+assert.equal(
+  deriveBlueprintSafetyStatus(report("Review this combination with a pharmacist.")),
+  "warning",
+  "An unstructured safety section must not receive a green status.",
+);
+
+const warningReport = report("- Review this combination with a pharmacist.");
+assert.equal(
+  deriveBlueprintSafetyStatus(blueprintMarkdownFromStack({
+    sections: { markdown: warningReport },
+    summary: report("- **No material flags identified:** No specific interaction was identified."),
+  })),
+  "warning",
+  "The visible sections markdown must remain the canonical source when an older summary differs.",
+);
+
+console.log("Blueprint safety-status assertions passed.");

--- a/src/_tests_/interactiveBlueprints.assert.mjs
+++ b/src/_tests_/interactiveBlueprints.assert.mjs
@@ -53,6 +53,19 @@ assert.doesNotMatch(workspace, /\bNo safety issues detected\b/i, "Customer-facin
 const blueprintLibrary = read("app/(app)/blueprints/BlueprintsClient.tsx");
 assert.match(blueprintLibrary, /timeZone: "UTC"/, "Blueprint library dates must render consistently during hydration.");
 
+const blueprintLibraryPage = read("app/(app)/blueprints/page.tsx");
+assert.match(
+  blueprintLibraryPage,
+  /deriveBlueprintSafetyStatus\(blueprintMarkdownFromStack\(stack\)\)/,
+  "Existing Blueprint badges must be derived from the visible report, not stale database status."
+);
+
+assert.match(
+  detailPage,
+  /safetyStatus: deriveBlueprintSafetyStatus\(markdown\)/,
+  "The selected Blueprint badge must use the same visible safety section."
+);
+
 const reportEmail = read("src/lib/reportEmail.ts");
 assert.match(
   reportEmail,

--- a/src/lib/blueprintSafetyStatus.ts
+++ b/src/lib/blueprintSafetyStatus.ts
@@ -1,0 +1,45 @@
+export type BlueprintSafetyStatus = "safe" | "warning" | "error";
+
+const SAFETY_HEADING = "## Contraindications & Med Interactions";
+const NO_MATERIAL_FINDING_RE =
+  /\b(?:no material flags? identified|no specific interaction (?:requiring action )?(?:was )?(?:identified|flagged)|no specific conflicts? (?:were )?(?:identified|flagged))\b/i;
+
+function safetySection(markdown: string): string {
+  const source = String(markdown ?? "");
+  const start = source.toLowerCase().indexOf(SAFETY_HEADING.toLowerCase());
+  if (start < 0) return "";
+
+  const bodyStart = start + SAFETY_HEADING.length;
+  const remainder = source.slice(bodyStart);
+  const nextHeading = /(?:^|\r?\n)##\s+/m.exec(remainder);
+  return remainder.slice(0, nextHeading?.index ?? remainder.length).trim();
+}
+
+export function blueprintMarkdownFromStack(stack: {
+  sections?: unknown;
+  summary?: string | null;
+}): string {
+  if (stack.sections && typeof stack.sections === "object" && "markdown" in stack.sections) {
+    const markdown = (stack.sections as { markdown?: unknown }).markdown;
+    if (typeof markdown === "string") return markdown;
+  }
+  return typeof stack.summary === "string" ? stack.summary : "";
+}
+
+/**
+ * Derive the customer-facing safety badge from the same safety section the
+ * customer can read. Report-format validation is intentionally not used here.
+ */
+export function deriveBlueprintSafetyStatus(markdown: string): BlueprintSafetyStatus {
+  const section = safetySection(markdown);
+  if (!section) return "error";
+
+  const findings = section
+    .split(/^\s*###\s+Safety Takeaway\s*$/im)[0]
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^[-*]\s+/.test(line));
+
+  if (!findings.length) return "warning";
+  return findings.every((line) => NO_MATERIAL_FINDING_RE.test(line)) ? "safe" : "warning";
+}

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -14,6 +14,7 @@ import { formatStartingGuidance } from "@/lib/supplementDosingRegistry";
 import { AFFILIATE_DISCLOSURE_NEAR_LINKS } from "@/lib/reportDisclosures";
 import { neutralGoalDescription, recommendationRationale } from "@/lib/reportIntegrity";
 import { parseBlueprintReport, validateBlueprintReport } from "@/lib/blueprintReport";
+import { deriveBlueprintSafetyStatus } from "@/lib/blueprintSafetyStatus";
 import { applySafetyChecks } from "@/lib/safetyCheck";
 import { enrichAffiliateLinks, buildAmazonSearchLink } from "@/lib/affiliateLinks";
 import { getTopCitationsFor } from "@/lib/evidence";
@@ -2317,8 +2318,7 @@ md = replaceOrAppendSection(md, buildPracticalFollowUpSection());
     return !looksLikeTimingArtifact(n);
   });
 
-  type SafetyStatus = "safe" | "warning" | "error";
-  interface SafetyOutput { cleaned: StackItem[]; status: SafetyStatus }
+  interface SafetyOutput { cleaned: StackItem[] }
 const safetyInput = {
   medications: Array.isArray((baseClient as any).medications)
     ? (baseClient as any).medications.map((m: any) => m?.med_name || m?.name || m)
@@ -2338,12 +2338,10 @@ const safetyInput = {
   is_premium: mode === "premium",
 };
 
-  let safetyStatus: SafetyStatus = "warning";
   let cleanedItems: StackItem[] = filteredItems;
   try {
     const res = (await applySafetyChecks(safetyInput, filteredItems)) as Partial<SafetyOutput> | null;
     cleanedItems = asArray<StackItem>((res?.cleaned as StackItem[]) ?? filteredItems);
-    const st = (res as any)?.status; safetyStatus = st === "safe" ? "safe" : st === "error" ? "error" : "warning";
   } catch (e) { console.warn("applySafetyChecks failed; continuing with uncautioned items.", e); }
 
   const itemKey = (name: string) => normalizeSupplementName(name).toLowerCase();
@@ -2468,6 +2466,7 @@ const safetyInput = {
     throw new Error(`Refusing to persist invalid canonical report: ${canonicalIssues.join(", ")}`);
   }
   md = canonicalReport.canonicalMarkdown;
+  const persistedSafetyStatus = deriveBlueprintSafetyStatus(md);
 
   if (/\[object Object\]/i.test(md)) {
     throw new Error("Invalid object string leaked into report");
@@ -2563,7 +2562,7 @@ const safetyInput = {
           tokens_used: (promptTokens ?? 0) + (completionTokens ?? 0),
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
-          safety_status: (ok.headingsValid && ok.blueprintValid && ok.blueprintMixValid && ok.citationsValid && ok.sectionBodiesValid && ok.currentStackParityValid && ok.currentStackNamesValid) ? "safe" : "warning",
+          safety_status: persistedSafetyStatus,
           summary: md,
           sections: { markdown: md, generated_at: new Date().toISOString(), mode, item_cap: cap ?? null },
           notes: null,
@@ -2592,7 +2591,7 @@ const safetyInput = {
             tokens_used: (promptTokens ?? 0) + (completionTokens ?? 0),
             prompt_tokens: promptTokens,
             completion_tokens: completionTokens,
-            safety_status: (ok.headingsValid && ok.blueprintValid && ok.blueprintMixValid && ok.citationsValid && ok.sectionBodiesValid && ok.currentStackParityValid && ok.currentStackNamesValid) ? "safe" : "warning",
+            safety_status: persistedSafetyStatus,
             summary: md,
             sections: { markdown: md, generated_at: new Date().toISOString(), mode, item_cap: cap ?? null },
             notes: null,
@@ -2687,7 +2686,13 @@ const safetyInput = {
   }
 
   const tokens_used = (promptTokens ?? 0) + (completionTokens ?? 0);
-  const raw = { stack_id: stackId ?? undefined, mode, item_cap: cap, validation: ok };
+  const raw = {
+    stack_id: stackId ?? undefined,
+    mode,
+    item_cap: cap,
+    validation: ok,
+    safety_status: persistedSafetyStatus,
+  };
   return { markdown: md, raw, model_used: modelUsed, tokens_used, prompt_tokens: promptTokens, completion_tokens: completionTokens };
 }
 


### PR DESCRIPTION
## Purpose

Prevent LVE360 from showing a green safety badge when the visible Blueprint contains medication or supplement cautions.

## Root cause

`stacks.safety_status` was derived from structural report validation. A report could be well-formed and therefore stored as `safe` even when its Contraindications & Med Interactions section contained material cautions.

## What changed

- Added one conservative safety-status derivation based on the customer-visible safety section.
- Any displayed caution now produces `warning`.
- Missing or unstructured safety content fails closed.
- New Blueprint generations persist the derived status.
- Existing Blueprint library, workspace, version history, and stacks API derive the status at read time, so older incorrect rows display truthfully without a destructive migration.
- Added regression coverage for clear, caution, mixed, missing, and unstructured states.

## User impact

A user will no longer see “No material concern identified” above a Blueprint that tells them to review safety cautions. The report body remains the source of truth.

## Validation

- `npm.cmd run qa:blueprint-safety`
- `npm.cmd run qa:blueprints`
- `npm.cmd run typecheck`
- `npm.cmd run build` with inert placeholder configuration
- `git diff --check`

## Not verified locally

- Full production generation with live OpenAI and Supabase credentials
- Authenticated Vercel Preview rendering

Local `qa:env` correctly reports that launch secrets are unavailable in this checkout. No environment variables or database schema were changed.

## Risk and rollback

The derivation is intentionally conservative. Ambiguous safety content produces a review state rather than a green status. Rollback is the single commit in this PR.