### PR TITLE
PR71: Connect and harden the Blueprint safety engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "qa:stripe-pricing": "node src/_tests_/stripePricing.assert.mjs",
     "qa:blueprints": "node src/_tests_/interactiveBlueprints.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
+    "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"
   },
   "dependencies": {

--- a/src/_tests_/safetyEngine.assert.ts
+++ b/src/_tests_/safetyEngine.assert.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import {
+  applySafetyEvaluationToMarkdown,
+  evaluateSafetyCandidates,
+  unavailableSafetyEvaluation,
+  type InteractionRow,
+  type SafetyContext,
+} from "../lib/safetyEngine.ts";
+
+const interactions: InteractionRow[] = [
+  { ingredient: "Ashwagandha (KSM-66 or similar)", pregnancy_caution: false, sedatives_additive: true },
+  { ingredient: "Ashwagandha", pregnancy_caution: true },
+  { ingredient: "Omega-3 (EPA+DHA)", anticoagulants_bleeding_risk: true },
+  { ingredient: "Berberine", diabetes_meds_additive: true },
+  { ingredient: "Magnesium (glycinate)", binds_thyroid_meds: true, sep_hours_thyroid: 4, kidney_disease_caution: true },
+  { ingredient: "Creatine monohydrate", kidney_disease_caution: true },
+  { ingredient: "Vitamin A", liver_disease_caution: true },
+  { ingredient: "Melatonin", sedatives_additive: true },
+  { ingredient: "Vitamin D3" },
+  { ingredient: "Collagen peptides" },
+];
+
+const run = (context: SafetyContext, name: string) => evaluateSafetyCandidates(
+  context,
+  [{ name, is_current: false }],
+  { interactions, rules: [] },
+);
+
+assert.equal(run({ pregnant: true }, "Ashwagandha").status, "blocked", "Pregnancy caution must block a proposed item.");
+assert.equal(run({ allergies: ["Magnesium"] }, "Magnesium glycinate").status, "blocked", "A matching reported allergy must block a proposed item.");
+assert.equal(run({ procedures: ["Colonoscopy procedure next week"] }, "Omega-3").status, "blocked", "A bleeding-risk item must stop for procedure review.");
+assert.equal(run({ medications: ["Eliquis"] }, "Omega-3").status, "blocked", "Anticoagulant combinations must stop for coordinated review.");
+assert.equal(run({ medications: ["Metformin"] }, "Berberine").status, "review", "Additive glucose lowering must require review.");
+assert.match(run({ medications: ["Levothyroxine"] }, "Magnesium glycinate").findings[0].message, /4 hours/, "Thyroid spacing must include the structured interval.");
+assert.equal(run({ conditions: ["Chronic kidney disease"] }, "Creatine monohydrate").status, "review", "Kidney context must require review.");
+assert.equal(run({ conditions: ["Liver impairment"] }, "Vitamin A").status, "review", "Liver context must require review.");
+assert.equal(run({ medications: ["Lunesta"] }, "Melatonin").status, "review", "Additive sedation must require review.");
+assert.equal(run({ medications: ["BrandNewMedication"] }, "Vitamin D3").status, "review", "An unclassified medication must fail closed.");
+assert.equal(run({}, "Collagen peptides").status, "clear", "A matched item without a contextual flag may remain qualified clear.");
+assert.equal(run({}, "Unmapped compound").status, "review", "A missing interaction record must fail closed.");
+
+const unavailable = unavailableSafetyEvaluation([{ name: "Vitamin D3", is_current: false }]);
+assert.equal(unavailable.complete, false, "A source failure must be explicit.");
+assert.equal(unavailable.status, "review", "A source failure must never produce a clear result.");
+
+const currentFinding = evaluateSafetyCandidates(
+  { medications: ["Levothyroxine"] },
+  [
+    { name: "Magnesium glycinate", is_current: true },
+    { name: "Unmapped compound", is_current: false },
+  ],
+  { interactions, rules: [] },
+);
+const report = [
+  "## Your Blueprint Recommendations",
+  "",
+  "| Rank | Supplement | Status | Why it Matters |",
+  "| --- | --- | --- | --- |",
+  "| 1 | Magnesium glycinate | Current - optimize | Existing routine |",
+  "| 2 | Unmapped compound | New - consider | Proposed option |",
+  "",
+  "## Contraindications & Med Interactions",
+  "",
+  "- **No material flags identified:** Placeholder.",
+  "",
+  "## Current Stack",
+  "",
+  "| Current Item | Type | Purpose | Dosage | Timing |",
+  "| --- | --- | --- | --- | --- |",
+  "| Levothyroxine | Medication | Thyroid | Keep prescribed dose | Keep prescribed timing |",
+].join("\n");
+const patched = applySafetyEvaluationToMarkdown(report, currentFinding);
+assert.match(patched, /\| 1 \| Magnesium glycinate \| Current - optimize \|/, "Current item status and instructions must remain unchanged.");
+assert.match(patched, /\| 2 \| Unmapped compound \| Clinician review \|/, "A proposed item that cannot be cleared must not remain active.");
+assert.match(patched, /Clinician review: Unmapped compound/, "The customer-visible safety section must use the canonical structured finding.");
+assert.doesNotMatch(patched, /Placeholder/, "The structured safety section must replace generated placeholder content.");
+
+console.log("Safety engine assertions passed.");

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -16,6 +16,7 @@ import { neutralGoalDescription, recommendationRationale } from "@/lib/reportInt
 import { parseBlueprintReport, validateBlueprintReport } from "@/lib/blueprintReport";
 import { deriveBlueprintSafetyStatus } from "@/lib/blueprintSafetyStatus";
 import { applySafetyChecks } from "@/lib/safetyCheck";
+import { applySafetyEvaluationToMarkdown } from "@/lib/safetyEngine";
 import { enrichAffiliateLinks, buildAmazonSearchLink } from "@/lib/affiliateLinks";
 import { getTopCitationsFor } from "@/lib/evidence";
 import { callOpenAI } from "@/lib/openai";
@@ -713,7 +714,7 @@ function validateBlueprintMix(md: string) {
     clinicianReview: statuses.filter((status) => status === "Clinician review").length,
   };
   return {
-    valid: counts.total === 10 && counts.current <= 5 && counts.new >= 4 && counts.clinicianReview <= 1 &&
+    valid: counts.total === 10 && counts.current <= 5 && (counts.new + counts.clinicianReview) >= 4 &&
       statuses.every((status) => ["Current - optimize", "New - consider", "Clinician review"].includes(status)),
     counts,
   };
@@ -2318,7 +2319,6 @@ md = replaceOrAppendSection(md, buildPracticalFollowUpSection());
     return !looksLikeTimingArtifact(n);
   });
 
-  interface SafetyOutput { cleaned: StackItem[] }
 const safetyInput = {
   medications: Array.isArray((baseClient as any).medications)
     ? (baseClient as any).medications.map((m: any) => m?.med_name || m?.name || m)
@@ -2333,19 +2333,38 @@ const safetyInput = {
     typeof (baseClient as any).pregnant === "boolean" || typeof (baseClient as any).pregnant === "string"
       ? (baseClient as any).pregnant
       : null,
+  procedures: extractReadableNames([
+    (baseClient as any).procedures,
+    (baseClient as any).upcoming_procedures,
+    (baseClient as any).surgeries,
+    (baseClient as any).surgery,
+  ]),
   brand_pref: (baseClient as any)?.preferences?.brand_pref ?? (baseClient as any)?.brand_pref ?? null,
   dosing_pref: (baseClient as any)?.preferences?.dosing_pref ?? (baseClient as any)?.dosing_pref ?? null,
   is_premium: mode === "premium",
 };
 
-  let cleanedItems: StackItem[] = filteredItems;
-  try {
-    const res = (await applySafetyChecks(safetyInput, filteredItems)) as Partial<SafetyOutput> | null;
-    cleanedItems = asArray<StackItem>((res?.cleaned as StackItem[]) ?? filteredItems);
-  } catch (e) { console.warn("applySafetyChecks failed; continuing with uncautioned items.", e); }
-
   const itemKey = (name: string) => normalizeSupplementName(name).toLowerCase();
   const currentKindByName = new Map(currentStackLedger.map((item) => [itemKey(item.name), item.kind]));
+  const safetyCandidates = filteredItems.filter((item) => {
+    const currentKind = currentKindByName.get(itemKey(item.name));
+    return !currentKind || currentKind === "supplement" || currentKind === "endocrine_active_supplement";
+  });
+  const safetyResult = await applySafetyChecks(safetyInput, safetyCandidates);
+  const safetyItemsByName = new Map(
+    asArray<StackItem>(safetyResult.cleaned as StackItem[]).map((item) => [itemKey(item.name), item])
+  );
+  const cleanedItems = filteredItems.map((item) => safetyItemsByName.get(itemKey(item.name)) ?? item);
+  md = applySafetyEvaluationToMarkdown(md, safetyResult);
+  console.info("[safety.engine]", {
+    complete: safetyResult.complete,
+    status: safetyResult.status,
+    candidate_count: safetyResult.candidates.length,
+    finding_count: safetyResult.findings.length,
+    review_count: safetyResult.candidates.filter((candidate) => candidate.decision === "review").length,
+    blocked_count: safetyResult.candidates.filter((candidate) => candidate.decision === "blocked").length,
+  });
+
   const blueprintShoppableNames = new Set(blueprintNames(tableMd).filter(isEligibleSupplementName).map(itemKey));
   const shoppableNames = new Set([
     ...blueprintNames(tableMd).filter(isEligibleSupplementName),

--- a/src/lib/safetyCheck.ts
+++ b/src/lib/safetyCheck.ts
@@ -1,227 +1,101 @@
-// -----------------------------------------------------------------------------
-// File: lib/safetyCheck.ts
-// LVE360 — Hybrid Safety Engine (Interactions + Rules + Static Fallback)
-// Updated: 2025-10-13
-//
-// Purpose:
-//   Evaluate supplement safety using three layers:
-//     1️⃣ Supabase interactions table  → structured pharmacological risks
-//     2️⃣ Supabase rules table         → custom best-practice cautions
-//     3️⃣ Static fallback rules        → in-code backup if DB unavailable
-//
-// Returns an array of structured SafetyWarnings ready for dashboard display.
-//
-// -----------------------------------------------------------------------------
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import {
+  evaluateSafetyCandidates,
+  unavailableSafetyEvaluation,
+  type InteractionRow,
+  type SafetyCandidate,
+  type SafetyContext,
+  type SafetyEvaluation,
+  type SafetyFinding,
+  type SafetyRuleRow,
+} from "@/lib/safetyEngine";
 
-import { supabaseAdmin as supa } from "@/lib/supabaseAdmin";
+type SafetyItem = SafetyCandidate & {
+  caution?: string | null;
+};
 
-// -----------------------------
-// Types
-// -----------------------------
-export type SafetySeverity = "info" | "warning" | "danger";
-
-export interface SafetyWarning {
-  item: string;
-  caution: string;
-  severity: SafetySeverity;
-  source: "interactions" | "rules" | "static";
-  note?: string | null;
+export interface AppliedSafetyResult extends SafetyEvaluation {
+  cleaned: SafetyItem[];
 }
 
-// -----------------------------
-// Static fallback rules (only used if DB fetch fails)
-// -----------------------------
-const STATIC_RULES: SafetyWarning[] = [
-  {
-    item: "Zinc",
-    caution: "Separate from thyroid medication by at least 4 hours.",
-    severity: "warning",
-    source: "static",
-  },
-  {
-    item: "Garlic",
-    caution: "May increase bleeding risk when combined with anticoagulants.",
-    severity: "danger",
-    source: "static",
-  },
-  {
-    item: "Omega-3",
-    caution: "High doses may increase bleeding risk with anticoagulants.",
-    severity: "warning",
-    source: "static",
-  },
-  {
-    item: "Ashwagandha",
-    caution: "Avoid during pregnancy.",
-    severity: "warning",
-    source: "static",
-  },
-  {
-    item: "Green Tea",
-    caution: "Can reduce absorption of some medications if taken together.",
-    severity: "info",
-    source: "static",
-  },
-];
+const INTERACTION_COLUMNS = [
+  "ingredient",
+  "binds_thyroid_meds",
+  "sep_hours_thyroid",
+  "anticoagulants_bleeding_risk",
+  "diabetes_meds_additive",
+  "sedatives_additive",
+  "antibiotics_interaction",
+  "pregnancy_caution",
+  "liver_disease_caution",
+  "kidney_disease_caution",
+  "immunocompromised_caution",
+  "caffeine_stimulant_caution",
+  "liver_caution",
+  "kidney_caution",
+  "notes",
+].join(",");
 
-// -----------------------------
-// Utility helpers
-// -----------------------------
-function normalize(str: string | null | undefined): string {
-  return (str ?? "").toLowerCase().trim();
+const RULE_COLUMNS = [
+  "rule_id",
+  "rule_type",
+  "action",
+  "entity_a_name",
+  "max_daily_amount",
+  "unit",
+  "message",
+  "source_url",
+  "trigger_name",
+  "severity",
+  "notes",
+  "caution",
+].join(",");
+
+function applyFindingsToItems(items: SafetyItem[], evaluation: SafetyEvaluation): SafetyItem[] {
+  const resultByName = new Map(evaluation.candidates.map((candidate) => [candidate.name.toLowerCase().trim(), candidate]));
+  return items.map((item) => {
+    const result = resultByName.get(item.name.toLowerCase().trim());
+    if (!result?.findings.length) return item;
+    const safetyCaution = Array.from(new Set(result.findings.map((finding) => finding.message))).join(" ");
+    return {
+      ...item,
+      caution: [item.caution, safetyCaution].filter(Boolean).join(" "),
+    };
+  });
 }
 
-function matchesAny(target: string, candidates: string[]): boolean {
-  const lowerTarget = normalize(target);
-  return candidates.some(c => lowerTarget.includes(normalize(c)));
+async function loadSafetySources(): Promise<{ interactions: InteractionRow[]; rules: SafetyRuleRow[] }> {
+  const [interactionsResult, rulesResult] = await Promise.all([
+    supabaseAdmin.from("interactions").select(INTERACTION_COLUMNS),
+    supabaseAdmin.from("rules").select(RULE_COLUMNS),
+  ]);
+  if (interactionsResult.error) throw new Error(`Interactions query failed: ${interactionsResult.error.message}`);
+  if (rulesResult.error) throw new Error(`Rules query failed: ${rulesResult.error.message}`);
+  return {
+    interactions: (interactionsResult.data ?? []) as unknown as InteractionRow[],
+    rules: (rulesResult.data ?? []) as unknown as SafetyRuleRow[],
+  };
 }
 
-// -----------------------------
-// Main safety evaluation
-// -----------------------------
-export async function evaluateSafety(input: {
-  medications?: string[];
-  supplements?: string[];
-  conditions?: string[];
-  pregnant?: string | null;
-}): Promise<SafetyWarning[]> {
-  const { medications = [], supplements = [], conditions = [], pregnant } = input;
-  const warnings: SafetyWarning[] = [];
-
+export async function applySafetyChecks(context: SafetyContext, items: SafetyItem[]): Promise<AppliedSafetyResult> {
+  let evaluation: SafetyEvaluation;
   try {
-    // -------------------------------------------------------------------------
-    // 1️⃣ Pull data from Supabase
-    // -------------------------------------------------------------------------
-    const [interactionsRes, rulesRes] = await Promise.all([
-      supa.from("interactions").select("*"),
-      supa.from("rules").select("*"),
-    ]);
-
-    const interactions = interactionsRes.data ?? [];
-    const rules = rulesRes.data ?? [];
-
-    // -------------------------------------------------------------------------
-    // 2️⃣ Evaluate Interactions Table (structured risk flags)
-    // -------------------------------------------------------------------------
-    for (const supp of supplements) {
-      const match = interactions.find(
-        (i: any) => normalize(i.ingredient) === normalize(supp)
-      );
-      if (!match) continue;
-
-      // Thyroid meds
-      if (match.binds_thyroid_meds && medications.some(m => normalize(m).includes("thyroid"))) {
-        warnings.push({
-          item: supp,
-          caution: `Separate from thyroid medication by ${match.sep_hours_thyroid || 4} hours.`,
-          severity: "warning",
-          source: "interactions",
-        });
-      }
-
-      // Anticoagulants
-      if (match.anticoagulants_bleeding_risk && medications.some(m => normalize(m).includes("warfarin") || normalize(m).includes("anticoagulant"))) {
-        warnings.push({
-          item: supp,
-          caution: "May increase bleeding risk when combined with anticoagulants.",
-          severity: "danger",
-          source: "interactions",
-        });
-      }
-
-      // Diabetes meds
-      if (match.diabetes_meds_additive_risk && medications.some(m => normalize(m).includes("metformin") || normalize(m).includes("insulin"))) {
-        warnings.push({
-          item: supp,
-          caution: "May enhance blood sugar–lowering effect; monitor glucose closely.",
-          severity: "warning",
-          source: "interactions",
-        });
-      }
-
-      // Liver/kidney cautions
-      if (match.liver_caution) {
-        warnings.push({
-          item: supp,
-          caution: "Use cautiously with liver impairment.",
-          severity: "warning",
-          source: "interactions",
-        });
-      }
-      if (match.kidney_caution) {
-        warnings.push({
-          item: supp,
-          caution: "Use cautiously with kidney impairment.",
-          severity: "warning",
-          source: "interactions",
-        });
-      }
-
-      // Pregnancy caution
-      if (pregnant && match.pregnancy_caution) {
-        warnings.push({
-          item: supp,
-          caution: "Not recommended during pregnancy.",
-          severity: "warning",
-          source: "interactions",
-        });
-      }
-    }
-
-    // -------------------------------------------------------------------------
-    // 3️⃣ Evaluate Rules Table (custom free-text cautions)
-    // -------------------------------------------------------------------------
-    for (const rule of rules) {
-      const trigger = normalize(rule.trigger);
-      const matchedSupp = supplements.find(s => normalize(s).includes(trigger));
-      if (matchedSupp) {
-        warnings.push({
-          item: matchedSupp,
-          caution: rule.caution || "Caution advised.",
-          severity: (rule.severity || "warning").toLowerCase() as SafetySeverity,
-          source: "rules",
-          note: rule.notes || null,
-        });
-      }
-    }
-
-    // -------------------------------------------------------------------------
-    // 4️⃣ Deduplicate by supplement + caution text
-    // -------------------------------------------------------------------------
-    const unique: Record<string, SafetyWarning> = {};
-    for (const w of warnings) {
-      const key = `${normalize(w.item)}::${normalize(w.caution)}`;
-      if (!unique[key]) unique[key] = w;
-    }
-
-    const deduped = Object.values(unique);
-
-    // -------------------------------------------------------------------------
-    // 5️⃣ Return results (or fallback)
-    // -------------------------------------------------------------------------
-    return deduped.length > 0 ? deduped : [
-      {
-        item: "All clear",
-        caution: "No safety issues detected.",
-        severity: "info",
-        source: "interactions",
-      },
-    ];
-  } catch (err) {
-    console.error("Safety evaluation failed; fallback to static:", err);
-
-    // -------------------------------------------------------------------------
-    // 6️⃣ Fallback mode (DB unavailable)
-    // -------------------------------------------------------------------------
-    return STATIC_RULES;
+    evaluation = evaluateSafetyCandidates(context, items, await loadSafetySources());
+  } catch (error) {
+    console.error("Safety evaluation failed closed", error);
+    evaluation = unavailableSafetyEvaluation(items);
   }
+  return {
+    ...evaluation,
+    cleaned: applyFindingsToItems(items, evaluation),
+  };
 }
-// ----------------------------------------------------------------------------
-// Fallback Export for generateStack.ts Compatibility
-// ----------------------------------------------------------------------------
 
-export function applySafetyChecks(stack: any, userData: any) {
-  // Basic wrapper: simply return stack if no logic defined
-  // (prevents Next.js build error until safety checks are implemented)
-  return stack;
+/** Compatibility adapter for older callers that only need warning rows. */
+export async function evaluateSafety(input: SafetyContext & { supplements?: string[] }): Promise<SafetyFinding[]> {
+  const result = await applySafetyChecks(
+    input,
+    (input.supplements ?? []).map((name) => ({ name, is_current: false }))
+  );
+  return result.findings;
 }

--- a/src/lib/safetyEngine.ts
+++ b/src/lib/safetyEngine.ts
@@ -1,0 +1,399 @@
+export type SafetySeverity = "info" | "warning" | "danger";
+export type SafetyDecision = "clear" | "review" | "blocked";
+export type SafetySource = "interactions" | "rules" | "intake" | "system";
+
+export interface SafetyContext {
+  medications?: string[];
+  conditions?: string[];
+  allergies?: string[];
+  procedures?: string[];
+  pregnant?: boolean | string | null;
+}
+
+export interface SafetyCandidate {
+  name: string;
+  dose?: string | null;
+  is_current?: boolean;
+}
+
+export interface InteractionRow {
+  ingredient: string;
+  binds_thyroid_meds?: boolean | null;
+  sep_hours_thyroid?: number | null;
+  anticoagulants_bleeding_risk?: boolean | null;
+  diabetes_meds_additive?: boolean | null;
+  sedatives_additive?: boolean | null;
+  antibiotics_interaction?: boolean | null;
+  pregnancy_caution?: boolean | null;
+  liver_disease_caution?: boolean | null;
+  kidney_disease_caution?: boolean | null;
+  immunocompromised_caution?: boolean | null;
+  caffeine_stimulant_caution?: boolean | null;
+  liver_caution?: boolean | null;
+  kidney_caution?: boolean | null;
+  notes?: string | null;
+}
+
+export interface SafetyRuleRow {
+  rule_id?: string | null;
+  rule_type?: string | null;
+  action?: string | null;
+  entity_a_name?: string | null;
+  max_daily_amount?: number | string | null;
+  unit?: string | null;
+  message?: string | null;
+  source_url?: string | null;
+  trigger_name?: string | null;
+  severity?: string | null;
+  notes?: string | null;
+  caution?: string | null;
+}
+
+export interface SafetyFinding {
+  code: string;
+  item: string;
+  message: string;
+  severity: SafetySeverity;
+  decision: Exclude<SafetyDecision, "clear">;
+  source: SafetySource;
+  sourceUrl?: string | null;
+}
+
+export interface SafetyCandidateResult {
+  name: string;
+  isCurrent: boolean;
+  decision: SafetyDecision;
+  findings: SafetyFinding[];
+}
+
+export interface SafetyEvaluation {
+  complete: boolean;
+  status: SafetyDecision;
+  candidates: SafetyCandidateResult[];
+  findings: SafetyFinding[];
+}
+
+export interface SafetySources {
+  interactions: InteractionRow[];
+  rules: SafetyRuleRow[];
+}
+
+const THYROID_MED_RE = /\b(?:levothyroxine|synthroid|levoxyl|unithroid|tirosint|liothyronine|cytomel|armour\s+thyroid|np\s+thyroid|thyroid\s+med)/i;
+const ANTICOAGULANT_RE = /\b(?:warfarin|coumadin|apixaban|eliquis|rivaroxaban|xarelto|dabigatran|pradaxa|edoxaban|savaysa|heparin|enoxaparin|lovenox|clopidogrel|plavix|anticoagulant|blood\s+thinner)/i;
+const GLUCOSE_MED_RE = /\b(?:metformin|insulin|semaglutide|ozempic|wegovy|rybelsus|tirzepatide|mounjaro|zepbound|dulaglutide|trulicity|liraglutide|victoza|saxenda|glipizide|glyburide|glimepiride|empagliflozin|jardiance|dapagliflozin|farxiga|diabetes\s+med)/i;
+const SEDATIVE_RE = /\b(?:eszopiclone|lunesta|zolpidem|ambien|alprazolam|xanax|lorazepam|ativan|clonazepam|klonopin|diazepam|valium|temazepam|restoril|trazodone|quetiapine|seroquel|sedative|sleep\s+med)/i;
+const ANTIBIOTIC_RE = /\b(?:ciprofloxacin|cipro|doxycycline|tetracycline|minocycline|amoxicillin|azithromycin|antibiotic)/i;
+const IMMUNOSUPPRESSANT_RE = /\b(?:tacrolimus|cyclosporine|azathioprine|mycophenolate|methotrexate|immunosuppress)/i;
+const STIMULANT_RE = /\b(?:amphetamine|adderall|dextroamphetamine|vyvanse|lisdexamfetamine|methylphenidate|ritalin|concerta|stimulant)/i;
+const SSRI_SNRI_MAOI_RE = /\b(?:sertraline|zoloft|fluoxetine|prozac|escitalopram|lexapro|citalopram|celexa|paroxetine|paxil|venlafaxine|effexor|duloxetine|cymbalta|phenelzine|nardil|tranylcypromine|parnate|ssri|snri|maoi)/i;
+const RECOGNIZED_MED_RE = new RegExp([
+  THYROID_MED_RE.source,
+  ANTICOAGULANT_RE.source,
+  GLUCOSE_MED_RE.source,
+  SEDATIVE_RE.source,
+  ANTIBIOTIC_RE.source,
+  IMMUNOSUPPRESSANT_RE.source,
+  STIMULANT_RE.source,
+  SSRI_SNRI_MAOI_RE.source,
+].join("|"), "i");
+
+function normalize(value: unknown): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\b(?:extract|powder|capsules?|tablets?|softgels?|hcl)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stringList(values?: string[]): string[] {
+  return (values ?? []).map((value) => String(value ?? "").trim()).filter(Boolean);
+}
+
+function contextMatches(values: string[], pattern: RegExp): boolean {
+  return values.some((value) => pattern.test(value));
+}
+
+function isPregnant(value: SafetyContext["pregnant"]): boolean {
+  return value === true || /^(?:yes|true|pregnant)$/i.test(String(value ?? "").trim());
+}
+
+function interactionMatches(name: string, rows: InteractionRow[]): InteractionRow[] {
+  const candidate = normalize(name);
+  return rows.filter((row) => {
+    const ingredient = normalize(row.ingredient);
+    return ingredient === candidate ||
+      (ingredient.length >= 5 && candidate.startsWith(ingredient)) ||
+      (candidate.length >= 5 && ingredient.startsWith(candidate));
+  });
+}
+
+function mergedInteraction(name: string, rows: InteractionRow[]): InteractionRow | undefined {
+  const matches = interactionMatches(name, rows);
+  if (!matches.length) return undefined;
+  const flag = (key: keyof InteractionRow) => matches.some((row) => row[key] === true);
+  const spacing = matches.map((row) => row.sep_hours_thyroid).filter((value): value is number => typeof value === "number");
+  return {
+    ingredient: name,
+    binds_thyroid_meds: flag("binds_thyroid_meds"),
+    sep_hours_thyroid: spacing.length ? Math.max(...spacing) : null,
+    anticoagulants_bleeding_risk: flag("anticoagulants_bleeding_risk"),
+    diabetes_meds_additive: flag("diabetes_meds_additive"),
+    sedatives_additive: flag("sedatives_additive"),
+    antibiotics_interaction: flag("antibiotics_interaction"),
+    pregnancy_caution: flag("pregnancy_caution"),
+    liver_disease_caution: flag("liver_disease_caution"),
+    kidney_disease_caution: flag("kidney_disease_caution"),
+    immunocompromised_caution: flag("immunocompromised_caution"),
+    caffeine_stimulant_caution: flag("caffeine_stimulant_caution"),
+    liver_caution: flag("liver_caution"),
+    kidney_caution: flag("kidney_caution"),
+    notes: matches.map((row) => row.notes).filter(Boolean).join(" ") || null,
+  };
+}
+
+function nameAppearsInText(name: string, text: string): boolean {
+  const candidate = normalize(name);
+  const haystack = normalize(text);
+  if (!candidate || !haystack) return false;
+  const firstWord = candidate.split(" ")[0];
+  return haystack.includes(candidate) || (firstWord.length >= 4 && haystack.includes(firstWord));
+}
+
+function allergyMatchesCandidate(allergy: string, candidate: string): boolean {
+  const a = normalize(allergy);
+  const c = normalize(candidate);
+  if (!a || !c || /^(?:seasonal|environmental|pollen|none|n a)$/.test(a)) return false;
+  return a === c || a.includes(c) || c.includes(a);
+}
+
+function parseDose(dose?: string | null): { amount: number; unit: string } | null {
+  const match = String(dose ?? "").match(/(\d+(?:\.\d+)?)\s*(mcg|µg|ug|mg|g|iu)\b/i);
+  if (!match) return null;
+  return { amount: Number(match[1]), unit: match[2].toLowerCase().replace("µg", "mcg").replace("ug", "mcg") };
+}
+
+function comparableRuleUnit(unit?: string | null): string {
+  const source = String(unit ?? "").toLowerCase();
+  if (source.startsWith("mcg")) return "mcg";
+  if (source.startsWith("mg")) return "mg";
+  if (source === "g" || source === "iu") return source;
+  return "";
+}
+
+function worstDecision(findings: SafetyFinding[]): SafetyDecision {
+  return findings.some((finding) => finding.decision === "blocked")
+    ? "blocked"
+    : findings.length ? "review" : "clear";
+}
+
+function addFinding(target: SafetyFinding[], finding: SafetyFinding): void {
+  const key = `${finding.code}:${normalize(finding.item)}:${normalize(finding.message)}`;
+  if (!target.some((existing) => `${existing.code}:${normalize(existing.item)}:${normalize(existing.message)}` === key)) {
+    target.push(finding);
+  }
+}
+
+function finding(
+  code: string,
+  item: string,
+  message: string,
+  severity: SafetySeverity,
+  source: SafetySource,
+  sourceUrl?: string | null
+): SafetyFinding {
+  return {
+    code,
+    item,
+    message,
+    severity,
+    decision: severity === "danger" ? "blocked" : "review",
+    source,
+    sourceUrl,
+  };
+}
+
+export function evaluateSafetyCandidates(
+  context: SafetyContext,
+  candidates: SafetyCandidate[],
+  sources: SafetySources
+): SafetyEvaluation {
+  const medications = stringList(context.medications);
+  const conditions = stringList(context.conditions);
+  const allergies = stringList(context.allergies);
+  const procedures = stringList(context.procedures);
+  const hasThyroidMedication = contextMatches(medications, THYROID_MED_RE);
+  const hasAnticoagulant = contextMatches(medications, ANTICOAGULANT_RE);
+  const hasGlucoseMedication = contextMatches(medications, GLUCOSE_MED_RE);
+  const hasSedative = contextMatches(medications, SEDATIVE_RE);
+  const hasAntibiotic = contextMatches(medications, ANTIBIOTIC_RE);
+  const hasImmunosuppressant = contextMatches(medications, IMMUNOSUPPRESSANT_RE);
+  const hasStimulant = contextMatches(medications, STIMULANT_RE);
+  const hasSerotonergicMedication = contextMatches(medications, SSRI_SNRI_MAOI_RE);
+  const hasKidneyCondition = contextMatches(conditions, /\b(?:kidney|renal|dialysis|neph)/i);
+  const hasLiverCondition = contextMatches(conditions, /\b(?:liver|hepatic|cirrhosis|hepatitis)/i);
+  const isImmunocompromised = contextMatches(conditions, /\b(?:immunocompromised|immune\s+suppression|transplant)/i);
+  const hasUpcomingProcedure = contextMatches([...procedures, ...conditions], /\b(?:surgery|procedure|operation|colonoscopy|endoscopy|dental\s+extraction)\b/i);
+  const unknownMedications = medications.filter((medication) => !RECOGNIZED_MED_RE.test(medication));
+
+  const candidateResults = candidates.map((candidate): SafetyCandidateResult => {
+    const findings: SafetyFinding[] = [];
+    const match = mergedInteraction(candidate.name, sources.interactions);
+
+    for (const allergy of allergies) {
+      if (allergyMatchesCandidate(allergy, candidate.name)) {
+        addFinding(findings, finding("allergy_match", candidate.name, `Reported allergy may match ${candidate.name}. Do not start or continue it until a clinician or pharmacist confirms the ingredient.`, "danger", "intake"));
+      }
+    }
+
+    if (!match) {
+      addFinding(findings, finding("interaction_record_missing", candidate.name, `No structured interaction record matched ${candidate.name}. A clinician or pharmacist should review it before a new start.`, "warning", "system"));
+    } else {
+      if (hasThyroidMedication && match.binds_thyroid_meds) {
+        addFinding(findings, finding("thyroid_spacing", candidate.name, `Separate ${candidate.name} from thyroid medication by at least ${match.sep_hours_thyroid ?? 4} hours, or follow the pharmacist's timing instructions.`, "warning", "interactions"));
+      }
+      if (hasAnticoagulant && match.anticoagulants_bleeding_risk) {
+        addFinding(findings, finding("anticoagulant_bleeding", candidate.name, `${candidate.name} may change bleeding risk with the reported anticoagulant. Do not add or change it without coordinated review.`, "danger", "interactions"));
+      }
+      if (hasUpcomingProcedure && match.anticoagulants_bleeding_risk) {
+        addFinding(findings, finding("procedure_bleeding", candidate.name, `${candidate.name} may matter before the reported procedure. Confirm the plan with the procedure team before use.`, "danger", "interactions"));
+      }
+      if (hasGlucoseMedication && match.diabetes_meds_additive) {
+        addFinding(findings, finding("glucose_lowering", candidate.name, `${candidate.name} may add to glucose-lowering effects. Review monitoring and timing before use.`, "warning", "interactions"));
+      }
+      if (hasSedative && match.sedatives_additive) {
+        addFinding(findings, finding("sedating_additive", candidate.name, `${candidate.name} may add to drowsiness from a reported medication. Review timing and avoid driving if drowsy.`, "warning", "interactions"));
+      }
+      if (hasAntibiotic && match.antibiotics_interaction) {
+        addFinding(findings, finding("antibiotic_interaction", candidate.name, `${candidate.name} may interact with or need spacing from the reported antibiotic. Ask a pharmacist for exact timing.`, "warning", "interactions"));
+      }
+      if (isPregnant(context.pregnant) && match.pregnancy_caution) {
+        addFinding(findings, finding("pregnancy_caution", candidate.name, `${candidate.name} is flagged for pregnancy caution. Do not start it without obstetric clinician review.`, "danger", "interactions"));
+      }
+      if (hasLiverCondition && (match.liver_disease_caution || match.liver_caution)) {
+        addFinding(findings, finding("liver_caution", candidate.name, `${candidate.name} is flagged for caution with the reported liver context. Review it before use.`, "warning", "interactions"));
+      }
+      if (hasKidneyCondition && (match.kidney_disease_caution || match.kidney_caution)) {
+        addFinding(findings, finding("kidney_caution", candidate.name, `${candidate.name} is flagged for caution with the reported kidney context. Review dose and monitoring before use.`, "warning", "interactions"));
+      }
+      if ((isImmunocompromised || hasImmunosuppressant) && match.immunocompromised_caution) {
+        addFinding(findings, finding("immune_caution", candidate.name, `${candidate.name} is flagged for review with the reported immune context or medication.`, "warning", "interactions"));
+      }
+      if (hasStimulant && match.caffeine_stimulant_caution) {
+        addFinding(findings, finding("stimulant_additive", candidate.name, `${candidate.name} may add to stimulant effects. Review timing, sleep impact, heart rate, and blood pressure before use.`, "warning", "interactions"));
+      }
+    }
+
+    if (hasSerotonergicMedication && /^5\s*htp\b/i.test(normalize(candidate.name))) {
+      addFinding(findings, finding("serotonergic_combination", candidate.name, `Do not combine ${candidate.name} with the reported serotonergic medication without clinician review.`, "danger", "rules"));
+    }
+
+    for (const rule of sources.rules) {
+      const trigger = normalize(rule.trigger_name);
+      const contextTrigger =
+        (trigger === "thyroid med" && hasThyroidMedication) ||
+        (trigger === "anticoagulant" && hasAnticoagulant) ||
+        (trigger === "diabetes med" && hasGlucoseMedication) ||
+        (trigger === "pregnancy" && isPregnant(context.pregnant)) ||
+        (trigger === "liver impairment" && hasLiverCondition) ||
+        (trigger === "kidney impairment" && hasKidneyCondition);
+      const ruleText = `${rule.caution ?? ""} ${rule.message ?? ""}`.trim();
+      if (contextTrigger && nameAppearsInText(candidate.name, ruleText)) {
+        const severity = String(rule.severity ?? "warning").toLowerCase() === "danger" ? "danger" : "warning";
+        addFinding(findings, finding(`rule_${trigger.replace(/\s+/g, "_")}`, candidate.name, rule.caution || rule.message || "Clinician review is recommended.", severity, "rules", rule.source_url));
+      }
+
+      if (String(rule.rule_type ?? "").toUpperCase() === "UL" && rule.entity_a_name && interactionMatches(candidate.name, [{ ingredient: rule.entity_a_name }]).length) {
+        const dose = parseDose(candidate.dose);
+        const max = Number(rule.max_daily_amount);
+        const unit = comparableRuleUnit(rule.unit);
+        if (dose && Number.isFinite(max) && unit && dose.unit === unit && dose.amount > max) {
+          addFinding(findings, finding("upper_limit", candidate.name, rule.message || `${candidate.name} exceeds the structured adult upper limit.`, "danger", "rules", rule.source_url));
+        }
+      }
+
+      if (String(rule.rule_type ?? "").toUpperCase() === "SPACING" && rule.entity_a_name && medications.some((medication) => normalize(medication).includes(normalize(rule.entity_a_name))) && nameAppearsInText(candidate.name, rule.message ?? "")) {
+        addFinding(findings, finding("medication_spacing", candidate.name, rule.message || `Separate ${candidate.name} from the reported medication.`, "warning", "rules", rule.source_url));
+      }
+    }
+
+    if (unknownMedications.length) {
+      addFinding(findings, finding("unknown_medication", candidate.name, `The interaction library did not classify ${unknownMedications.join(", ")}. Proposed supplements require pharmacist or clinician review before use.`, "warning", "system"));
+    }
+
+    return {
+      name: candidate.name,
+      isCurrent: candidate.is_current === true,
+      decision: worstDecision(findings),
+      findings,
+    };
+  });
+
+  const findings = candidateResults.flatMap((candidate) => candidate.findings);
+  return {
+    complete: true,
+    status: worstDecision(findings),
+    candidates: candidateResults,
+    findings,
+  };
+}
+
+export function unavailableSafetyEvaluation(candidates: SafetyCandidate[], reason = "Structured safety evaluation was unavailable."): SafetyEvaluation {
+  const results = candidates.map((candidate): SafetyCandidateResult => {
+    const systemFinding = finding("evaluation_unavailable", candidate.name, `${reason} Do not start a proposed supplement until a clinician or pharmacist reviews it.`, "warning", "system");
+    return {
+      name: candidate.name,
+      isCurrent: candidate.is_current === true,
+      decision: "review",
+      findings: [systemFinding],
+    };
+  });
+  return {
+    complete: false,
+    status: "review",
+    candidates: results,
+    findings: results.flatMap((candidate) => candidate.findings),
+  };
+}
+
+function findingLabel(finding: SafetyFinding): string {
+  return finding.decision === "blocked" ? "Stop and review" : "Clinician review";
+}
+
+export function safetySectionFromEvaluation(evaluation: SafetyEvaluation): string {
+  const uniqueFindings: SafetyFinding[] = [];
+  for (const item of evaluation.findings) addFinding(uniqueFindings, item);
+  const bullets = uniqueFindings.length
+    ? uniqueFindings.map((item) => `- **${findingLabel(item)}: ${item.item}:** ${item.message}`)
+    : ["- **No material flags identified:** No specific interaction requiring action was identified from the reported information and structured rules. Recheck whenever medications, supplements, pregnancy status, conditions, or procedures change."];
+  return [
+    "## Contraindications & Med Interactions",
+    "",
+    ...bullets,
+    "",
+    "**Analysis**",
+    "",
+    evaluation.complete
+      ? "This result is limited to the information provided and the structured rules available at generation time. Keep prescription and hormone instructions unchanged."
+      : "The safety review did not complete. Keep prescription and hormone instructions unchanged, and do not start proposed supplements until the review is completed.",
+  ].join("\n");
+}
+
+export function applySafetyEvaluationToMarkdown(markdown: string, evaluation: SafetyEvaluation): string {
+  const decisions = new Map(evaluation.candidates.map((candidate) => [normalize(candidate.name), candidate]));
+  const lines = markdown.split(/\r?\n/).map((line) => {
+    if (!/^\s*\|\s*\d+\s*\|/.test(line)) return line;
+    const cells = line.split("|");
+    const candidate = decisions.get(normalize(cells[2]));
+    if (!candidate || candidate.isCurrent || candidate.decision === "clear") return line;
+    cells[3] = " Clinician review ";
+    return cells.join("|");
+  });
+  const updated = lines.join("\n");
+  const section = safetySectionFromEvaluation(evaluation);
+  const sectionRe = /## Contraindications & Med Interactions[\s\S]*?(?=\n## |$)/i;
+  return sectionRe.test(updated)
+    ? updated.replace(sectionRe, section)
+    : `${updated.trim()}\n\n${section}`;
+}


### PR DESCRIPTION
## What changed

- Replaced the no-op safety compatibility stub with a typed safety evaluator backed by the existing Supabase interactions and rules tables.
- Evaluates proposed supplements against medications, conditions, allergies, pregnancy, and procedure context before persistence.
- Fails closed when an interaction record, medication classification, or database evaluation is unavailable.
- Writes one canonical structured result into the customer-visible Blueprint safety section, recommendation status, persisted item caution, PDF/email markdown, and downstream safety badge.
- Keeps current medication and hormone instructions unchanged.
- Supports the current database schema, including `diabetes_meds_additive` and `trigger_name`.
- Adds deterministic fixtures for pregnancy, allergy, procedure, anticoagulant, glucose lowering, thyroid spacing, kidney/liver context, sedation, unknown medication, unmatched supplements, and source failure.

## Why

The generator previously called `applySafetyChecks`, but that export returned its input unchanged. This allowed generated recommendations to continue without a working structured safety gate.

## Verification

- All 12 existing QA suites passed.
- New `qa:safety-engine` suite passed.
- TypeScript type checking passed.
- Production build passed with local non-secret placeholder environment values.
- `git diff --check` passed.
- Live Supabase schema and rule rows were inspected; no migration is required.

## Preview QA

Keep this PR in draft until an authenticated Preview Blueprint refresh confirms:

1. A low-risk stack receives qualified, non-absolute clear wording.
2. A medication interaction changes the proposed item to Clinician review.
3. The same caution appears in the Blueprint, PDF/export, and safety badge.
4. Current medication and hormone instructions remain unchanged.