### PR TITLE
PR72: Canonicalize the current medication and supplement regimen

### DIFF
--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -9,8 +9,9 @@ import {
 } from "@/lib/blueprintSafetyStatus";
 import {
   blueprintInputSnapshotHash,
-  getMemberSupplements,
 } from "@/lib/blueprintWorkspace";
+import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
+import { regimenToLedger } from "@/lib/currentRegimenModel";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 import BlueprintWorkspaceClient from "./BlueprintWorkspaceClient";
@@ -56,8 +57,21 @@ export default async function BlueprintPage({ params }: PageProps) {
 
   const markdown = blueprintMarkdownFromStack(stack);
   const report = parseBlueprintReport(markdown);
-  const { supplements, hasOverride } = getMemberSupplements(submission);
-  const currentInputHash = blueprintInputSnapshotHash(submission);
+  await ensureCurrentRegimen(user.id, submission.id, submission);
+  const regimen = await getCurrentRegimen(user.id);
+  const supplementRegimen = regimen.filter((item) =>
+    item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement"
+  );
+  const supplements = supplementRegimen.map((item) => ({
+    id: item.id,
+    name: item.name,
+    brand: null,
+    dose: item.dose,
+    timing: item.timing,
+    active: item.active,
+  }));
+  const hasOverride = supplementRegimen.some((item) => item.instruction_source !== "intake");
+  const currentInputHash = blueprintInputSnapshotHash(submission, regimenToLedger(regimen));
   const versioningReady = Object.prototype.hasOwnProperty.call(stack, "input_snapshot_hash");
   const stale = versioningReady
     ? !stack.input_snapshot_hash || stack.input_snapshot_hash !== currentInputHash

--- a/app/api/blueprints/[stackId]/refresh/route.ts
+++ b/app/api/blueprints/[stackId]/refresh/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
+import { ensureCurrentRegimen } from "@/lib/currentRegimen";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
 import { sendGeneratedBlueprintEmail } from "@/lib/reportEmail";
 import { requirePaidApi } from "@/lib/serverEntitlements";
@@ -49,7 +50,8 @@ export async function POST(_req: Request, { params }: RouteContext) {
       return NextResponse.json({ ok: false, error: "blueprint_not_found" }, { status: 404 });
     }
 
-    const inputSnapshotHash = blueprintInputSnapshotHash(submission);
+    const currentRegimen = await ensureCurrentRegimen(entitlement.user.id, submission.id, submission);
+    const inputSnapshotHash = blueprintInputSnapshotHash(submission, currentRegimen);
     const { data: existing, error: existingError } = await admin
       .from("stacks")
       .select("id")

--- a/app/api/blueprints/[stackId]/supplements/route.ts
+++ b/app/api/blueprints/[stackId]/supplements/route.ts
@@ -6,6 +6,8 @@ import {
   withMemberSupplementOverride,
 } from "@/lib/blueprintWorkspace";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
+import { replaceCurrentSupplements } from "@/lib/currentRegimen";
+import { regimenToLedger } from "@/lib/currentRegimenModel";
 import { requirePaidApi } from "@/lib/serverEntitlements";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
@@ -62,7 +64,9 @@ export async function PUT(req: Request, { params }: RouteContext) {
       return NextResponse.json({ ok: false, error: "update_not_saved" }, { status: 409 });
     }
 
-    const currentInputHash = blueprintInputSnapshotHash(updated);
+    const currentRegimen = await replaceCurrentSupplements(entitlement.user.id, submission.id, supplements);
+
+    const currentInputHash = blueprintInputSnapshotHash(updated, regimenToLedger(currentRegimen));
     await recordProductEventSafely({
       user_id: entitlement.user.id,
       event_name: "blueprint_input_change_saved",

--- a/app/api/fullscript/add/route.ts
+++ b/app/api/fullscript/add/route.ts
@@ -1,106 +1,30 @@
-// app/api/fullscript/add/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
-import { requirePaidApi } from "@/lib/serverEntitlements";
 
-// NEW: import timing helpers (you added src/lib/timing.ts earlier)
-import { bucketsForItem, collapseBucketsToString } from "@/src/lib/timing";
+import { upsertManualRegimenItem } from "@/lib/currentRegimen";
+import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export async function POST(req: Request) {
   const entitlement = await requirePaidApi();
   if (!entitlement.ok) return entitlement.response;
 
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
-
   try {
-    const { data: userWrap, error: userErr } = await supabase.auth.getUser();
-    if (userErr || !userWrap?.user?.id) {
-      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
-    }
-    const userId = userWrap.user.id;
+    const body = await req.json().catch(() => null) as {
+      name?: string;
+      dose?: string | null;
+      timing?: string | null;
+    } | null;
+    const name = body?.name?.trim();
+    if (!name) return NextResponse.json({ ok: false, error: "name_required" }, { status: 400 });
 
-    const body = await req.json();
-    const {
+    const item = await upsertManualRegimenItem(entitlement.user.id, {
       name,
-      brand = null,
-      dose = null,
-      link_fullscript = null,
-      link_amazon = null,
-      source = "fullscript",
-      sku = null,
-      timing = "AM",
-      notes = null,
-    } = body || {};
-
-    if (!name) {
-      return NextResponse.json({ ok: false, error: "name_required" }, { status: 400 });
-    }
-
-    // admin client to upsert (safer for creating stack if none exists)
-    const admin = getSupabaseAdmin();
-
-    // 1) ensure latest stack for user
-    const { data: stacksRows, error: stacksErr } = await admin
-      .from("stacks")
-      .select("id, created_at")
-      .eq("user_id", userId)
-      .order("created_at", { ascending: false })
-      .limit(1);
-
-    if (stacksErr) throw stacksErr;
-
-    let stackId = stacksRows?.[0]?.id;
-    if (!stackId) {
-      const { data: newStack, error: insErr } = await admin
-        .from("stacks")
-        .insert({
-          user_id: userId,
-          user_email: userWrap.user.email ?? "unknown@lve360.com",
-          submission_id: crypto.randomUUID(), // keep your existing behavior
-          version: "manual-add",
-          items: [],
-          summary: null,
-          total_monthly_cost: 0,
-          notes: "Created by /api/fullscript/add",
-        })
-        .select("id")
-        .single();
-      if (insErr) throw insErr;
-      stackId = newStack.id;
-    }
-
-    // --- NEW: normalize timing into a canonical bucket string
-    const bucketArr = bucketsForItem(timing);
-    const timing_bucket = collapseBucketsToString(bucketArr);
-
-    // 2) insert stacks_items row (add timing_bucket; keep everything else)
-    const { error: itemErr } = await admin.from("stacks_items").insert({
-      stack_id: stackId,
-      user_id: userId,
-      user_email: userWrap.user.email ?? null,
-      name,
-      brand,
-      dose,
-      timing,
-      timing_bucket,                 // <-- NEW: write normalized bucket
-      notes,
-      link_fullscript,
-      link_amazon,
-      link_other: null,
-      link_type: link_fullscript ? "fullscript" : link_amazon ? "amazon" : null,
-      source,                        // (leave as-is if your DB has this column)
-      sku,                           // (leave as-is if your DB has this column)
-      is_custom: source === "custom",
-      is_current: true,
+      dose: body?.dose ?? null,
+      timing: body?.timing ?? null,
+      active: true,
     });
-
-    if (itemErr) throw itemErr;
-
-    return NextResponse.json({ ok: true, stack_id: stackId });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, error: e?.message ?? "add_failed" }, { status: 500 });
+    return NextResponse.json({ ok: true, item });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "add_failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
 }

--- a/app/api/intake/set/route.ts
+++ b/app/api/intake/set/route.ts
@@ -1,48 +1,48 @@
-// app/api/intake/set/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
-import { requirePaidApi } from "@/lib/serverEntitlements";
 
-// Upsert today's intake event for (user, item)
+import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
 export async function POST(req: Request) {
   const entitlement = await requirePaidApi();
   if (!entitlement.ok) return entitlement.response;
 
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
-  const admin = getSupabaseAdmin();
-
   try {
-    const { data: userWrap, error: userErr } = await supabase.auth.getUser();
-    if (userErr || !userWrap?.user?.id) {
-      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    const userId = entitlement.user.id;
+    const body = await req.json().catch(() => null) as {
+      regimen_item_id?: string;
+      item_id?: string;
+      taken?: boolean;
+    } | null;
+    const regimenItemId = body?.regimen_item_id ?? body?.item_id;
+    const taken = body?.taken;
+    if (!regimenItemId || typeof taken !== "boolean") {
+      return NextResponse.json({ ok: false, error: "regimen_item_id_and_taken_required" }, { status: 400 });
     }
-    const userId = userWrap.user.id;
 
-    const body = await req.json();
-    const itemId = body?.item_id as string | undefined;
-    const taken = body?.taken as boolean | undefined;
-
-    if (!itemId || typeof taken !== "boolean") {
-      return NextResponse.json({ ok: false, error: "item_id_and_taken_required" }, { status: 400 });
+    const admin = getSupabaseAdmin();
+    const { data: ownedItem, error: itemError } = await admin
+      .from("current_regimen_items")
+      .select("id")
+      .eq("id", regimenItemId)
+      .eq("user_id", userId)
+      .eq("active", true)
+      .maybeSingle();
+    if (itemError) throw itemError;
+    if (!ownedItem) {
+      return NextResponse.json({ ok: false, error: "regimen_item_not_found" }, { status: 404 });
     }
 
     const today = new Date().toISOString().slice(0, 10);
+    const { error } = await admin.from("intake_events").upsert(
+      { user_id: userId, regimen_item_id: regimenItemId, intake_date: today, taken },
+      { onConflict: "user_id,regimen_item_id,intake_date" }
+    );
+    if (error) throw error;
 
-    // Upsert (user_id, item_id, intake_date) → taken
-    const { error: upErr } = await admin
-      .from("intake_events")
-      .upsert(
-        { user_id: userId, item_id: itemId, intake_date: today, taken },
-        { onConflict: "user_id,item_id,intake_date" }
-      );
-
-    if (upErr) throw upErr;
-
-    return NextResponse.json({ ok: true, item_id: itemId, date: today, taken });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, error: e?.message ?? "set_failed" }, { status: 500 });
+    return NextResponse.json({ ok: true, regimen_item_id: regimenItemId, date: today, taken });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "set_failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
 }

--- a/app/api/intake/status/route.ts
+++ b/app/api/intake/status/route.ts
@@ -1,111 +1,38 @@
-// app/api/intake/status/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+import { getCurrentRegimen } from "@/lib/currentRegimen";
 import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-export async function GET(req: Request) {
+export async function GET() {
   const entitlement = await requirePaidApi();
   if (!entitlement.ok) return entitlement.response;
 
-  const supabase = createRouteHandlerClient({ cookies });
-  const url = new URL(req.url);
-
   try {
-    // 1) Auth
-    const { data: { user }, error: userErr } = await supabase.auth.getUser();
-    if (userErr || !user?.id) {
-      console.warn("[intake/status] unauthorized:", userErr?.message);
-      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
-    }
-    const userId = user.id;
-
-    // 2) Params
-    const stackId = url.searchParams.get("stack_id");
-    if (!stackId) {
-      console.warn("[intake/status] missing stack_id");
-      return NextResponse.json({ ok: false, error: "stack_id_required" }, { status: 400 });
-    }
-
+    const userId = entitlement.user.id;
     const today = new Date().toISOString().slice(0, 10);
-    console.log("[intake/status] start", { userId, stackId, today });
+    const regimen = await getCurrentRegimen(userId);
+    const itemIds = regimen.map((item) => item.id);
+    const statuses = Object.fromEntries(itemIds.map((id) => [id, false])) as Record<string, boolean>;
+    if (!itemIds.length) return NextResponse.json({ ok: true, date: today, statuses });
 
-    // 3) Get the *item ids* that belong to this stack (PK is 'id' on stacks_items)
-    const { data: stackItems, error: itemsErr } = await supabase
-      .from("stacks_items")
-      .select("id") // <-- correct column (item_id does not exist here)
+    const { data, error } = await getSupabaseAdmin()
+      .from("intake_events")
+      .select("regimen_item_id,taken")
       .eq("user_id", userId)
-      .eq("stack_id", stackId);
-
-    if (itemsErr) {
-      console.error("[intake/status] stacks_items error:", itemsErr);
-      throw itemsErr;
+      .eq("intake_date", today)
+      .in("regimen_item_id", itemIds);
+    if (error) throw error;
+    for (const event of data ?? []) {
+      if (event.regimen_item_id) statuses[event.regimen_item_id] = Boolean(event.taken);
     }
-
-    const itemIds = (stackItems ?? []).map((r) => r.id).filter(Boolean);
-    console.log("[intake/status] stack items", { count: itemIds.length });
-
-    if (itemIds.length === 0) {
-      return NextResponse.json({ ok: true, date: today, statuses: {} });
-    }
-
-    // 4) Try fetching today's intake events by 'item_id' first.
-    let events:
-      | Array<{ item_id?: string | null; stack_item_id?: string | null; taken: boolean | null }>
-      | null = null;
-
-    let evErr = null;
-
-    {
-      const res = await supabase
-        .from("intake_events")
-        .select("item_id, taken") // preferred schema
-        .eq("user_id", userId)
-        .eq("intake_date", today)
-        .in("item_id", itemIds as string[]);
-      events = res.data as any;
-      evErr = res.error;
-    }
-
-    // 5) Fallback for alternate column name: 'stack_item_id'
-    if (evErr?.code === "42703") {
-      console.warn("[intake/status] retrying with 'stack_item_id' column");
-      const res2 = await supabase
-        .from("intake_events")
-        .select("stack_item_id, taken")
-        .eq("user_id", userId)
-        .eq("intake_date", today)
-        .in("stack_item_id", itemIds as string[]);
-      events = res2.data as any;
-      evErr = res2.error;
-    }
-
-    if (evErr) {
-      console.error("[intake/status] intake_events error:", evErr);
-      throw evErr;
-    }
-
-    console.log("[intake/status] events", { count: events?.length ?? 0 });
-
-    // 6) Build a stable boolean map for *every* item in the stack
-    const map: Record<string, boolean> = {};
-    for (const id of itemIds) map[id as string] = false;
-
-    for (const row of events ?? []) {
-      const key =
-        (row.item_id as string | null | undefined) ??
-        (row.stack_item_id as string | null | undefined) ??
-        null;
-      if (key) map[key] = !!row.taken;
-    }
-
-    console.log("[intake/status] done", { keys: Object.keys(map).length });
-    return NextResponse.json({ ok: true, date: today, statuses: map });
-  } catch (e: any) {
-    console.error("[intake/status] unhandled error:", e);
-    return NextResponse.json({ ok: false, error: e?.message ?? "status_failed" }, { status: 500 });
+    return NextResponse.json({ ok: true, date: today, statuses });
+  } catch (error) {
+    console.error("[intake/status] failed", error);
+    const message = error instanceof Error ? error.message : "status_failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
 }

--- a/app/api/stack-items/activate/route.ts
+++ b/app/api/stack-items/activate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { adoptStackRecommendation } from "@/lib/currentRegimen";
 import { requirePaidApi } from "@/lib/serverEntitlements";
 
 export async function POST(req: Request) {
@@ -12,9 +13,12 @@ export async function POST(req: Request) {
   if (!user?.id) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
   const body = (await req.json().catch(() => null)) as { item_id?: string } | null;
   if (!body?.item_id) return NextResponse.json({ ok: false, error: "item_id_required" }, { status: 400 });
-  const { data, error } = await supabase.from("stacks_items").update({ is_current: true })
-    .eq("id", body.item_id).eq("user_id", user.id).select("id").maybeSingle();
-  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
-  if (!data) return NextResponse.json({ ok: false, error: "item_not_found" }, { status: 404 });
-  return NextResponse.json({ ok: true });
+  try {
+    const regimenItem = await adoptStackRecommendation(user.id, body.item_id);
+    if (!regimenItem) return NextResponse.json({ ok: false, error: "item_not_found" }, { status: 404 });
+    return NextResponse.json({ ok: true, item: regimenItem });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "recommendation_adoption_failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
 }

--- a/app/api/stacks/combined/route.ts
+++ b/app/api/stacks/combined/route.ts
@@ -1,8 +1,9 @@
-// app/api/stacks/combined/route.ts
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
+import { normalizeRegimenName } from "@/lib/currentRegimenModel";
 import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -11,53 +12,61 @@ export async function GET() {
   const entitlement = await requirePaidApi();
   if (!entitlement.ok) return entitlement.response;
 
-  const supabase = createRouteHandlerClient({ cookies });
+  try {
+    const userId = entitlement.user.id;
+    const admin = getSupabaseAdmin();
+    const { data: latestStack, error: stackError } = await admin
+      .from("stacks")
+      .select("id,submission_id,created_at")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (stackError) throw stackError;
 
-  // 0) Who's calling?
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user?.id) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    if (latestStack?.submission_id) {
+      await ensureCurrentRegimen(userId, latestStack.submission_id);
+    }
+    const regimen = await getCurrentRegimen(userId);
+    const currentNames = new Set(regimen.map((item) => normalizeRegimenName(item.name)));
+    const current = regimen.map((item) => ({
+      id: item.id,
+      stack_id: latestStack?.id ?? null,
+      user_id: item.user_id,
+      name: item.name,
+      brand: null,
+      dose: item.dose,
+      timing: item.timing,
+      timing_text: item.timing,
+      timing_bucket: null,
+      notes: `Current ${item.item_kind.replaceAll("_", " ")}. Instruction source: ${item.instruction_source}.`,
+      is_current: true,
+      item_kind: item.item_kind,
+      source_type: "regimen",
+      link_amazon: null,
+      link_fullscript: null,
+      refill_days_left: null,
+      last_refilled_at: null,
+      supplement_id: null,
+      created_at: item.created_at ?? item.updated_at ?? null,
+    }));
 
-  // 1) Current items explicitly marked as current
-  const { data: current, error: currErr } = await supabase
-    .from("stacks_items")
-    .select("id, stack_id, user_id, name, brand, dose, timing, timing_text, timing_bucket, notes, is_current, link_amazon, link_fullscript, refill_days_left, last_refilled_at, supplement_id, created_at")
-    .eq("user_id", user.id)
-    .eq("is_current", true);
+    let proposals: any[] = [];
+    if (latestStack?.id) {
+      const { data, error } = await admin.from("stacks_items")
+        .select("id,stack_id,user_id,name,brand,dose,timing,timing_text,timing_bucket,notes,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,supplement_id,created_at")
+        .eq("stack_id", latestStack.id)
+        .eq("is_current", false);
+      if (error) throw error;
+      proposals = (data ?? [])
+        .filter((item) => !currentNames.has(normalizeRegimenName(item.name ?? "")))
+        .map((item) => ({ ...item, source_type: "blueprint_proposal" }));
+    }
 
-  if (currErr) return NextResponse.json({ ok: false, error: currErr.message }, { status: 400 });
-
-  // 2) Latest blueprint (most recent stack)
-  const { data: latestStack } = await supabase
-    .from("stacks")
-    .select("id, created_at")
-    .eq("user_id", user.id)
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  let blueprint: any[] = [];
-  if (latestStack?.id) {
-    const { data: bp, error: bpErr } = await supabase
-      .from("stacks_items")
-      .select("id, stack_id, user_id, name, brand, dose, timing, timing_text, timing_bucket, notes, is_current, link_amazon, link_fullscript, refill_days_left, last_refilled_at, supplement_id, created_at")
-      .eq("stack_id", latestStack.id);
-    if (bpErr) return NextResponse.json({ ok: false, error: bpErr.message }, { status: 400 });
-    blueprint = bp ?? [];
+    return NextResponse.json({ ok: true, latestStack: latestStack ?? null, items: [...current, ...proposals] });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "current_regimen_failed";
+    console.error("[stacks/combined] failed", error);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
-
-  // 3) Merge + de-dupe (prefer 'current' over 'blueprint' when both exist)
-  const combined = [...(current ?? []), ...(blueprint ?? [])];
-  const seen = new Set<string>();
-  const deduped = combined.filter((it) => {
-    const key = `${it.supplement_id ?? ""}::${(it.name ?? "").trim().toLowerCase()}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-
-  return NextResponse.json({
-    ok: true,
-    latestStack: latestStack ?? null, // so Dashboard header can still show generated date
-    items: deduped,
-  });
 }

--- a/app/api/stacks/update/route.ts
+++ b/app/api/stacks/update/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { bucketsForItem, collapseBucketsToString } from "@/src/lib/timing";
 import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -16,24 +16,29 @@ export async function POST(req: Request) {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
 
-    const { id, timing, ...rest } = await req.json();
+    const { id, purpose, dose, timing, active } = await req.json();
     if (!id) return NextResponse.json({ ok: false, error: "missing_id" }, { status: 400 });
 
-    const patch: any = { ...rest };
-
-    if (typeof timing !== "undefined") {
-      const bucketArr = bucketsForItem(timing);
-      patch.timing = timing;
-      patch.timing_bucket = collapseBucketsToString(bucketArr);
+    const patch: Record<string, unknown> = Object.fromEntries(
+      Object.entries({ purpose, dose, timing, active })
+        .filter(([, value]) => typeof value !== "undefined")
+    );
+    if (!Object.keys(patch).length) {
+      return NextResponse.json({ ok: false, error: "no_supported_changes" }, { status: 400 });
     }
+    patch.instruction_source = "member_update";
+    patch.updated_at = new Date().toISOString();
 
-    const { error } = await supabase
-      .from("stacks_items")
+    const { data, error } = await getSupabaseAdmin()
+      .from("current_regimen_items")
       .update(patch)
       .eq("id", id)
-      .eq("user_id", user.id);
+      .eq("user_id", user.id)
+      .select("id")
+      .maybeSingle();
 
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+    if (!data) return NextResponse.json({ ok: false, error: "regimen_item_not_found" }, { status: 404 });
     return NextResponse.json({ ok: true });
   } catch (e: any) {
     return NextResponse.json({ ok: false, error: e?.message ?? "unknown_error" }, { status: 500 });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "qa:gating": "node src/_tests_/premiumGating.assert.mjs",
     "qa:stripe-pricing": "node src/_tests_/stripePricing.assert.mjs",
     "qa:blueprints": "node src/_tests_/interactiveBlueprints.assert.mjs",
+    "qa:current-regimen": "node src/_tests_/currentRegimen.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/currentRegimen.assert.mjs
+++ b/src/_tests_/currentRegimen.assert.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const migration = read("supabase/migrations/20260801172222_canonical_current_regimen.sql");
+assert.match(migration, /create table if not exists public\.current_regimen_items/i, "PR72 needs a canonical regimen table.");
+assert.match(migration, /item_kind in \('medication', 'supplement', 'hormone', 'endocrine_active_supplement'\)/i, "Every regimen item must retain an explicit type.");
+assert.match(migration, /instruction_source in \('intake', 'member_update', 'adopted_recommendation', 'manual_add'\)/i, "Every instruction needs provenance.");
+assert.match(migration, /using \(\(select auth\.uid\(\)\) = user_id\)/i, "Regimen rows must be owner-isolated with RLS.");
+assert.match(migration, /intake_events_user_regimen_date_key/i, "Adherence must use stable regimen IDs.");
+const writePrivileges = read("supabase/migrations/20260801182000_server_control_current_regimen_writes.sql");
+assert.match(writePrivileges, /revoke update[^;]*from authenticated/i, "Member regimen writes must remain server-controlled.");
+
+const combined = read("app/api/stacks/combined/route.ts");
+assert.match(combined, /getCurrentRegimen/, "Today must read the canonical current regimen.");
+assert.match(combined, /\.eq\("stack_id", latestStack\.id\)/, "Only the newest Blueprint may provide proposals.");
+assert.match(combined, /\.eq\("is_current", false\)/, "Blueprint recommendations must remain proposals until adopted.");
+assert.doesNotMatch(combined, /\.eq\("user_id", userId\)[\s\S]*\.eq\("is_current", true\)/, "Historical current flags must not drive Today.");
+
+const supplements = read("app/api/blueprints/[stackId]/supplements/route.ts");
+assert.match(supplements, /replaceCurrentSupplements/, "Blueprint updates must replace the current supplement regimen.");
+assert.match(supplements, /blueprintInputSnapshotHash\(updated, regimenToLedger\(currentRegimen\)\)/, "Saved regimen changes must make the current Blueprint stale.");
+
+const generator = read("src/lib/generateStack.ts");
+assert.match(generator, /ensureCurrentRegimen\(user_id, id, sub\)/, "Safety refreshes must use the newest canonical regimen.");
+assert.match(generator, /blueprintInputSnapshotHash\(sub, currentStackLedger\)/, "Generated Blueprint versions must hash the regimen they reviewed.");
+
+const activate = read("app/api/stack-items/activate/route.ts");
+assert.match(activate, /adoptStackRecommendation/, "A proposal must require explicit adoption.");
+assert.doesNotMatch(activate, /stacks_items[\s\S]*is_current:\s*true/, "Adoption must not rewrite historical Blueprint rows.");
+
+const updateRoute = read("app/api/stacks/update/route.ts");
+assert.match(updateRoute, /getSupabaseAdmin/, "Regimen updates must use the owner-bound server route.");
+
+const today = read("src/components/dashboard/TodaysPlan.tsx");
+assert.match(today, /regimen_item_id: itemId/, "Today must save adherence against canonical regimen items.");
+assert.match(today, /fetch\("\/api\/stacks\/combined"/, "Today must reload from the canonical combined endpoint after an update.");
+
+const model = read("src/lib/currentRegimenModel.ts");
+assert.match(model, /purpose: item\.purpose \?\? null/, "Regimen normalization must preserve purpose.");
+assert.match(model, /dose: item\.dose \?\? null/, "Regimen normalization must preserve dose.");
+assert.match(model, /timing: item\.timing \?\? null/, "Regimen normalization must preserve timing.");
+
+const intakeFixture = read("src/_tests_/normalizedCurrentStackLedger.assert.ts");
+assert.match(intakeFixture, /Magnesium Threonate/, "Fixtures must cover the supplement update that previously went stale.");
+assert.match(intakeFixture, /Monday and Thursday evenings/, "Fixtures must preserve free-text timing instructions.");
+assert.match(intakeFixture, /Testosterone cypionate/, "Fixtures must cover a distinct hormone type.");
+assert.match(intakeFixture, /Medication 2/, "Fixtures must cover repeated Tally medication groups.");
+
+console.log("Current regimen assertions passed.");

--- a/src/_tests_/intakePermissions.assert.mjs
+++ b/src/_tests_/intakePermissions.assert.mjs
@@ -42,7 +42,7 @@ assert.match(setRoute, /requirePaidApi/, "Intake writes must remain paid-gated."
 assert.match(setRoute, /getSupabaseAdmin/, "Intake writes must remain server-controlled.");
 assert.match(
   setRoute,
-  /\{\s*user_id:\s*userId,\s*item_id:\s*itemId,\s*intake_date:\s*today,\s*taken\s*\}/,
+  /\{\s*user_id:\s*userId,\s*regimen_item_id:\s*regimenItemId,\s*intake_date:\s*today,\s*taken\s*\}/,
   "Server writes must bind the authenticated user ID."
 );
 

--- a/src/_tests_/normalizedCurrentStackLedger.assert.ts
+++ b/src/_tests_/normalizedCurrentStackLedger.assert.ts
@@ -21,6 +21,14 @@ const fields = [
   { label: "Purpose", value: "Muscle and cognition" },
   { label: "Dosage", value: "5 g" },
   { label: "Frequency", value: "Daily PM" },
+  { label: "Supplement 3", value: "Magnesium Threonate" },
+  { label: "Purpose", value: "Sleep and cognition" },
+  { label: "Dosage", value: "2 capsules" },
+  { label: "Frequency", value: "Before bed" },
+  { label: "List Hormones", value: "Testosterone cypionate" },
+  { label: "Purpose", value: "Hormone replacement" },
+  { label: "Dosage", value: "80 mg" },
+  { label: "Frequency", value: "Monday and Thursday evenings" },
 ];
 
 const ledger = buildNormalizedCurrentStackLedger({ payload_json: { data: { fields } } });
@@ -34,6 +42,11 @@ assert(byName.get("Omega-3")?.dose === "1000 mg", "Expected Omega alias and exam
 assert(byName.get("Omega-3")?.timing === "Daily AM", "Expected example-labeled supplement timing to be retained");
 assert(byName.get("Creatine Monohydrate")?.dose === "5 g", "Expected repeated supplement dose to be retained");
 assert(byName.get("Creatine Monohydrate")?.timing === "Daily PM", "Expected repeated supplement timing to be retained");
+assert(byName.get("Magnesium Threonate")?.timing === "Before bed", "Expected free-text supplement timing to be retained");
+assert(byName.get("Testosterone cypionate")?.kind === "hormone", "Expected an intake hormone to retain its type");
+assert(byName.get("Testosterone cypionate")?.purpose === "Hormone replacement", "Expected hormone purpose to be retained");
+assert(byName.get("Testosterone cypionate")?.dose === "80 mg", "Expected hormone dose to be retained");
+assert(byName.get("Testosterone cypionate")?.timing === "Monday and Thursday evenings", "Expected free-text hormone timing to be retained");
 assert(ledger.filter((item) => item.name === "Omega-3").length === 1, "Expected Omega aliases to deduplicate");
 
 console.log("normalizedCurrentStackLedger assertions passed");

--- a/src/components/dashboard/TodaysPlan.tsx
+++ b/src/components/dashboard/TodaysPlan.tsx
@@ -31,6 +31,7 @@ type StackItem = {
   link_fullscript: string | null;
   refill_days_left: number | null;
   last_refilled_at: string | null;
+  source_type?: "regimen" | "blueprint_proposal";
 };
 
 type SearchItem = {
@@ -106,8 +107,8 @@ useEffect(() => {
       setItems(json.items || []);        // merged + de-duped items
 
       // today statuses (unchanged logic)
-      if (json.latestStack?.id) {
-        const res2 = await fetch(`/api/intake/status?stack_id=${json.latestStack.id}`, { cache: "no-store" });
+      if (json.latestStack?.id || (json.items ?? []).length > 0) {
+        const res2 = await fetch("/api/intake/status", { cache: "no-store" });
         const sjson = await res2.json();
         if (sjson?.ok) {
           setTakenMap(sjson.statuses || {});
@@ -145,7 +146,7 @@ useEffect(() => {
       const res = await fetch("/api/intake/set", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ item_id: itemId, taken: nextVal }),
+        body: JSON.stringify({ regimen_item_id: itemId, taken: nextVal }),
       });
       const json = await res.json();
       if (!json?.ok) throw new Error(json?.error || "set_failed");
@@ -177,7 +178,7 @@ useEffect(() => {
         fetch("/api/intake/set", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ item_id: id, taken }),
+          body: JSON.stringify({ regimen_item_id: id, taken }),
         })
       )
     );
@@ -202,28 +203,25 @@ useEffect(() => {
       setToast("Unable to add that recommendation");
       return;
     }
-    setItems((prev) => prev.map((item) => item.id === itemId ? { ...item, is_current: true } : item));
+    await reloadItems();
     setToast("Added to your active plan");
   }
 
   // Reload items (after adding new in modal)
   async function reloadItems() {
-    if (!stack?.id) return;
-    const { data: itemRows } = await supabase
-      .from("stacks_items")
-      .select(
-        "id, stack_id, name, brand, dose, timing, notes, link_amazon, link_fullscript, refill_days_left, last_refilled_at"
-      )
-      .eq("stack_id", stack.id)
-      .order("created_at", { ascending: true });
-    setItems((itemRows ?? []) as StackItem[]);
-
     try {
-      const res = await fetch(`/api/intake/status?stack_id=${stack.id}`, { cache: "no-store" });
-      const json = await res.json();
-      if (json?.ok) {
-        setTakenMap(json.statuses || {});
-        if (localKey) localStorage.setItem(localKey, JSON.stringify(json.statuses || {}));
+      const [itemsResponse, statusResponse] = await Promise.all([
+        fetch("/api/stacks/combined", { cache: "no-store" }),
+        fetch("/api/intake/status", { cache: "no-store" }),
+      ]);
+      const [itemsJson, statusJson] = await Promise.all([itemsResponse.json(), statusResponse.json()]);
+      if (itemsJson?.ok) {
+        setStack(itemsJson.latestStack ?? null);
+        setItems(itemsJson.items ?? []);
+      }
+      if (statusJson?.ok) {
+        setTakenMap(statusJson.statuses || {});
+        if (localKey) localStorage.setItem(localKey, JSON.stringify(statusJson.statuses || {}));
       }
     } catch {}
   }

--- a/src/lib/blueprintWorkspace.ts
+++ b/src/lib/blueprintWorkspace.ts
@@ -150,14 +150,20 @@ function stableValue(value: unknown): unknown {
   );
 }
 
-export function blueprintInputSnapshotHash(submission: SubmissionInput): string {
+export function blueprintInputSnapshotHash(
+  submission: SubmissionInput,
+  canonicalRegimen?: unknown
+): string {
   const engine = asObject(submission.engine_input_json);
-  const source = Object.keys(engine).length > 0
+  const submissionSource = Object.keys(engine).length > 0
     ? { engine_input_json: engine }
     : {
         answers: submission.answers ?? null,
         payload_json: submission.payload_json ?? null,
       };
+  const source = typeof canonicalRegimen === "undefined"
+    ? submissionSource
+    : { ...submissionSource, canonical_current_regimen: canonicalRegimen };
   return createHash("sha256")
     .update(JSON.stringify(stableValue(source)))
     .digest("hex");

--- a/src/lib/currentRegimen.ts
+++ b/src/lib/currentRegimen.ts
@@ -1,0 +1,147 @@
+import "server-only";
+
+import { getSubmissionWithChildren } from "@/lib/getSubmissionWithChildren";
+import { buildNormalizedCurrentStackLedger } from "@/lib/normalizedCurrentStackLedger";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import {
+  ledgerToRegimenRows,
+  normalizeRegimenName,
+  regimenKindForSupplement,
+  regimenToLedger,
+  type CurrentRegimenItem,
+  type CurrentRegimenSource,
+} from "@/lib/currentRegimenModel";
+
+const REGIMEN_COLUMNS = "id,user_id,source_submission_id,source_stack_item_id,item_kind,name,normalized_name,purpose,dose,timing,instruction_source,active,created_at,updated_at";
+
+export async function getCurrentRegimen(userId: string, includeInactive = false): Promise<CurrentRegimenItem[]> {
+  const admin = getSupabaseAdmin();
+  let query = admin.from("current_regimen_items").select(REGIMEN_COLUMNS).eq("user_id", userId);
+  if (!includeInactive) query = query.eq("active", true);
+  const { data, error } = await query.order("updated_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as unknown as CurrentRegimenItem[];
+}
+
+export async function ensureCurrentRegimen(userId: string, submissionId: string, submission?: unknown) {
+  const existing = await getCurrentRegimen(userId, true);
+  if (existing.length) return regimenToLedger(existing);
+
+  const source = submission ?? await getSubmissionWithChildren(submissionId);
+  const ledger = buildNormalizedCurrentStackLedger(source);
+  if (!ledger.length) return ledger;
+  const { data, error } = await getSupabaseAdmin()
+    .from("current_regimen_items")
+    .upsert(ledgerToRegimenRows(ledger, userId, submissionId), { onConflict: "user_id,item_kind,normalized_name" })
+    .select(REGIMEN_COLUMNS);
+  if (error) throw error;
+  return regimenToLedger((data ?? []) as unknown as CurrentRegimenItem[]);
+}
+
+async function ensureLatestUserRegimen(userId: string) {
+  const existing = await getCurrentRegimen(userId, true);
+  if (existing.length) return;
+  const { data, error } = await getSupabaseAdmin().from("submissions")
+    .select("id")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  if (data?.id) await ensureCurrentRegimen(userId, data.id);
+}
+
+type SupplementInput = {
+  name: string;
+  dose?: string | null;
+  timing?: string | null;
+  active?: boolean;
+};
+
+export async function replaceCurrentSupplements(
+  userId: string,
+  submissionId: string,
+  supplements: SupplementInput[]
+) {
+  const admin = getSupabaseAdmin();
+  await ensureCurrentRegimen(userId, submissionId);
+  const now = new Date().toISOString();
+  const { error: deactivateError } = await admin
+    .from("current_regimen_items")
+    .update({ active: false, updated_at: now })
+    .eq("user_id", userId)
+    .in("item_kind", ["supplement", "endocrine_active_supplement"]);
+  if (deactivateError) throw deactivateError;
+
+  const active = supplements.filter((item) => item.active !== false);
+  if (active.length) {
+    const rows = active.map((item) => ({
+      user_id: userId,
+      source_submission_id: submissionId,
+      source_stack_item_id: null,
+      item_kind: regimenKindForSupplement(item.name),
+      name: item.name,
+      normalized_name: normalizeRegimenName(item.name),
+      purpose: null,
+      dose: item.dose ?? null,
+      timing: item.timing ?? null,
+      instruction_source: "member_update" satisfies CurrentRegimenSource,
+      active: true,
+      updated_at: now,
+    }));
+    const { error } = await admin.from("current_regimen_items")
+      .upsert(rows, { onConflict: "user_id,item_kind,normalized_name" });
+    if (error) throw error;
+  }
+  return getCurrentRegimen(userId);
+}
+
+export async function adoptStackRecommendation(userId: string, stackItemId: string) {
+  const admin = getSupabaseAdmin();
+  await ensureLatestUserRegimen(userId);
+  const { data: item, error } = await admin.from("stacks_items")
+    .select("id,user_id,name,dose,timing,timing_text,rationale")
+    .eq("id", stackItemId).eq("user_id", userId).maybeSingle();
+  if (error) throw error;
+  if (!item) return null;
+  const row = {
+    user_id: userId,
+    source_submission_id: null,
+    source_stack_item_id: item.id,
+    item_kind: regimenKindForSupplement(item.name),
+    name: item.name,
+    normalized_name: normalizeRegimenName(item.name),
+    purpose: item.rationale ?? null,
+    dose: item.dose ?? null,
+    timing: item.timing_text ?? item.timing ?? null,
+    instruction_source: "adopted_recommendation" satisfies CurrentRegimenSource,
+    active: true,
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error: upsertError } = await admin.from("current_regimen_items")
+    .upsert(row, { onConflict: "user_id,item_kind,normalized_name" }).select(REGIMEN_COLUMNS).maybeSingle();
+  if (upsertError) throw upsertError;
+  return data as unknown as CurrentRegimenItem;
+}
+
+export async function upsertManualRegimenItem(userId: string, input: SupplementInput) {
+  await ensureLatestUserRegimen(userId);
+  const row = {
+    user_id: userId,
+    source_submission_id: null,
+    source_stack_item_id: null,
+    item_kind: regimenKindForSupplement(input.name),
+    name: input.name,
+    normalized_name: normalizeRegimenName(input.name),
+    purpose: null,
+    dose: input.dose ?? null,
+    timing: input.timing ?? null,
+    instruction_source: "manual_add" satisfies CurrentRegimenSource,
+    active: input.active !== false,
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error } = await getSupabaseAdmin().from("current_regimen_items")
+    .upsert(row, { onConflict: "user_id,item_kind,normalized_name" }).select(REGIMEN_COLUMNS).maybeSingle();
+  if (error) throw error;
+  return data as unknown as CurrentRegimenItem;
+}

--- a/src/lib/currentRegimenModel.ts
+++ b/src/lib/currentRegimenModel.ts
@@ -1,0 +1,69 @@
+import type { NormalizedCurrentStackLedgerItem } from "@/lib/normalizedCurrentStackLedger";
+import { isEndocrineActiveSupplementName } from "@/lib/supplementEligibility";
+
+export type CurrentRegimenKind = NormalizedCurrentStackLedgerItem["kind"];
+export type CurrentRegimenSource = "intake" | "member_update" | "adopted_recommendation" | "manual_add";
+
+export type CurrentRegimenItem = {
+  id: string;
+  user_id: string;
+  source_submission_id: string | null;
+  source_stack_item_id: string | null;
+  item_kind: CurrentRegimenKind;
+  name: string;
+  normalized_name: string;
+  purpose: string | null;
+  dose: string | null;
+  timing: string | null;
+  instruction_source: CurrentRegimenSource;
+  active: boolean;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export function normalizeRegimenName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+export function regimenKindForSupplement(name: string): CurrentRegimenKind {
+  return isEndocrineActiveSupplementName(name) ? "endocrine_active_supplement" : "supplement";
+}
+
+export function ledgerToRegimenRows(
+  ledger: NormalizedCurrentStackLedgerItem[],
+  userId: string,
+  submissionId: string,
+  source: CurrentRegimenSource = "intake"
+) {
+  return ledger.map((item) => ({
+    user_id: userId,
+    source_submission_id: submissionId,
+    source_stack_item_id: null,
+    item_kind: item.kind,
+    name: item.name,
+    normalized_name: normalizeRegimenName(item.name),
+    purpose: item.purpose ?? null,
+    dose: item.dose ?? null,
+    timing: item.timing ?? null,
+    instruction_source: source,
+    active: true,
+    updated_at: new Date().toISOString(),
+  }));
+}
+
+export function regimenToLedger(items: CurrentRegimenItem[]): NormalizedCurrentStackLedgerItem[] {
+  return items.filter((item) => item.active)
+    .sort((left, right) =>
+      left.item_kind.localeCompare(right.item_kind) ||
+      left.normalized_name.localeCompare(right.normalized_name)
+    )
+    .map((item) => ({
+    name: item.name,
+    kind: item.item_kind,
+    ...(item.purpose ? { purpose: item.purpose } : {}),
+    ...(item.dose ? { dose: item.dose } : {}),
+    ...(item.timing ? { timing: item.timing } : {}),
+    source_paths: [`current_regimen_items.${item.id}`, `instruction_source.${item.instruction_source}`],
+    raw_labels: [item.instruction_source],
+  }));
+}

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -35,6 +35,7 @@ import {
   RECOMMENDABLE_SUPPLEMENT_CANDIDATES,
 } from "@/lib/supplementEligibility";
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
+import { ensureCurrentRegimen } from "@/lib/currentRegimen";
 
 // Curated evidence index (JSON)
 // If this path differs in your repo, update the import below.
@@ -1661,7 +1662,6 @@ export async function generateStackForSubmission(arg: string | { submissionId: s
   const inferredPremium = Boolean((sub as any)?.is_premium) || Boolean((sub as any)?.user?.is_premium) || ((sub as any)?.plan === "premium");
   const mode: GenerateMode = modeFromOpts ?? (inferredPremium ? "premium" : "free");
   const cap = requestedCap; // only cap when provided
-  const inputSnapshotHash = options?.inputSnapshotHash ?? blueprintInputSnapshotHash(sub);
   const generationReason = options?.generationReason ?? "initial";
   const supersedesStackId = options?.supersedesStackId ?? null;
 
@@ -1788,9 +1788,13 @@ const conditionsMerged = mergeReadableValues(normalizationStats,
 );
 const conditionsRaw = conditionsMerged.values;
 
-const currentStackLedger = buildNormalizedCurrentStackLedger(sub).filter((item) =>
+const resolvedCurrentStackLedger = user_id
+  ? await ensureCurrentRegimen(user_id, id, sub)
+  : buildNormalizedCurrentStackLedger(sub);
+const currentStackLedger = resolvedCurrentStackLedger.filter((item) =>
   !isPreferenceFieldOrValue(item.name) && !item.raw_labels.some(isPreferenceFieldOrValue)
 );
+const inputSnapshotHash = options?.inputSnapshotHash ?? blueprintInputSnapshotHash(sub, currentStackLedger);
 const berberineRequiresReview = /\b(?:metformin|zepbound|tirzepatide|mounjaro|diabet(?:es|ic)?|blood sugar|glucose|a1c)\b/i.test(
   JSON.stringify({ currentStackLedger, conditions: conditionsRaw })
 );

--- a/supabase/migrations/20260801172222_canonical_current_regimen.sql
+++ b/supabase/migrations/20260801172222_canonical_current_regimen.sql
@@ -1,0 +1,65 @@
+-- PR72: separate the member's current regimen from immutable Blueprint history.
+create table if not exists public.current_regimen_items (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  source_submission_id uuid references public.submissions(id) on delete set null,
+  source_stack_item_id uuid references public.stacks_items(id) on delete set null,
+  item_kind text not null check (item_kind in ('medication', 'supplement', 'hormone', 'endocrine_active_supplement')),
+  name text not null,
+  normalized_name text not null,
+  purpose text,
+  dose text,
+  timing text,
+  instruction_source text not null check (instruction_source in ('intake', 'member_update', 'adopted_recommendation', 'manual_add')),
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists current_regimen_items_user_kind_name_key
+  on public.current_regimen_items (user_id, item_kind, normalized_name);
+create index if not exists current_regimen_items_user_active_idx
+  on public.current_regimen_items (user_id, active, updated_at desc);
+create index if not exists current_regimen_items_source_submission_idx
+  on public.current_regimen_items (source_submission_id);
+create index if not exists current_regimen_items_source_stack_item_idx
+  on public.current_regimen_items (source_stack_item_id);
+
+alter table public.current_regimen_items enable row level security;
+
+drop policy if exists "current_regimen_items: select own" on public.current_regimen_items;
+create policy "current_regimen_items: select own"
+  on public.current_regimen_items for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "current_regimen_items: insert own" on public.current_regimen_items;
+create policy "current_regimen_items: insert own"
+  on public.current_regimen_items for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "current_regimen_items: update own" on public.current_regimen_items;
+create policy "current_regimen_items: update own"
+  on public.current_regimen_items for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "current_regimen_items: delete own" on public.current_regimen_items;
+create policy "current_regimen_items: delete own"
+  on public.current_regimen_items for delete to authenticated
+  using ((select auth.uid()) = user_id);
+
+grant select, update on public.current_regimen_items to authenticated;
+grant select, insert, update, delete on public.current_regimen_items to service_role;
+
+-- Daily adherence follows stable regimen IDs instead of report-version row IDs.
+alter table public.intake_events alter column item_id drop not null;
+alter table public.intake_events
+  add column if not exists regimen_item_id uuid references public.current_regimen_items(id) on delete cascade;
+create index if not exists intake_events_regimen_item_idx
+  on public.intake_events (regimen_item_id);
+create unique index if not exists intake_events_user_regimen_date_key
+  on public.intake_events (user_id, regimen_item_id, intake_date);
+
+-- Rollback notes:
+-- Drop intake_events_user_regimen_date_key and regimen_item_id, restore item_id NOT NULL
+-- after confirming every new event has an item_id, then drop current_regimen_items.

--- a/supabase/migrations/20260801180500_tighten_current_regimen_privileges.sql
+++ b/supabase/migrations/20260801180500_tighten_current_regimen_privileges.sql
@@ -1,0 +1,6 @@
+-- PR72: override broad project defaults with the minimum direct client access.
+revoke all on table public.current_regimen_items from public, anon, authenticated;
+grant select, update on table public.current_regimen_items to authenticated;
+grant select, insert, update, delete on table public.current_regimen_items to service_role;
+
+-- All inserts and deletes remain server-controlled through paid, owner-bound routes.

--- a/supabase/migrations/20260801182000_server_control_current_regimen_writes.sql
+++ b/supabase/migrations/20260801182000_server_control_current_regimen_writes.sql
@@ -1,0 +1,3 @@
+-- PR72: regimen mutations are validated by paid, owner-bound server routes.
+revoke update on table public.current_regimen_items from authenticated;
+grant select on table public.current_regimen_items to authenticated;


### PR DESCRIPTION
## What changed

- Added a user-owned canonical regimen for medications, supplements, hormones, and hormone-active supplements.
- Preserved item type, name, purpose, dose, timing, active state, and instruction source.
- Updated Blueprint editing, refresh hashing, Today, recommendation adoption, manual additions, and daily adherence to use the canonical regimen.
- Kept generated Blueprint rows immutable and treated new recommendations as proposals until the member explicitly adopts them.
- Added stable regimen IDs to daily intake events so Blueprint regeneration no longer breaks adherence tracking.
- Added owner-scoped RLS, server-controlled writes, supporting indexes, and regression fixtures.

## Why

Blueprint edits and Today were reading different sources. Today merged every historical `stacks_items` row marked current, while Blueprint edits only changed the submission overlay. That allowed older report rows to override newer member input and caused updates such as Magnesium Threonate to disappear from current surfaces.

## Member impact

The newest saved regimen now drives Blueprint refreshes and Today. Historical reports remain available as history, while recommendations marked New - consider or Clinician review stay proposals until adopted.

## Database

The three backward-compatible PR72 migrations have already been applied and verified in Supabase. The new table has RLS enabled, anonymous access disabled, and direct member writes disabled. Database advisors report no PR72 security findings.

## Validation

- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:intake-permissions`
- `npm.cmd run qa:blueprints`
- `npm.cmd run qa:gating`
- `npm.cmd run typecheck`
- `git diff --check`
- Next production build compiled and type-checked. Static generation could not complete in this checkout because local OpenAI and public Supabase environment values are empty.