### PR TITLE
PR73: Move regimen management into a dedicated Routine page

### DIFF
--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  CirclePlus,
+  Clock3,
+  ExternalLink,
+  HeartPulse,
+  Loader2,
+  Pencil,
+  Pill,
+  RotateCcw,
+  Search,
+  ShieldAlert,
+  Sparkles,
+  TestTube2,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  groupRoutineItems,
+  isClinicianReviewProposal,
+  ROUTINE_SECTION_LABELS,
+  ROUTINE_SECTION_ORDER,
+  routineScheduleLabel,
+  routineSourceLabel,
+  type RoutineItem,
+  type RoutineItemKind,
+} from "@/lib/routine";
+
+type LatestStack = { id: string; submission_id: string | null; created_at: string } | null;
+type ToastState = { message: string; undo?: () => Promise<void> } | null;
+type SearchItem = {
+  vendor: "fullscript" | "fallback";
+  sku: string | null;
+  name: string;
+  brand: string | null;
+  dose: string | null;
+  link_fullscript: string | null;
+  link_amazon: string | null;
+  price: number | null;
+};
+
+const SECTION_DESCRIPTIONS: Record<RoutineItemKind, string> = {
+  medication: "Your reported prescriptions. Follow your prescription label and clinician instructions.",
+  hormone: "Your reported hormone therapies. Dose changes belong with your prescriber.",
+  supplement: "Your current supplements and the schedule you recorded.",
+  endocrine_active_supplement: "Supplements that may affect hormone pathways and deserve extra care.",
+};
+
+export default function RoutineClient({
+  initialItems,
+  latestStack,
+}: {
+  initialItems: RoutineItem[];
+  latestStack: LatestStack;
+}) {
+  const [items, setItems] = useState(initialItems);
+  const [editing, setEditing] = useState<RoutineItem | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>(null);
+  const grouped = useMemo(() => groupRoutineItems(items), [items]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = window.setTimeout(() => setToast(null), 7000);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
+
+  async function refreshRoutine() {
+    const response = await fetch("/api/stacks/combined", { cache: "no-store" });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body?.ok) throw new Error(body?.error ?? "routine_unavailable");
+    setItems(body.items ?? []);
+  }
+
+  async function updateItem(id: string, patch: Record<string, unknown>) {
+    const response = await fetch("/api/stacks/update", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, ...patch }),
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body?.ok) throw new Error(body?.error ?? "routine_update_failed");
+  }
+
+  async function saveEdit(item: RoutineItem, patch: { dose?: string | null; timing: string | null }) {
+    setBusyId(item.id);
+    const previous = { dose: item.dose, timing: item.timing };
+    try {
+      await updateItem(item.id, patch);
+      await refreshRoutine();
+      setEditing(null);
+      setToast({
+        message: `${item.name} was updated.`,
+        undo: async () => {
+          await updateItem(item.id, previous);
+          await refreshRoutine();
+          setToast({ message: `Changes to ${item.name} were undone.` });
+        },
+      });
+    } catch {
+      setToast({ message: "We could not save that change. Your previous routine is unchanged." });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function stopTracking(item: RoutineItem) {
+    setBusyId(item.id);
+    try {
+      await updateItem(item.id, { active: false });
+      setItems((current) => current.filter((candidate) => candidate.id !== item.id));
+      setToast({
+        message: `${item.name} is no longer in your current routine.`,
+        undo: async () => {
+          await updateItem(item.id, { active: true });
+          await refreshRoutine();
+          setToast({ message: `${item.name} is back in your current routine.` });
+        },
+      });
+    } catch {
+      setToast({ message: "We could not change that item. Your current routine is unchanged." });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function adoptProposal(item: RoutineItem) {
+    if (isClinicianReviewProposal(item)) {
+      const confirmed = window.confirm(
+        "This item was flagged for clinician or pharmacist review. Only add it if you have already decided it belongs in your routine."
+      );
+      if (!confirmed) return;
+    }
+    setBusyId(item.id);
+    try {
+      const response = await fetch("/api/stack-items/activate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ item_id: item.id }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok || !body?.item?.id) throw new Error("adoption_failed");
+      await refreshRoutine();
+      const adoptedId = body.item.id as string;
+      setToast({
+        message: `${item.name} was added to your current routine.`,
+        undo: async () => {
+          await updateItem(adoptedId, { active: false });
+          await refreshRoutine();
+          setToast({ message: `${item.name} was returned to ideas to consider.` });
+        },
+      });
+    } catch {
+      setToast({ message: "We could not add that idea. Your current routine is unchanged." });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-[#041B2D]">Your current routine</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-600">
+            {grouped.current.length} current item{grouped.current.length === 1 ? "" : "s"}
+            {latestStack?.created_at ? `, reviewed against your latest Blueprint from ${formatDate(latestStack.created_at)}` : ""}.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white transition hover:bg-[#06695F] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
+        >
+          <CirclePlus className="mr-2 h-5 w-5" aria-hidden="true" />
+          Add a supplement
+        </button>
+      </div>
+
+      <div className="space-y-5">
+        {ROUTINE_SECTION_ORDER.map((kind) => (
+          <RoutineSection
+            key={kind}
+            kind={kind}
+            items={grouped.byKind[kind]}
+            busyId={busyId}
+            onEdit={setEditing}
+            onStop={stopTracking}
+          />
+        ))}
+      </div>
+
+      <IdeasSection items={grouped.proposals} busyId={busyId} onAdopt={adoptProposal} />
+
+      {editing ? (
+        <EditRoutineDialog
+          item={editing}
+          saving={busyId === editing.id}
+          onClose={() => setEditing(null)}
+          onSave={saveEdit}
+        />
+      ) : null}
+
+      {showAdd ? (
+        <AddSupplementDialog
+          onClose={() => setShowAdd(false)}
+          onAdded={async (itemName, addedId) => {
+            await refreshRoutine();
+            setShowAdd(false);
+            setToast({
+              message: `${itemName} was added to your current routine.`,
+              undo: async () => {
+                await updateItem(addedId, { active: false });
+                await refreshRoutine();
+                setToast({ message: `${itemName} was removed from your current routine.` });
+              },
+            });
+          }}
+        />
+      ) : null}
+
+      {toast ? (
+        <div className="fixed inset-x-0 bottom-5 z-[70] flex justify-center px-4" aria-live="polite">
+          <div className="flex w-full max-w-xl items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-[#041B2D] shadow-xl">
+            <span>{toast.message}</span>
+            {toast.undo ? (
+              <button
+                type="button"
+                onClick={() => void toast.undo?.()}
+                className="inline-flex min-h-11 shrink-0 items-center rounded-xl px-3 py-2 text-[#087F72] hover:bg-[#EAFBF8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
+              >
+                <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" /> Undo
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function RoutineSection({
+  kind,
+  items,
+  busyId,
+  onEdit,
+  onStop,
+}: {
+  kind: RoutineItemKind;
+  items: RoutineItem[];
+  busyId: string | null;
+  onEdit: (item: RoutineItem) => void;
+  onStop: (item: RoutineItem) => void;
+}) {
+  const Icon = kind === "medication" ? Pill : kind === "hormone" ? TestTube2 : kind === "endocrine_active_supplement" ? HeartPulse : Sparkles;
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6" aria-labelledby={`routine-${kind}`}>
+      <div className="flex items-start gap-3">
+        <span className="rounded-xl bg-[#EAFBF8] p-2.5 text-[#087F72]"><Icon className="h-6 w-6" aria-hidden="true" /></span>
+        <div>
+          <h2 id={`routine-${kind}`} className="text-xl font-bold text-[#041B2D]">{ROUTINE_SECTION_LABELS[kind]}</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-600">{SECTION_DESCRIPTIONS[kind]}</p>
+        </div>
+      </div>
+      {items.length ? (
+        <ul className="mt-5 grid gap-3 lg:grid-cols-2">
+          {items.map((item) => (
+            <RoutineCard key={item.id} item={item} busy={busyId === item.id} onEdit={onEdit} onStop={onStop} />
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-5 rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+          No current {ROUTINE_SECTION_LABELS[kind].toLowerCase()} recorded.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function RoutineCard({
+  item,
+  busy,
+  onEdit,
+  onStop,
+}: {
+  item: RoutineItem;
+  busy: boolean;
+  onEdit: (item: RoutineItem) => void;
+  onStop: (item: RoutineItem) => void;
+}) {
+  const protectedDose = item.item_kind === "medication" || item.item_kind === "hormone";
+  return (
+    <li className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-lg font-bold text-[#041B2D]">{item.name}</h3>
+          <p className="mt-1 text-sm text-slate-600">{routineSourceLabel(item.instruction_source)}</p>
+        </div>
+        {busy ? <Loader2 className="h-5 w-5 animate-spin text-[#087F72]" aria-label="Saving" /> : null}
+      </div>
+      <dl className="mt-4 space-y-3 text-sm">
+        <div>
+          <dt className="font-bold text-[#041B2D]">{protectedDose ? "Reported dose" : "Recorded amount"}</dt>
+          <dd className="mt-0.5 text-slate-700">{item.dose?.trim() || "Dose not recorded"}</dd>
+        </div>
+        <div>
+          <dt className="flex items-center font-bold text-[#041B2D]"><Clock3 className="mr-1.5 h-4 w-4" aria-hidden="true" /> Schedule</dt>
+          <dd className={`mt-0.5 ${routineScheduleLabel(item) === "Schedule not recorded" ? "font-semibold text-amber-700" : "text-slate-700"}`}>
+            {routineScheduleLabel(item)}
+          </dd>
+        </div>
+        {item.purpose ? <div><dt className="font-bold text-[#041B2D]">Purpose you reported</dt><dd className="mt-0.5 text-slate-700">{item.purpose}</dd></div> : null}
+      </dl>
+      {protectedDose ? (
+        <p className="mt-4 rounded-xl bg-white p-3 text-xs leading-5 text-slate-600">
+          LVE360 does not change this dose. Follow your prescription label and clinician instructions.
+        </p>
+      ) : null}
+      <div className="mt-4 grid gap-2 sm:grid-cols-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onEdit(item)}
+          className="inline-flex min-h-12 items-center justify-center rounded-xl border border-[#9DCFC3] bg-white px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
+        >
+          <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> {protectedDose ? "Edit schedule" : "Edit details"}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void onStop(item)}
+          className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-3 font-bold text-slate-700 hover:bg-slate-100 disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
+        >
+          <X className="mr-2 h-4 w-4" aria-hidden="true" /> Stop tracking
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function IdeasSection({ items, busyId, onAdopt }: { items: RoutineItem[]; busyId: string | null; onAdopt: (item: RoutineItem) => void }) {
+  return (
+    <section className="rounded-2xl border border-amber-200 bg-amber-50 p-5 shadow-sm sm:p-6" aria-labelledby="routine-ideas">
+      <div className="flex items-start gap-3">
+        <span className="rounded-xl bg-white p-2.5 text-amber-700"><ShieldAlert className="h-6 w-6" aria-hidden="true" /></span>
+        <div>
+          <h2 id="routine-ideas" className="text-xl font-bold text-[#041B2D]">Ideas to consider</h2>
+          <p className="mt-1 text-sm leading-6 text-amber-900">These Blueprint ideas are not current. They only move into your routine after you explicitly add them.</p>
+        </div>
+      </div>
+      {items.length ? (
+        <ul className="mt-5 grid gap-3 lg:grid-cols-2">
+          {items.map((item) => {
+            const clinicianReview = isClinicianReviewProposal(item);
+            const link = item.link_fullscript || item.link_amazon;
+            return (
+              <li key={item.id} className="rounded-2xl border border-amber-200 bg-white p-4">
+                <h3 className="text-lg font-bold text-[#041B2D]">{item.name}</h3>
+                <p className="mt-2 text-sm text-slate-700">{item.purpose || item.notes || "Review the evidence and safety context in your Blueprint."}</p>
+                {clinicianReview ? <p className="mt-3 flex items-start rounded-xl bg-amber-100 p-3 text-sm font-semibold text-amber-900"><AlertTriangle className="mr-2 mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> Clinician or pharmacist review is recommended before adding this.</p> : null}
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                  <button
+                    type="button"
+                    disabled={busyId === item.id}
+                    onClick={() => void onAdopt(item)}
+                    className="inline-flex min-h-12 flex-1 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white hover:bg-[#06695F] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
+                  >
+                    {busyId === item.id ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />}
+                    {clinicianReview ? "Add after review" : "Add to current routine"}
+                  </button>
+                  {link ? <a href={link} target="_blank" rel="noopener noreferrer nofollow sponsored" className="inline-flex min-h-12 items-center justify-center rounded-xl border border-amber-300 px-4 py-3 font-bold text-amber-900 hover:bg-amber-100"><ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" /> Product info</a> : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : <p className="mt-5 rounded-xl bg-white p-4 text-sm text-slate-600">No new Blueprint ideas are waiting for review.</p>}
+    </section>
+  );
+}
+
+function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineItem; saving: boolean; onClose: () => void; onSave: (item: RoutineItem, patch: { dose?: string | null; timing: string | null }) => void }) {
+  const protectedDose = item.item_kind === "medication" || item.item_kind === "hormone";
+  const [dose, setDose] = useState(item.dose ?? "");
+  const [timing, setTiming] = useState(item.timing ?? "");
+  return (
+    <DialogShell title={protectedDose ? `Record ${item.name} schedule` : `Update ${item.name}`} onClose={onClose}>
+      <p className="text-sm leading-6 text-slate-600">Record what you currently do. This does not create a medical instruction or replace a product label.</p>
+      {!protectedDose ? <label className="mt-5 block text-sm font-bold text-[#041B2D]">Amount you take<input autoFocus value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, 2 capsules" /></label> : null}
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">When you take it<input autoFocus={protectedDose} value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, morning with breakfast" /></label>
+      {protectedDose ? <p className="mt-3 text-sm text-slate-600">Reported dose: <strong>{item.dose || "Dose not recorded"}</strong>. Dose cannot be changed here.</p> : null}
+      <div className="mt-6 grid gap-2 sm:grid-cols-2">
+        <button type="button" onClick={onClose} disabled={saving} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
+        <button type="button" disabled={saving} onClick={() => onSave(item, { ...(protectedDose ? {} : { dose: dose.trim() || null }), timing: timing.trim() || null })} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
+          {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Save record
+        </button>
+      </div>
+    </DialogShell>
+  );
+}
+
+function AddSupplementDialog({ onClose, onAdded }: { onClose: () => void; onAdded: (name: string, id: string) => Promise<void> }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchItem[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function search() {
+    setBusy(true); setError(null);
+    try {
+      const response = await fetch(`/api/fullscript/search?q=${encodeURIComponent(query)}`, { cache: "no-store" });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error("search_failed");
+      setResults(body.items ?? []);
+    } catch { setError("We could not search the catalog right now."); }
+    finally { setBusy(false); }
+  }
+  async function add(item: SearchItem, timing: "AM" | "PM" | "AM/PM") {
+    setBusy(true); setError(null);
+    try {
+      const response = await fetch("/api/fullscript/add", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name: item.name, dose: item.dose, timing }) });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok || !body?.item?.id) throw new Error("add_failed");
+      await onAdded(item.name, body.item.id);
+    } catch { setError("We could not add that supplement. Your routine is unchanged."); }
+    finally { setBusy(false); }
+  }
+  return (
+    <DialogShell title="Add a supplement" onClose={onClose} wide>
+      <p className="text-sm leading-6 text-slate-600">Search for a product, then record when you take it. Adding a product records your choice and is not an LVE360 recommendation.</p>
+      <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+        <label className="sr-only" htmlFor="routine-product-search">Search supplements</label>
+        <input autoFocus id="routine-product-search" value={query} onChange={(event) => setQuery(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void search(); }} placeholder="Search supplements" className="min-h-12 flex-1 rounded-xl border border-slate-300 px-4 py-3 outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" />
+        <button type="button" disabled={busy || !query.trim()} onClick={() => void search()} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white disabled:opacity-60"><Search className="mr-2 h-5 w-5" aria-hidden="true" /> Search</button>
+      </div>
+      {error ? <p className="mt-4 rounded-xl bg-amber-50 p-3 text-sm font-semibold text-amber-900">{error}</p> : null}
+      <div className="mt-5 max-h-[50vh] space-y-3 overflow-y-auto pr-1">
+        {results.map((item, index) => <div key={item.sku ?? `${item.name}-${index}`} className="rounded-2xl border border-slate-200 p-4"><h3 className="font-bold text-[#041B2D]">{item.name}</h3><p className="mt-1 text-sm text-slate-600">{item.brand || "Brand not listed"}{item.dose ? `, ${item.dose}` : ""}</p><div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">{(["AM", "PM", "AM/PM"] as const).map((timing) => <button key={timing} type="button" disabled={busy} onClick={() => void add(item, timing)} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-[#9DCFC3] px-3 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">Add {timing}<ChevronRight className="ml-1 h-4 w-4" aria-hidden="true" /></button>)}</div></div>)}
+        {!results.length && !busy ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">Search by supplement or ingredient name.</p> : null}
+      </div>
+    </DialogShell>
+  );
+}
+
+function DialogShell({ title, onClose, children, wide = false }: { title: string; onClose: () => void; children: React.ReactNode; wide?: boolean }) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return <div className="fixed inset-0 z-[65] flex items-center justify-center bg-[#041B2D]/55 p-4" role="dialog" aria-modal="true" aria-label={title}><div className={`max-h-[92vh] w-full overflow-y-auto rounded-3xl bg-white p-5 shadow-2xl sm:p-6 ${wide ? "max-w-3xl" : "max-w-xl"}`}><div className="flex items-center justify-between gap-4"><h2 className="text-2xl font-bold text-[#041B2D]">{title}</h2><button type="button" onClick={onClose} className="inline-flex min-h-12 min-w-12 items-center justify-center rounded-xl text-slate-600 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]" aria-label="Close dialog"><X className="h-6 w-6" aria-hidden="true" /></button></div><div className="mt-4">{children}</div></div></div>;
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" }).format(new Date(value));
+}

--- a/app/(app)/routine/page.tsx
+++ b/app/(app)/routine/page.tsx
@@ -1,0 +1,26 @@
+import { requireTier } from "@/app/_auth/requireTier";
+import { getRoutineData } from "@/lib/routineData";
+
+import RoutineClient from "./RoutineClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function RoutinePage() {
+  const { user } = await requireTier(["premium", "trial"], { next: "/routine" });
+  const data = await getRoutineData(user.id);
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-6">
+      <header className="rounded-3xl bg-[#041B2D] px-5 py-7 text-white shadow-sm sm:px-8 sm:py-9">
+        <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#8DE5D5]">Routine</p>
+        <h1 className="mt-2 text-3xl font-extrabold tracking-tight sm:text-4xl">Organize what you take and when</h1>
+        <p className="mt-3 max-w-3xl text-base leading-7 text-slate-200">
+          Keep your reported prescriptions, hormones, supplements, and timing in one place. Routine records your choices. It does not replace your prescriber, pharmacist, or product label.
+        </p>
+      </header>
+
+      <RoutineClient initialItems={data.items} latestStack={data.latestStack} />
+    </div>
+  );
+}

--- a/app/(app)/today/TodayClient.tsx
+++ b/app/(app)/today/TodayClient.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import { ChevronDown } from "lucide-react";
-
 import DailyLog from "@/components/dashboard/DailyLog";
 import TodayExperience from "@/components/dashboard/TodayExperience";
 import TodaysPlan from "@/components/dashboard/TodaysPlan";
@@ -33,34 +31,9 @@ export default function TodayClient({
           <DailyLog />
         </section>
 
-        <Disclosure title="Your supplement routine" description="Track your current stack, review timing, and manage refills when you need it.">
-          <TodaysPlan />
-        </Disclosure>
+        <TodaysPlan />
 
       </div>
     </div>
-  );
-}
-
-function Disclosure({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <details className="group rounded-2xl border border-slate-200 bg-white shadow-sm">
-      <summary className="flex cursor-pointer list-none items-center gap-4 p-5 marker:content-none sm:p-6">
-        <div className="min-w-0 flex-1">
-          <h2 className="text-xl font-bold text-[#041B2D]">{title}</h2>
-          <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
-        </div>
-        <ChevronDown className="h-5 w-5 shrink-0 text-[#087F72] transition-transform group-open:rotate-180" />
-      </summary>
-      <div className="border-t border-slate-200 p-4 sm:p-6">{children}</div>
-    </details>
   );
 }

--- a/app/api/stacks/combined/route.ts
+++ b/app/api/stacks/combined/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
 
-import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
-import { normalizeRegimenName } from "@/lib/currentRegimenModel";
+import { getRoutineData } from "@/lib/routineData";
 import { requirePaidApi } from "@/lib/serverEntitlements";
-import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -13,57 +11,8 @@ export async function GET() {
   if (!entitlement.ok) return entitlement.response;
 
   try {
-    const userId = entitlement.user.id;
-    const admin = getSupabaseAdmin();
-    const { data: latestStack, error: stackError } = await admin
-      .from("stacks")
-      .select("id,submission_id,created_at")
-      .eq("user_id", userId)
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    if (stackError) throw stackError;
-
-    if (latestStack?.submission_id) {
-      await ensureCurrentRegimen(userId, latestStack.submission_id);
-    }
-    const regimen = await getCurrentRegimen(userId);
-    const currentNames = new Set(regimen.map((item) => normalizeRegimenName(item.name)));
-    const current = regimen.map((item) => ({
-      id: item.id,
-      stack_id: latestStack?.id ?? null,
-      user_id: item.user_id,
-      name: item.name,
-      brand: null,
-      dose: item.dose,
-      timing: item.timing,
-      timing_text: item.timing,
-      timing_bucket: null,
-      notes: `Current ${item.item_kind.replaceAll("_", " ")}. Instruction source: ${item.instruction_source}.`,
-      is_current: true,
-      item_kind: item.item_kind,
-      source_type: "regimen",
-      link_amazon: null,
-      link_fullscript: null,
-      refill_days_left: null,
-      last_refilled_at: null,
-      supplement_id: null,
-      created_at: item.created_at ?? item.updated_at ?? null,
-    }));
-
-    let proposals: any[] = [];
-    if (latestStack?.id) {
-      const { data, error } = await admin.from("stacks_items")
-        .select("id,stack_id,user_id,name,brand,dose,timing,timing_text,timing_bucket,notes,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,supplement_id,created_at")
-        .eq("stack_id", latestStack.id)
-        .eq("is_current", false);
-      if (error) throw error;
-      proposals = (data ?? [])
-        .filter((item) => !currentNames.has(normalizeRegimenName(item.name ?? "")))
-        .map((item) => ({ ...item, source_type: "blueprint_proposal" }));
-    }
-
-    return NextResponse.json({ ok: true, latestStack: latestStack ?? null, items: [...current, ...proposals] });
+    const data = await getRoutineData(entitlement.user.id);
+    return NextResponse.json({ ok: true, ...data });
   } catch (error) {
     const message = error instanceof Error ? error.message : "current_regimen_failed";
     console.error("[stacks/combined] failed", error);

--- a/app/api/stacks/update/route.ts
+++ b/app/api/stacks/update/route.ts
@@ -1,6 +1,4 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { requirePaidApi } from "@/lib/serverEntitlements";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
@@ -12,12 +10,25 @@ export async function POST(req: Request) {
     const entitlement = await requirePaidApi();
     if (!entitlement.ok) return entitlement.response;
 
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
-
     const { id, purpose, dose, timing, active } = await req.json();
     if (!id) return NextResponse.json({ ok: false, error: "missing_id" }, { status: 400 });
+
+    const admin = getSupabaseAdmin();
+    const { data: existing, error: existingError } = await admin
+      .from("current_regimen_items")
+      .select("id,item_kind")
+      .eq("id", id)
+      .eq("user_id", entitlement.user.id)
+      .maybeSingle();
+
+    if (existingError) return NextResponse.json({ ok: false, error: existingError.message }, { status: 400 });
+    if (!existing) return NextResponse.json({ ok: false, error: "regimen_item_not_found" }, { status: 404 });
+    if (typeof dose !== "undefined" && ["medication", "hormone"].includes(existing.item_kind)) {
+      return NextResponse.json(
+        { ok: false, error: "dose_updates_unavailable_for_prescriptions_and_hormones" },
+        { status: 400 },
+      );
+    }
 
     const patch: Record<string, unknown> = Object.fromEntries(
       Object.entries({ purpose, dose, timing, active })
@@ -29,11 +40,11 @@ export async function POST(req: Request) {
     patch.instruction_source = "member_update";
     patch.updated_at = new Date().toISOString();
 
-    const { data, error } = await getSupabaseAdmin()
+    const { data, error } = await admin
       .from("current_regimen_items")
       .update(patch)
       .eq("id", id)
-      .eq("user_id", user.id)
+      .eq("user_id", entitlement.user.id)
       .select("id")
       .maybeSingle();
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "qa:stripe-pricing": "node src/_tests_/stripePricing.assert.mjs",
     "qa:blueprints": "node src/_tests_/interactiveBlueprints.assert.mjs",
     "qa:current-regimen": "node src/_tests_/currentRegimen.assert.mjs",
+    "qa:routine": "node --experimental-strip-types src/_tests_/routine.assert.ts && node src/_tests_/routinePage.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/authenticatedNavigation.assert.ts
+++ b/src/_tests_/authenticatedNavigation.assert.ts
@@ -8,14 +8,15 @@ import {
 
 assert.deepEqual(
   AUTHENTICATED_NAV_ITEMS.map((item) => item.label),
-  ["Today", "Journey", "Blueprints", "Settings"]
+  ["Today", "Routine", "Journey", "Blueprints", "Settings"]
 );
-assert.equal(new Set(AUTHENTICATED_NAV_ITEMS.map((item) => item.href)).size, 4);
+assert.equal(new Set(AUTHENTICATED_NAV_ITEMS.map((item) => item.href)).size, 5);
 assert.equal(LEGACY_AUTHENTICATED_REDIRECTS["/dashboard"], "/today");
 assert.equal(LEGACY_AUTHENTICATED_REDIRECTS["/dashboard/my-quiz"], "/blueprints");
 assert.equal(LEGACY_AUTHENTICATED_REDIRECTS["/quiz/premium"], "/blueprints");
 assert.equal(LEGACY_AUTHENTICATED_REDIRECTS["/account"], "/settings");
 assert.equal(isAuthenticatedRouteActive("/today", "/today"), true);
+assert.equal(isAuthenticatedRouteActive("/routine", "/routine"), true);
 assert.equal(isAuthenticatedRouteActive("/blueprints/archive", "/blueprints"), true);
 assert.equal(isAuthenticatedRouteActive("/journey", "/today"), false);
 

--- a/src/_tests_/currentRegimen.assert.mjs
+++ b/src/_tests_/currentRegimen.assert.mjs
@@ -13,10 +13,12 @@ const writePrivileges = read("supabase/migrations/20260801182000_server_control_
 assert.match(writePrivileges, /revoke update[^;]*from authenticated/i, "Member regimen writes must remain server-controlled.");
 
 const combined = read("app/api/stacks/combined/route.ts");
-assert.match(combined, /getCurrentRegimen/, "Today must read the canonical current regimen.");
-assert.match(combined, /\.eq\("stack_id", latestStack\.id\)/, "Only the newest Blueprint may provide proposals.");
-assert.match(combined, /\.eq\("is_current", false\)/, "Blueprint recommendations must remain proposals until adopted.");
-assert.doesNotMatch(combined, /\.eq\("user_id", userId\)[\s\S]*\.eq\("is_current", true\)/, "Historical current flags must not drive Today.");
+assert.match(combined, /getRoutineData/, "Today must read the canonical routine data service.");
+const routineData = read("src/lib/routineData.ts");
+assert.match(routineData, /getCurrentRegimen/, "Routine data must read the canonical current regimen.");
+assert.match(routineData, /\.eq\("stack_id", latestStack\.id\)/, "Only the newest Blueprint may provide proposals.");
+assert.match(routineData, /\.eq\("is_current", false\)/, "Blueprint recommendations must remain proposals until adopted.");
+assert.doesNotMatch(routineData, /\.eq\("user_id", userId\)[\s\S]*\.eq\("is_current", true\)/, "Historical current flags must not drive Today.");
 
 const supplements = read("app/api/blueprints/[stackId]/supplements/route.ts");
 assert.match(supplements, /replaceCurrentSupplements/, "Blueprint updates must replace the current supplement regimen.");
@@ -34,8 +36,9 @@ const updateRoute = read("app/api/stacks/update/route.ts");
 assert.match(updateRoute, /getSupabaseAdmin/, "Regimen updates must use the owner-bound server route.");
 
 const today = read("src/components/dashboard/TodaysPlan.tsx");
-assert.match(today, /regimen_item_id: itemId/, "Today must save adherence against canonical regimen items.");
-assert.match(today, /fetch\("\/api\/stacks\/combined"/, "Today must reload from the canonical combined endpoint after an update.");
+assert.match(today, /fetch\("\/api\/stacks\/combined"/, "Today must load its summary from the canonical combined endpoint.");
+assert.match(today, /href="\/routine"/, "Today must hand detailed regimen work off to Routine.");
+assert.doesNotMatch(today, /\/api\/intake\/set/, "The compact Today summary must not retain inline regimen tracking controls.");
 
 const model = read("src/lib/currentRegimenModel.ts");
 assert.match(model, /purpose: item\.purpose \?\? null/, "Regimen normalization must preserve purpose.");

--- a/src/_tests_/routine.assert.ts
+++ b/src/_tests_/routine.assert.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+
+import {
+  getRoutineTodaySummary,
+  groupRoutineItems,
+  isClinicianReviewProposal,
+  isRoutineItemDueToday,
+  routineScheduleLabel,
+  type RoutineItem,
+} from "../lib/routine.ts";
+
+function item(overrides: Partial<RoutineItem>): RoutineItem {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    stack_id: null,
+    name: "Example",
+    brand: null,
+    purpose: null,
+    dose: null,
+    timing: null,
+    notes: null,
+    item_kind: "supplement",
+    instruction_source: "intake",
+    active: true,
+    is_current: true,
+    source_type: "regimen",
+    link_amazon: null,
+    link_fullscript: null,
+    refill_days_left: null,
+    last_refilled_at: null,
+    ...overrides,
+  };
+}
+
+const regimen = [
+  item({ id: "med", name: "Metformin", item_kind: "medication", timing: "Morning with breakfast" }),
+  item({ id: "hormone", name: "Testosterone", item_kind: "hormone", timing: "Monday and Thursday evenings" }),
+  item({ id: "supplement", name: "Magnesium Threonate", item_kind: "supplement", timing: "Before bed" }),
+  item({ id: "active", name: "DHEA", item_kind: "endocrine_active_supplement", timing: null }),
+  item({ id: "idea", name: "Berberine", source_type: "blueprint_proposal", is_current: true, active: false, notes: "Clinician review" }),
+];
+
+const grouped = groupRoutineItems(regimen);
+assert.deepEqual(grouped.byKind.medication.map(({ id }) => id), ["med"]);
+assert.deepEqual(grouped.byKind.hormone.map(({ id }) => id), ["hormone"]);
+assert.deepEqual(grouped.byKind.supplement.map(({ id }) => id), ["supplement"]);
+assert.deepEqual(grouped.byKind.endocrine_active_supplement.map(({ id }) => id), ["active"]);
+assert.equal(grouped.current.some(({ id }) => id === "idea"), false, "A proposal must never appear current even if a historical flag says otherwise");
+assert.deepEqual(grouped.proposals.map(({ id }) => id), ["idea"]);
+
+assert.equal(routineScheduleLabel(regimen[3]), "Schedule not recorded");
+assert.equal(isRoutineItemDueToday(regimen[0], new Date(2026, 7, 3)), true);
+assert.equal(isRoutineItemDueToday(regimen[1], new Date(2026, 7, 3)), true, "Monday hormone schedule should be due Monday");
+assert.equal(isRoutineItemDueToday(regimen[1], new Date(2026, 7, 4)), false, "Monday/Thursday hormone schedule should not be due Tuesday");
+assert.equal(isRoutineItemDueToday(item({ timing: "As needed" }), new Date(2026, 7, 3)), false);
+assert.equal(isClinicianReviewProposal(regimen[4]), true);
+
+assert.deepEqual(getRoutineTodaySummary(regimen, new Date(2026, 7, 3)), {
+  dueToday: 3,
+  scheduleReview: 1,
+  ideasToConsider: 1,
+});
+
+console.log("Routine assertions passed");

--- a/src/_tests_/routinePage.assert.mjs
+++ b/src/_tests_/routinePage.assert.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const navigation = read("src/lib/authenticatedNavigation.ts");
+assert.match(navigation, /href: "\/routine", label: "Routine"/, "Paid member navigation must include Routine.");
+
+const page = read("app/(app)/routine/page.tsx");
+assert.match(page, /requireTier\(\["premium", "trial"\]/, "Routine must require paid or trial access.");
+assert.match(page, /getRoutineData\(user\.id\)/, "Routine must render the canonical regimen on the server.");
+
+const data = read("src/lib/routineData.ts");
+assert.match(data, /item_kind: item\.item_kind/, "Current items must use their persisted type.");
+assert.match(data, /\.eq\("is_current", false\)/, "Only unadopted Blueprint rows may appear as proposals.");
+assert.match(data, /source_type: "blueprint_proposal"/, "Proposals need an explicit non-current source type.");
+
+const client = read("app/(app)/routine/RoutineClient.tsx");
+const routineModel = read("src/lib/routine.ts");
+assert.match(routineModel, /medication: "Prescriptions"/, "Routine must separate prescriptions.");
+assert.match(routineModel, /hormone: "Hormones"/, "Routine must separate hormones.");
+assert.match(routineModel, /supplement: "Supplements"/, "Routine must separate supplements.");
+assert.match(routineModel, /endocrine_active_supplement: "Hormone-active items"/, "Routine must separate hormone-active items.");
+assert.match(client, /Ideas to consider/, "Routine must separate proposed ideas.");
+assert.match(client, /Dose cannot be changed here/, "Prescription and hormone dose changes must be unavailable.");
+assert.match(client, /Schedule not recorded/, "Missing schedules must be stated plainly.");
+assert.match(client, /RotateCcw[\s\S]*Undo/, "State changes must expose text and icon Undo.");
+assert.match(client, /min-h-12/, "Primary mobile controls must use large tap targets.");
+assert.match(routineModel, /source_type === "blueprint_proposal"/, "Proposal grouping must not depend on historical current flags.");
+const updateRoute = read("app/api/stacks/update/route.ts");
+assert.match(updateRoute, /dose_updates_unavailable_for_prescriptions_and_hormones/, "Protected dose edits must also be rejected by the API.");
+
+const today = read("app/(app)/today/TodayClient.tsx");
+assert.doesNotMatch(today, /Disclosure|details|summary/, "Today must not retain the collapsed regimen manager.");
+const todaySummary = read("src/components/dashboard/TodaysPlan.tsx");
+assert.match(todaySummary, /Open Routine/, "Today must link its compact summary to Routine.");
+assert.match(todaySummary, /Due today/, "Today must show a compact due summary.");
+assert.match(todaySummary, /Need a schedule/, "Today must show schedule review needs.");
+
+console.log("Routine page assertions passed.");

--- a/src/components/dashboard/TodaysPlan.tsx
+++ b/src/components/dashboard/TodaysPlan.tsx
@@ -1,688 +1,83 @@
 "use client";
 
+import { AlertTriangle, ArrowRight, CalendarCheck2, ClipboardList, Loader2 } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { CheckCircle2, Circle, TriangleAlert, PackageOpen, Pill, Search,} from "lucide-react";
-import {
-  cleanDashboardDose,
-  getDashboardItemKind,
-  getDashboardSchedule,
-  isBatchTrackable,
-  isPendingRecommendation,
-} from "@/src/lib/dashboardPlan";
 
-/* =========================
-   Types
-========================= */
-type StackRow = { id: string; created_at: string };
-type StackItem = {
-  id: string;
-  stack_id: string;
-  name: string;
-  brand: string | null;
-  dose: string | null;
-  timing: "AM" | "PM" | "AM/PM" | (string & {}) | null;
-  /** ADD THIS: enables the normalizer to use either field */
-  timing_bucket?: string | null;
-  timing_text?: string | null;
-  is_current?: boolean | null;
-  notes: string | null;
-  link_amazon: string | null;
-  link_fullscript: string | null;
-  refill_days_left: number | null;
-  last_refilled_at: string | null;
-  source_type?: "regimen" | "blueprint_proposal";
-};
-
-type SearchItem = {
-  vendor: "fullscript" | "fallback";
-  sku: string | null;
-  name: string;
-  brand: string | null;
-  dose: string | null;
-  link_fullscript: string | null;
-  link_amazon: string | null;
-  price: number | null;
-};
-
-type ViewTab = "All" | "AM" | "PM";
+import { getRoutineTodaySummary, type RoutineItem } from "@/lib/routine";
 
 export default function TodaysPlan() {
-  const supabase = createClientComponentClient();
-
-  /* -------------------------
-     State
-  ------------------------- */
+  const [items, setItems] = useState<RoutineItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const [userId, setUserId] = useState<string | null>(null);
-  const [stack, setStack] = useState<StackRow | null>(null);
-  const [items, setItems] = useState<StackItem[]>([]);
-  const [showManager, setShowManager] = useState(false);
+  const [unavailable, setUnavailable] = useState(false);
 
-  // View filter (sticky header tabs)
-  const [view, setView] = useState<ViewTab>("All");
-
-  // DB-persisted "taken today" statuses
-  const [takenMap, setTakenMap] = useState<Record<string, boolean>>({});
-  const today = new Date().toISOString().slice(0, 10);
-
-  // Toast
-  const [toast, setToast] = useState<string | null>(null);
   useEffect(() => {
-    if (!toast) return;
-    const t = setTimeout(() => setToast(null), 2500);
-    return () => clearTimeout(t);
-  }, [toast]);
+    let cancelled = false;
+    fetch("/api/stacks/combined", { cache: "no-store" })
+      .then(async (response) => {
+        const body = await response.json().catch(() => null);
+        if (!response.ok || !body?.ok) throw new Error("routine_unavailable");
+        if (!cancelled) setItems(body.items ?? []);
+      })
+      .catch(() => { if (!cancelled) setUnavailable(true); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
 
-  // Local fallback key (only if API fails)
-  const localKey = useMemo(() => {
-    if (!userId) return null;
-    return `lve360_taken_${userId}_${today}`;
-  }, [userId, today]);
-
-  /* -------------------------
-     Load: user → latest stack → items → today statuses
-  ------------------------- */
-useEffect(() => {
-  (async () => {
-    setLoading(true);
-
-    // who am I?
-    const { data: userWrap } = await supabase.auth.getUser();
-    const uid = userWrap?.user?.id ?? null;
-    setUserId(uid);
-    if (!uid) {
-      setLoading(false);
-      return;
-    }
-
-    // NEW: one call to get merged list + latest stack meta
-    try {
-      const res = await fetch("/api/stacks/combined", { cache: "no-store" });
-      const json = await res.json();
-
-      if (!json?.ok) throw new Error(json?.error || "combined_failed");
-
-      setStack(json.latestStack);        // { id, created_at } or null
-      setItems(json.items || []);        // merged + de-duped items
-
-      // today statuses (unchanged logic)
-      if (json.latestStack?.id || (json.items ?? []).length > 0) {
-        const res2 = await fetch("/api/intake/status", { cache: "no-store" });
-        const sjson = await res2.json();
-        if (sjson?.ok) {
-          setTakenMap(sjson.statuses || {});
-          if (localKey) localStorage.setItem(localKey, JSON.stringify(sjson.statuses || {}));
-        } else if (localKey) {
-          const raw = localStorage.getItem(localKey);
-          setTakenMap(raw ? JSON.parse(raw) : {});
-        }
-      } else if (localKey) {
-        const raw = localStorage.getItem(localKey);
-        setTakenMap(raw ? JSON.parse(raw) : {});
-      }
-    } catch {
-      // fallback to any locally-cached taken states
-      if (localKey) {
-        const raw = localStorage.getItem(localKey);
-        setTakenMap(raw ? JSON.parse(raw) : {});
-      }
-    } finally {
-      setLoading(false);
-    }
-  })();
-}, [supabase, localKey]);
-
-
-  /* -------------------------
-     Actions
-  ------------------------- */
-
-  // Toggle a single item (DB, with local fallback)
-  async function toggleTaken(itemId: string) {
-    const nextVal = !takenMap[itemId];
-
-    try {
-      const res = await fetch("/api/intake/set", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ regimen_item_id: itemId, taken: nextVal }),
-      });
-      const json = await res.json();
-      if (!json?.ok) throw new Error(json?.error || "set_failed");
-
-      setTakenMap((prev) => {
-        const next = { ...prev, [itemId]: nextVal };
-        if (localKey) localStorage.setItem(localKey, JSON.stringify(next));
-        return next;
-      });
-      setToast(nextVal ? "Marked item taken" : "Marked item not taken");
-    } catch {
-      // Fallback to local only if DB write fails
-      setTakenMap((prev) => {
-        const next = { ...prev, [itemId]: nextVal };
-        if (localKey) localStorage.setItem(localKey, JSON.stringify(next));
-        return next;
-      });
-      setToast(nextVal ? "Marked item taken" : "Marked item not taken");
-    }
-  }
-
-  // Mark all in current view (All/AM/PM) as taken (true) or not (false)
-  async function markAllInView(taken: boolean) {
-    const scoped = visibleItems.filter(isBatchTrackable).map((i) => i.id);
-    if (scoped.length === 0) return;
-
-    await Promise.allSettled(
-      scoped.map((id) =>
-        fetch("/api/intake/set", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ regimen_item_id: id, taken }),
-        })
-      )
-    );
-
-    setTakenMap((prev) => {
-      const next = { ...prev };
-      scoped.forEach((id) => (next[id] = taken));
-      if (localKey) localStorage.setItem(localKey, JSON.stringify(next));
-      return next;
-    });
-    setToast(taken ? "Marked all visible items taken" : "Cleared all visible items");
-  }
-
-  async function activateRecommendation(itemId: string) {
-    const res = await fetch("/api/stack-items/activate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ item_id: itemId }),
-    });
-    const json = await res.json();
-    if (!res.ok || !json?.ok) {
-      setToast("Unable to add that recommendation");
-      return;
-    }
-    await reloadItems();
-    setToast("Added to your active plan");
-  }
-
-  // Reload items (after adding new in modal)
-  async function reloadItems() {
-    try {
-      const [itemsResponse, statusResponse] = await Promise.all([
-        fetch("/api/stacks/combined", { cache: "no-store" }),
-        fetch("/api/intake/status", { cache: "no-store" }),
-      ]);
-      const [itemsJson, statusJson] = await Promise.all([itemsResponse.json(), statusResponse.json()]);
-      if (itemsJson?.ok) {
-        setStack(itemsJson.latestStack ?? null);
-        setItems(itemsJson.items ?? []);
-      }
-      if (statusJson?.ok) {
-        setTakenMap(statusJson.statuses || {});
-        if (localKey) localStorage.setItem(localKey, JSON.stringify(statusJson.statuses || {}));
-      }
-    } catch {}
-  }
-
-  /* -------------------------
-     Derived (AM/PM bucketing via normalizer)
-  ------------------------- */
-  const pendingItems = useMemo(() => items.filter(isPendingRecommendation), [items]);
-  const activeItems = useMemo(() => items.filter((item) => !isPendingRecommendation(item)), [items]);
-  const { itemsAM, itemsPM, itemsOther } = useMemo(() => {
-    const groups: { AM: StackItem[]; PM: StackItem[]; OTHER: StackItem[] } = { AM: [], PM: [], OTHER: [] };
-    for (const it of activeItems) {
-      const schedule = getDashboardSchedule(it);
-      if (schedule === "AM/PM") {
-        groups.AM.push(it);
-        groups.PM.push(it);
-      } else if (schedule === "AM") groups.AM.push(it);
-      else if (schedule === "PM") groups.PM.push(it);
-      else groups.OTHER.push(it);
-    }
-    return {
-      itemsAM: groups.AM,
-      itemsPM: groups.PM,
-      itemsOther: groups.OTHER,
-    };
-  }, [activeItems]);
-
-  // Items visible under current tab
-  const visibleItems = useMemo<StackItem[]>(() => {
-    if (view === "All") return activeItems;
-    if (view === "AM") return itemsAM;
-    return itemsPM;
-  }, [view, activeItems, itemsAM, itemsPM]);
-
-  // Completion overall + scoped
-  const completionScoped = useMemo(() => {
-    const ids = visibleItems.map((i) => i.id);
-    const total = ids.length || 1;
-    const done = ids.reduce((acc, id) => acc + (takenMap[id] ? 1 : 0), 0);
-    return Math.round((done / total) * 100);
-  }, [visibleItems, takenMap]);
-
-  /* -------------------------
-     Render
-  ------------------------- */
-  if (loading) {
-    return (
-      <div id="todays-plan" className="bg-white/70 backdrop-blur-md rounded-2xl p-6 shadow-sm">
-        <div className="flex items-center text-gray-600">
-          <Pill className="w-5 h-5 mr-2 text-purple-600" />
-          Loading your plan…
-        </div>
-      </div>
-    );
-  }
+  const summary = useMemo(() => getRoutineTodaySummary(items), [items]);
 
   return (
-    <div id="todays-plan" className="rounded-2xl border border-slate-200 bg-white p-0 shadow-sm">
-      {/* Sticky Header */}
-      <div className="sticky top-0 z-10 rounded-t-2xl border-b border-slate-200 bg-white/95 backdrop-blur-md">
-        <div className="px-6 pt-5 pb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-[#041B2D]">🗓️ Today’s Plan</h2>
-            <p className="text-gray-600">
-              Your latest stack{stack?.created_at ? ` • generated ${new Date(stack.created_at).toLocaleDateString()}` : ""}.
-            </p>
-          </div>
-
-          {/* Tabs + scoped actions */}
-          <div className="flex items-center gap-2">
-            <Tab label="All" active={view === "All"} onClick={() => setView("All")} />
-            <Tab label="AM" active={view === "AM"} onClick={() => setView("AM")} />
-            <Tab label="PM" active={view === "PM"} onClick={() => setView("PM")} />
-          </div>
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6" aria-labelledby="today-routine-summary">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Routine at a glance</p>
+          <h2 id="today-routine-summary" className="mt-1 text-xl font-bold text-[#041B2D]">What needs your attention today</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            Keep detailed medication, hormone, and supplement organization in Routine. Today only shows what may need attention.
+          </p>
         </div>
-
-        {/* Progress bar row */}
-        <div className="px-6 pb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <div className="flex-1">
-            <div className="text-xs text-gray-600 mb-1">
-              Completion {view === "All" ? "(overall)" : `(in ${view})`}: <span className="font-semibold">{completionScoped}%</span>
-            </div>
-            <ProgressBar pct={completionScoped} />
-          </div>
-
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => {
-                const batchItems = visibleItems.filter(isBatchTrackable);
-                const allDone = batchItems.length > 0 && batchItems.every((i) => takenMap[i.id]);
-                markAllInView(!allDone);
-              }}
-              className="text-sm font-semibold text-[#06C1A0] underline underline-offset-2"
-              title="Toggle all items in current tab"
-              aria-label="Toggle all items in current tab"
-            >
-              {visibleItems.filter(isBatchTrackable).length > 0 &&
-              visibleItems.filter(isBatchTrackable).every((i) => takenMap[i.id]) ? "Clear routine" : "Mark routine taken"}
-            </button>
-
-            <button
-              onClick={() => setShowManager(true)}
-              className="inline-flex items-center rounded-xl bg-[#047F6D] px-3 py-1.5 text-white text-sm font-semibold shadow-md hover:bg-[#036957]"
-              aria-label="Manage stack"
-            >
-              <Search className="w-4 h-4 mr-1" />
-              Manage
-            </button>
-          </div>
-        </div>
+        <Link href="/routine" className="inline-flex min-h-12 shrink-0 items-center justify-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white transition hover:bg-[#06695F] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2">
+          Open Routine <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+        </Link>
       </div>
 
-      {/* Lists */}
-      <div className="px-6 pb-6 pt-4 space-y-6">
-        {/* Scoped list if AM/PM selected */}
-        {view !== "All" ? (
-          <TimingBlock
-            title={`${view} Routine`}
-            items={visibleItems}
-            takenMap={takenMap}
-            onToggle={toggleTaken}
-          />
-        ) : (
-          <>
-            <TimingBlock title="AM Routine" items={itemsAM} takenMap={takenMap} onToggle={toggleTaken} />
-            <TimingBlock title="PM Routine" items={itemsPM} takenMap={takenMap} onToggle={toggleTaken} />
-            {itemsOther.length > 0 && (
-              <TimingBlock title="Anytime, weekly, or as needed" items={itemsOther} takenMap={takenMap} onToggle={toggleTaken} />
-            )}
-          </>
-        )}
-
-        {pendingItems.length > 0 && (
-          <RecommendationBlock items={pendingItems} onActivate={activateRecommendation} />
-        )}
-
-        {/* Manage & Refill row */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <LowStockBanner items={activeItems} />
-          {/* spacer to keep layout balanced; Manage sits in sticky header now */}
-          <div className="h-0" />
+      {loading ? (
+        <div className="mt-5 flex min-h-24 items-center justify-center rounded-xl bg-slate-50 text-slate-600">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin text-[#087F72]" aria-hidden="true" /> Loading routine summary
         </div>
-      </div>
-
-      {/* Stack Manager Modal (search + add) */}
-      {showManager && (
-        <StackManagerModal
-          onClose={() => setShowManager(false)}
-          onAdded={async () => {
-            await reloadItems();
-            setShowManager(false);
-          }}
-        />
-      )}
-
-      {/* Toast (stay fixed to viewport) */}
-      {toast && (
-        <div className="fixed inset-x-0 bottom-6 z-[60] flex justify-center px-4">
-          <div className="rounded-xl border border-purple-200 bg-white/90 backdrop-blur-md shadow-lg px-4 py-2 text-sm text-[#041B2D]">
-            {toast}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/* ============================================================
-   Modal (search + add)
-============================================================ */
-function StackManagerModal({ onClose, onAdded }: { onClose: () => void; onAdded: () => void }) {
-  const [q, setQ] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [items, setItems] = useState<SearchItem[]>([]);
-  const [error, setError] = useState<string | null>(null);
-
-  async function doSearch() {
-    try {
-      setBusy(true);
-      setError(null);
-      const res = await fetch(`/api/fullscript/search?q=${encodeURIComponent(q)}`, { cache: "no-store" });
-      const json = await res.json();
-      if (!json?.ok) throw new Error(json?.error || "search_failed");
-      setItems(json.items || []);
-    } catch (e: any) {
-      setError(e?.message ?? "Search failed");
-      setItems([]);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function addToStack(it: SearchItem, timing: "AM" | "PM" | "AM/PM") {
-    try {
-      setBusy(true);
-      setError(null);
-      const res = await fetch("/api/fullscript/add", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: it.name,
-          brand: it.brand,
-          dose: it.dose,
-          link_fullscript: it.link_fullscript,
-          link_amazon: it.link_amazon,
-          source: it.vendor === "fullscript" ? "fullscript" : "amazon",
-          sku: it.sku,
-          timing,
-          notes: null,
-        }),
-      });
-      const json = await res.json();
-      if (!json?.ok) throw new Error(json?.error || "add_failed");
-      await onAdded();
-    } catch (e: any) {
-      setError(e?.message ?? "Add failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl max-w-3xl w-full p-6 shadow-xl">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-xl font-semibold text-[#041B2D]">Manage Your Stack</h3>
-          <button onClick={onClose} className="text-gray-500 hover:text-gray-700" aria-label="Close">
-            ✕
-          </button>
-        </div>
-
-        <div className="flex gap-2">
-          <input
-            className="flex-1 rounded-lg border px-3 py-2"
-            placeholder="Search Fullscript (or fallback catalog)…"
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && doSearch()}
-          />
-          <button
-            onClick={doSearch}
-            disabled={busy || !q.trim()}
-            className="rounded-lg border px-4 py-2 font-medium hover:bg-white disabled:opacity-60"
-          >
-            {busy ? "Searching…" : "Search"}
-          </button>
-        </div>
-
-        {error && (
-          <div className="mt-3 text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3">
-            {error}
-          </div>
-        )}
-
-        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-[50vh] overflow-auto pr-1">
-          {items.map((it, idx) => (
-            <div
-              key={`${it.sku ?? idx}`}
-              className="rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-yellow-50 p-4"
-            >
-              <div className="font-semibold text-[#041B2D]">{it.name}</div>
-              <div className="text-sm text-gray-700">{it.brand ?? "—"}</div>
-              <div className="text-xs text-gray-600">{it.dose ?? ""}</div>
-              <div className="text-xs text-gray-500 mt-1">
-                {it.price != null ? `~$${Number(it.price).toFixed(2)}` : ""}
-              </div>
-              <div className="mt-3 flex gap-2">
-                <button onClick={() => addToStack(it, "AM")} className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white">
-                  Add to AM
-                </button>
-                <button onClick={() => addToStack(it, "PM")} className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white">
-                  Add to PM
-                </button>
-                <button onClick={() => addToStack(it, "AM/PM")} className="rounded-lg border px-3 py-1.5 text-sm hover:bg-white">
-                  Add AM/PM
-                </button>
-              </div>
-            </div>
-          ))}
-          {items.length === 0 && !error && (
-            <div className="text-gray-600">Try “magnesium”, “omega”, “ashwagandha”…</div>
-          )}
-        </div>
-
-        <div className="mt-4 text-right">
-          <button onClick={onClose} className="rounded-lg border px-4 py-2 text-sm">
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ============================================================
-   Banners & Blocks
-============================================================ */
-function LowStockBanner({ items }: { items: StackItem[] }) {
-  const low = items.filter((i) => (i.refill_days_left ?? Infinity) <= 10);
-  if (!low.length) return null;
-  return (
-    <div className="inline-flex items-center gap-2 text-amber-800 bg-amber-50 border border-amber-200 rounded-xl px-3 py-2">
-      <TriangleAlert className="w-4 h-4" />
-      {low.length} item{low.length > 1 ? "s" : ""} low — consider reordering.
-    </div>
-  );
-}
-
-function RecommendationBlock({ items, onActivate }: { items: StackItem[]; onActivate: (id: string) => void }) {
-  return (
-    <section aria-label="Recommendations to consider">
-      <div className="text-xs uppercase tracking-wide text-[#047F6D] mb-2">Recommendations to consider</div>
-      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
-        <p className="mb-3 text-sm text-amber-900">
-          These Blueprint ideas are not part of your daily checklist until you choose to add them.
-        </p>
-        <ul className="space-y-2">
-          {items.map((item) => (
-            <li key={item.id} className="flex flex-col gap-3 rounded-lg bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <div className="font-semibold text-[#041B2D]">{item.name}</div>
-                <div className="text-sm text-gray-700">{cleanDashboardDose(item.dose) ?? "Starting guidance is in your Blueprint"}</div>
-              </div>
-              <button onClick={() => onActivate(item.id)} className="rounded-lg border border-[#06C1A0] px-3 py-1.5 text-sm font-semibold text-[#047F6D] hover:bg-[#EAFBF8]">
-                Add to my plan
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </section>
-  );
-}
-
-function TimingBlock({
-  title,
-  items,
-  takenMap,
-  onToggle,
-}: {
-  title: string;
-  items: StackItem[];
-  takenMap: Record<string, boolean>;
-  onToggle: (id: string) => void;
-}) {
-  return (
-    <section aria-label={title}>
-      <div className="text-xs uppercase tracking-wide text-[#047F6D] mb-2">{title}</div>
-      {items.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-gray-600">
-          No items in this timing.
+      ) : unavailable ? (
+        <div className="mt-5 flex items-start rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <AlertTriangle className="mr-2 mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" /> Routine details are temporarily unavailable. Open Routine to try again.
         </div>
       ) : (
-        <ul className="space-y-2">
-          {items.map((it) => {
-            const taken = !!takenMap[it.id];
-            const kind = getDashboardItemKind(it.name);
-            const schedule = getDashboardSchedule(it);
-            const link = kind === "supplement" ? it.link_fullscript || it.link_amazon || null : null;
-            const low = (it.refill_days_left ?? Infinity) <= 10;
-            return (
-              <li
-                key={it.id}
-                className="rounded-xl border border-slate-200 bg-slate-50 p-3"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex items-start gap-3">
-                    <button
-                      onClick={() => onToggle(it.id)}
-                      className="mt-0.5 text-[#7C3AED]"
-                      aria-label={taken ? "Mark not taken" : "Mark taken"}
-                      title={taken ? "Mark not taken" : "Mark taken"}
-                    >
-                      {taken ? <CheckCircle2 className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
-                    </button>
-                    <div>
-                      <div className="font-semibold text-[#041B2D]">
-                        {(it.name || "").replace(/^theanine$/i, "L-Theanine")}
-                        {it.brand ? ` — ${it.brand}` : ""}
-                      </div>
-                      <div className="text-sm text-gray-700">
-                        {cleanDashboardDose(it.dose) || "Reported dose not set"}
-                        {it.timing && !["AM", "PM", "AM/PM"].includes(it.timing) ? ` • ${it.timing}` : ""}
-                      </div>
-                      <div className="mt-1 flex flex-wrap gap-1.5">
-                        {kind !== "supplement" && (
-                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-700">
-                            {kind === "endocrine_active_supplement" ? "Hormone-active" : "Medication / hormone"}
-                          </span>
-                        )}
-                        {schedule === "WEEKLY" && <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700">Weekly</span>}
-                        {schedule === "AS_NEEDED" && <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700">As needed</span>}
-                        {schedule === "UNSCHEDULED" && <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">Schedule not set</span>}
-                      </div>
-                      {it.notes && (
-                        <div className="text-xs text-gray-600 mt-0.5 line-clamp-2" title={it.notes}>
-                          {it.notes}
-                        </div>
-                      )}
-                      {low && (
-                        <div className="mt-1 inline-flex items-center gap-1 text-xs text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">
-                          <TriangleAlert className="w-3 h-3" /> Refill soon
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="flex items-center gap-2">
-                    {link ? (
-                      <a
-                        className="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm hover:bg-white"
-                        href={link}
-                        target="_blank"
-                        rel="noopener noreferrer nofollow sponsored"
-                        title="Reorder"
-                      >
-                        <PackageOpen className="w-4 h-4 mr-1" />
-                        Reorder
-                      </a>
-                    ) : null}
-                  </div>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+        <dl className="mt-5 grid gap-3 sm:grid-cols-3">
+          <SummaryStat icon={CalendarCheck2} value={summary.dueToday} label="Due today" detail="Based on your recorded schedule" />
+          <SummaryStat icon={ClipboardList} value={summary.scheduleReview} label="Need a schedule" detail="Schedule not recorded" warning={summary.scheduleReview > 0} />
+          <SummaryStat icon={AlertTriangle} value={summary.ideasToConsider} label="Ideas to consider" detail="Not in your current routine" warning={summary.ideasToConsider > 0} />
+        </dl>
       )}
     </section>
   );
 }
 
-/* =========================
-   Small UI bits
-========================= */
-function Tab({ label, active, onClick }: { label: ViewTab; active: boolean; onClick: () => void }) {
+function SummaryStat({
+  icon: Icon,
+  value,
+  label,
+  detail,
+  warning = false,
+}: {
+  icon: typeof CalendarCheck2;
+  value: number;
+  label: string;
+  detail: string;
+  warning?: boolean;
+}) {
   return (
-    <button
-      onClick={onClick}
-      className={`rounded-full px-3 py-1 text-sm border ${
-        active ? "bg-[#047F6D] text-white border-transparent" : "bg-white text-[#041B2D] border-slate-200"
-      }`}
-      aria-pressed={active}
-      aria-label={`Show ${label} items`}
-    >
-      {label}
-    </button>
-  );
-}
-
-function ProgressBar({ pct }: { pct: number }) {
-  const clamped = Math.max(0, Math.min(100, pct));
-  return (
-    <div className="h-2 w-full rounded-full bg-gray-200 overflow-hidden">
-      <div
-        className="h-full bg-gradient-to-r from-[#06C1A0] to-[#7C3AED] transition-all"
-        style={{ width: `${clamped}%` }}
-        aria-valuenow={clamped}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        role="progressbar"
-      />
+    <div className={`rounded-xl border p-4 ${warning ? "border-amber-200 bg-amber-50" : "border-slate-200 bg-slate-50"}`}>
+      <dt className="flex items-center text-sm font-bold text-[#041B2D]"><Icon className={`mr-2 h-5 w-5 ${warning ? "text-amber-700" : "text-[#087F72]"}`} aria-hidden="true" /> {label}</dt>
+      <dd className="mt-2 text-3xl font-extrabold text-[#041B2D]">{value}</dd>
+      <p className="mt-1 text-xs leading-5 text-slate-600">{detail}</p>
     </div>
   );
 }

--- a/src/lib/authenticatedNavigation.ts
+++ b/src/lib/authenticatedNavigation.ts
@@ -1,5 +1,6 @@
 export const AUTHENTICATED_NAV_ITEMS = [
   { href: "/today", label: "Today" },
+  { href: "/routine", label: "Routine" },
   { href: "/journey", label: "Journey" },
   { href: "/blueprints", label: "Blueprints" },
   { href: "/settings", label: "Settings" },

--- a/src/lib/routine.ts
+++ b/src/lib/routine.ts
@@ -1,0 +1,97 @@
+export type RoutineItemKind = "medication" | "supplement" | "hormone" | "endocrine_active_supplement";
+export type RoutineSourceType = "regimen" | "blueprint_proposal";
+
+export type RoutineItem = {
+  id: string;
+  stack_id: string | null;
+  name: string;
+  brand: string | null;
+  purpose: string | null;
+  dose: string | null;
+  timing: string | null;
+  timing_text?: string | null;
+  notes: string | null;
+  item_kind: RoutineItemKind;
+  instruction_source?: "intake" | "member_update" | "adopted_recommendation" | "manual_add" | null;
+  active?: boolean;
+  is_current: boolean;
+  source_type: RoutineSourceType;
+  link_amazon: string | null;
+  link_fullscript: string | null;
+  refill_days_left: number | null;
+  last_refilled_at: string | null;
+  created_at?: string | null;
+};
+
+export const ROUTINE_SECTION_ORDER = [
+  "medication",
+  "hormone",
+  "supplement",
+  "endocrine_active_supplement",
+] as const;
+
+export const ROUTINE_SECTION_LABELS: Record<RoutineItemKind, string> = {
+  medication: "Prescriptions",
+  hormone: "Hormones",
+  supplement: "Supplements",
+  endocrine_active_supplement: "Hormone-active items",
+};
+
+export function groupRoutineItems(items: RoutineItem[]) {
+  const current = items.filter((item) => item.source_type === "regimen" && item.is_current && item.active !== false);
+  return {
+    current,
+    proposals: items.filter((item) => item.source_type === "blueprint_proposal"),
+    byKind: Object.fromEntries(
+      ROUTINE_SECTION_ORDER.map((kind) => [kind, current.filter((item) => item.item_kind === kind)])
+    ) as Record<RoutineItemKind, RoutineItem[]>,
+  };
+}
+
+export function routineScheduleLabel(item: Pick<RoutineItem, "timing" | "timing_text">): string {
+  return item.timing?.trim() || item.timing_text?.trim() || "Schedule not recorded";
+}
+
+const DAY_INDEX: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+export function isRoutineItemDueToday(
+  item: Pick<RoutineItem, "timing" | "timing_text">,
+  today = new Date()
+): boolean {
+  const schedule = routineScheduleLabel(item).toLowerCase();
+  if (schedule === "schedule not recorded" || /\b(as needed|prn)\b/.test(schedule)) return false;
+  const namedDays = Object.entries(DAY_INDEX)
+    .filter(([day]) => new RegExp(`\\b${day}(?:s)?\\b`, "i").test(schedule))
+    .map(([, index]) => index);
+  if (namedDays.length) return namedDays.includes(today.getDay());
+  if (/\bweekly|once (?:a|per) week\b/.test(schedule)) return false;
+  return true;
+}
+
+export function getRoutineTodaySummary(items: RoutineItem[], today = new Date()) {
+  const { current, proposals } = groupRoutineItems(items);
+  return {
+    dueToday: current.filter((item) => isRoutineItemDueToday(item, today)).length,
+    scheduleReview: current.filter((item) => routineScheduleLabel(item) === "Schedule not recorded").length,
+    ideasToConsider: proposals.length,
+  };
+}
+
+export function routineSourceLabel(source: RoutineItem["instruction_source"]): string {
+  if (source === "member_update") return "Updated by you";
+  if (source === "adopted_recommendation") return "Added from your Blueprint";
+  if (source === "manual_add") return "Added by you";
+  return "From your intake";
+}
+
+export function isClinicianReviewProposal(item: Pick<RoutineItem, "notes">): boolean {
+  return /clinician review|pharmacist|interaction|contraindicat|use caution|avoid/i.test(item.notes ?? "");
+}

--- a/src/lib/routineData.ts
+++ b/src/lib/routineData.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
+import { normalizeRegimenName, regimenKindForSupplement } from "@/lib/currentRegimenModel";
+import type { RoutineItem } from "@/lib/routine";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export async function getRoutineData(userId: string): Promise<{
+  latestStack: { id: string; submission_id: string | null; created_at: string } | null;
+  items: RoutineItem[];
+}> {
+  const admin = getSupabaseAdmin();
+  const { data: latestStack, error: stackError } = await admin
+    .from("stacks")
+    .select("id,submission_id,created_at")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (stackError) throw stackError;
+
+  if (latestStack?.submission_id) await ensureCurrentRegimen(userId, latestStack.submission_id);
+  const regimen = await getCurrentRegimen(userId);
+  const currentNames = new Set(regimen.map((item) => normalizeRegimenName(item.name)));
+  const current: RoutineItem[] = regimen.map((item) => ({
+    id: item.id,
+    stack_id: latestStack?.id ?? null,
+    name: item.name,
+    brand: null,
+    purpose: item.purpose,
+    dose: item.dose,
+    timing: item.timing,
+    timing_text: item.timing,
+    notes: null,
+    item_kind: item.item_kind,
+    instruction_source: item.instruction_source,
+    active: item.active,
+    is_current: true,
+    source_type: "regimen",
+    link_amazon: null,
+    link_fullscript: null,
+    refill_days_left: null,
+    last_refilled_at: null,
+    created_at: item.created_at ?? item.updated_at ?? null,
+  }));
+
+  let proposals: RoutineItem[] = [];
+  if (latestStack?.id) {
+    const { data, error } = await admin.from("stacks_items")
+      .select("id,stack_id,name,brand,dose,timing,timing_text,notes,rationale,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,created_at")
+      .eq("stack_id", latestStack.id)
+      .eq("is_current", false);
+    if (error) throw error;
+    proposals = (data ?? [])
+      .filter((item) => !currentNames.has(normalizeRegimenName(item.name ?? "")))
+      .map((item) => ({
+        id: item.id,
+        stack_id: item.stack_id,
+        name: item.name,
+        brand: item.brand,
+        purpose: item.rationale ?? null,
+        dose: item.dose,
+        timing: item.timing_text ?? item.timing,
+        timing_text: item.timing_text,
+        notes: item.notes,
+        item_kind: regimenKindForSupplement(item.name),
+        instruction_source: null,
+        active: false,
+        is_current: false,
+        source_type: "blueprint_proposal",
+        link_amazon: item.link_amazon,
+        link_fullscript: item.link_fullscript,
+        refill_days_left: item.refill_days_left,
+        last_refilled_at: item.last_refilled_at,
+        created_at: item.created_at,
+      }));
+  }
+
+  return { latestStack: latestStack ?? null, items: [...current, ...proposals] };
+}


### PR DESCRIPTION
## What changed

- adds a paid member Routine page for prescriptions, hormones, supplements, and hormone-active items
- keeps Blueprint ideas separate from the current routine until the member explicitly adopts them
- replaces the large collapsed manager on Today with a compact due, schedule, and ideas summary
- adds safe editing, stop tracking, add supplement, adoption, and Undo interactions
- prevents prescription and hormone dose edits in both the interface and API
- adds Routine navigation plus focused regression coverage

## Why

Medication, hormone, and supplement management had outgrown the collapsed Today panel. This gives members a clearer home for maintaining the routine that powers their Blueprint and daily experience while keeping Today focused.

## Validation

- `npm.cmd run qa:routine`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:gating`
- `npm.cmd run qa:intake-permissions`
- authenticated navigation assertions
- `npm.cmd run typecheck`
- production compilation completed; local page-data collection requires the intentionally absent `OPENAI_API_KEY`
