### PR TITLE
PR75: Make reminders practice-aware and add hormone updates

### DIFF
--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -68,6 +68,7 @@ export default function RoutineClient({
   const [editing, setEditing] = useState<RoutineItem | null>(null);
   const [showAdd, setShowAdd] = useState(false);
   const [showAddMedication, setShowAddMedication] = useState(false);
+  const [showAddHormone, setShowAddHormone] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [toast, setToast] = useState<ToastState>(null);
   const grouped = useMemo(() => groupRoutineItems(items), [items]);
@@ -103,11 +104,11 @@ export default function RoutineClient({
       await refreshRoutine();
       setEditing(null);
       setToast({
-        message: `${item.name} was updated.`,
+        message: `${item.name} was updated.${item.item_kind === "medication" || item.item_kind === "hormone" ? " Review your Blueprint after this change." : ""}`,
         undo: async () => {
           await updateItem(item.id, {
             ...previous,
-            ...(item.item_kind === "medication" && patch.instructionAuthority
+            ...((item.item_kind === "medication" || item.item_kind === "hormone") && patch.instructionAuthority
               ? { instructionAuthority: patch.instructionAuthority }
               : {}),
           });
@@ -123,9 +124,10 @@ export default function RoutineClient({
   }
 
   async function stopTracking(item: RoutineItem) {
-    if (item.item_kind === "medication") {
+    if (item.item_kind === "medication" || item.item_kind === "hormone") {
+      const label = item.item_kind === "hormone" ? "hormone therapy" : "medication";
       const confirmed = window.confirm(
-        "Only stop tracking this medication if it reflects your current prescribed list. LVE360 is not advising you to discontinue it."
+        `Only stop tracking this ${label} if it reflects your current prescribed list. LVE360 is not advising you to discontinue or change it.`
       );
       if (!confirmed) return;
     }
@@ -191,7 +193,7 @@ export default function RoutineClient({
             {latestStack?.created_at ? `, reviewed against your latest Blueprint from ${formatDate(latestStack.created_at)}` : ""}.
           </p>
         </div>
-        <div className="flex flex-col gap-2 sm:flex-row">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
           <button
             type="button"
             onClick={() => setShowAddMedication(true)}
@@ -199,6 +201,14 @@ export default function RoutineClient({
           >
             <Pill className="mr-2 h-5 w-5" aria-hidden="true" />
             Add a medication
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowAddHormone(true)}
+            className="inline-flex min-h-12 items-center justify-center rounded-xl border border-[#087F72] bg-white px-5 py-3 font-bold text-[#06695F] transition hover:bg-[#EAFBF8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
+          >
+            <TestTube2 className="mr-2 h-5 w-5" aria-hidden="true" />
+            Add a hormone
           </button>
           <button
             type="button"
@@ -254,13 +264,33 @@ export default function RoutineClient({
       ) : null}
 
       {showAddMedication ? (
-        <AddMedicationDialog
+        <AddPrescribedItemDialog
+          kind="medication"
           onClose={() => setShowAddMedication(false)}
           onAdded={async (itemName, addedId) => {
             await refreshRoutine();
             setShowAddMedication(false);
             setToast({
               message: `${itemName} was added as a medication you reported. Review your Blueprint after this change.`,
+              undo: async () => {
+                await updateItem(addedId, { active: false });
+                await refreshRoutine();
+                setToast({ message: `${itemName} was removed from your current routine.` });
+              },
+            });
+          }}
+        />
+      ) : null}
+
+      {showAddHormone ? (
+        <AddPrescribedItemDialog
+          kind="hormone"
+          onClose={() => setShowAddHormone(false)}
+          onAdded={async (itemName, addedId) => {
+            await refreshRoutine();
+            setShowAddHormone(false);
+            setToast({
+              message: `${itemName} was added as a hormone therapy you reported. Review your Blueprint after this change.`,
               undo: async () => {
                 await updateItem(addedId, { active: false });
                 await refreshRoutine();
@@ -367,7 +397,7 @@ function RoutineCard({
       </dl>
       {prescribedItem ? (
         <p className="mt-4 rounded-xl bg-white p-3 text-xs leading-5 text-slate-600">
-          LVE360 records what you report. It does not select or recommend prescription doses. Follow your medication label and clinician instructions.
+          LVE360 records what you report. It does not select or recommend prescription doses. Follow your prescription label and clinician instructions.
         </p>
       ) : null}
       <div className="mt-4 grid gap-2 sm:grid-cols-2">
@@ -377,7 +407,7 @@ function RoutineCard({
           onClick={() => onEdit(item)}
           className="inline-flex min-h-12 items-center justify-center rounded-xl border border-[#9DCFC3] bg-white px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
         >
-          <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> {item.item_kind === "medication" ? "Record prescribed change" : item.item_kind === "hormone" ? "Edit schedule" : "Edit details"}
+          <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> {prescribedItem ? "Record prescribed change" : "Edit details"}
         </button>
         <button
           type="button"
@@ -434,23 +464,22 @@ function IdeasSection({ items, busyId, onAdopt }: { items: RoutineItem[]; busyId
 }
 
 function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineItem; saving: boolean; onClose: () => void; onSave: (item: RoutineItem, patch: { dose?: string | null; timing: string | null; instructionAuthority?: MedicationInstructionAuthority }) => void }) {
-  const medication = item.item_kind === "medication";
-  const protectedDose = item.item_kind === "hormone";
+  const prescribedItem = item.item_kind === "medication" || item.item_kind === "hormone";
   const [dose, setDose] = useState(item.dose ?? "");
   const [timing, setTiming] = useState(item.timing ?? "");
   const [instructionAuthority, setInstructionAuthority] = useState<MedicationInstructionAuthority | "">(
     item.instruction_authority ?? ""
   );
   return (
-    <DialogShell title={medication ? `Record a prescribed change for ${item.name}` : protectedDose ? `Record ${item.name} schedule` : `Update ${item.name}`} onClose={onClose}>
+    <DialogShell title={prescribedItem ? `Record a prescribed change for ${item.name}` : `Update ${item.name}`} onClose={onClose}>
       <p className="text-sm leading-6 text-slate-600">
-        {medication
-          ? "Use this only to record a change you received from your clinician, pharmacist, or current medication label. LVE360 is not changing your prescription."
+        {prescribedItem
+          ? "Use this only to record a change you received from your clinician, pharmacist, or current prescription label. LVE360 is not changing or recommending your prescription."
           : "Record what you currently do. This does not create a medical instruction or replace a product label."}
       </p>
-      {!protectedDose ? <label className="mt-5 block text-sm font-bold text-[#041B2D]">Amount you take<input autoFocus value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, 2 capsules" /></label> : null}
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">When you take it<input autoFocus={protectedDose} value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, morning with breakfast" /></label>
-      {medication ? (
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">{prescribedItem ? "Prescribed dose" : "Amount you take"}<input autoFocus value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={item.item_kind === "hormone" ? "For example, 80 mg" : "For example, 2 capsules"} /></label>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">When you take it<input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, Monday and Thursday evenings" /></label>
+      {prescribedItem ? (
         <label className="mt-5 block text-sm font-bold text-[#041B2D]">
           Where did this instruction come from?
           <select value={instructionAuthority} onChange={(event) => setInstructionAuthority(event.target.value as MedicationInstructionAuthority)} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20">
@@ -459,10 +488,9 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
           </select>
         </label>
       ) : null}
-      {protectedDose ? <p className="mt-3 text-sm text-slate-600">Reported dose: <strong>{item.dose || "Dose not recorded"}</strong>. Hormone dose changes remain outside this tool.</p> : null}
       <div className="mt-6 grid gap-2 sm:grid-cols-2">
         <button type="button" onClick={onClose} disabled={saving} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
-        <button type="button" disabled={saving || (medication && !instructionAuthority)} onClick={() => onSave(item, { ...(protectedDose ? {} : { dose: dose.trim() || null }), timing: timing.trim() || null, ...(medication && instructionAuthority ? { instructionAuthority } : {}) })} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
+        <button type="button" disabled={saving || (prescribedItem && !instructionAuthority)} onClick={() => onSave(item, { dose: dose.trim() || null, timing: timing.trim() || null, ...(prescribedItem && instructionAuthority ? { instructionAuthority } : {}) })} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
           {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Save record
         </button>
       </div>
@@ -470,7 +498,7 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
   );
 }
 
-function AddMedicationDialog({ onClose, onAdded }: { onClose: () => void; onAdded: (name: string, id: string) => Promise<void> }) {
+function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication" | "hormone"; onClose: () => void; onAdded: (name: string, id: string) => Promise<void> }) {
   const [name, setName] = useState("");
   const [dose, setDose] = useState("");
   const [timing, setTiming] = useState("");
@@ -479,11 +507,13 @@ function AddMedicationDialog({ onClose, onAdded }: { onClose: () => void; onAdde
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function addMedication() {
+  const label = kind === "hormone" ? "hormone therapy" : "medication";
+
+  async function addPrescribedItem() {
     setBusy(true);
     setError(null);
     try {
-      const response = await fetch("/api/routine/medications", {
+      const response = await fetch(`/api/routine/${kind === "hormone" ? "hormones" : "medications"}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -495,24 +525,24 @@ function AddMedicationDialog({ onClose, onAdded }: { onClose: () => void; onAdde
         }),
       });
       const body = await response.json().catch(() => null);
-      if (!response.ok || !body?.ok || !body?.item?.id) throw new Error(body?.error ?? "medication_add_failed");
+      if (!response.ok || !body?.ok || !body?.item?.id) throw new Error(body?.error ?? `${kind}_add_failed`);
       await onAdded(name.trim(), body.item.id);
     } catch {
-      setError("We could not add that medication. Your routine is unchanged.");
+      setError(`We could not add that ${label}. Your routine is unchanged.`);
     } finally {
       setBusy(false);
     }
   }
 
   return (
-    <DialogShell title="Add a prescribed medication" onClose={onClose}>
+    <DialogShell title={`Add a prescribed ${label}`} onClose={onClose}>
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-950">
-        Record only what you currently take based on your clinician, pharmacist, or medication label. This does not ask LVE360 to recommend a medication or dose.
+        Record only what you currently take based on your clinician, pharmacist, or prescription label. This does not ask LVE360 to recommend a {label} or dose.
       </div>
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Medication name<input autoFocus value={name} onChange={(event) => setName(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, Zepbound" /></label>
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Prescribed dose<input value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, 10 mg / 0.5 mL" /></label>
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Schedule<input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, once weekly on Sunday" /></label>
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Purpose you were given <span className="font-normal text-slate-500">(optional)</span><input value={purpose} onChange={(event) => setPurpose(event.target.value)} maxLength={200} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, weight management" /></label>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">{kind === "hormone" ? "Hormone name" : "Medication name"}<input autoFocus value={name} onChange={(event) => setName(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, testosterone cypionate" : "For example, Zepbound"} /></label>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Prescribed dose<input value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, 80 mg" : "For example, 10 mg / 0.5 mL"} /></label>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Schedule<input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, Monday and Thursday evenings" : "For example, once weekly on Sunday"} /></label>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Purpose you were given <span className="font-normal text-slate-500">(optional)</span><input value={purpose} onChange={(event) => setPurpose(event.target.value)} maxLength={200} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, hormone replacement" : "For example, weight management"} /></label>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Where did this instruction come from?
         <select value={instructionAuthority} onChange={(event) => setInstructionAuthority(event.target.value as MedicationInstructionAuthority)} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20">
           <option value="">Choose a source</option>
@@ -522,8 +552,8 @@ function AddMedicationDialog({ onClose, onAdded }: { onClose: () => void; onAdde
       {error ? <p className="mt-4 rounded-xl bg-rose-50 p-3 text-sm font-semibold text-rose-800">{error}</p> : null}
       <div className="mt-6 grid gap-2 sm:grid-cols-2">
         <button type="button" onClick={onClose} disabled={busy} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
-        <button type="button" disabled={busy || !name.trim() || !instructionAuthority} onClick={() => void addMedication()} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
-          {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Add reported medication
+        <button type="button" disabled={busy || !name.trim() || !instructionAuthority} onClick={() => void addPrescribedItem()} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
+          {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Add reported {label}
         </button>
       </div>
     </DialogShell>

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -224,7 +224,7 @@ export default function SettingsPage() {
                   className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-[#041B2D] shadow-sm focus:border-[#047F6D] focus:ring-2 focus:ring-teal-100"
                 />
               </Field>
-              <Field label="Cue time" hint="When a short reminder is most useful.">
+              <Field label="Default cue time" hint="Used when a weekly practice does not have its own reminder plan.">
                 <HourSelect
                   value={account.cue_hour}
                   onChange={(cue_hour) => setAccount({ ...account, cue_hour })}

--- a/app/(app)/today/TodayClient.tsx
+++ b/app/(app)/today/TodayClient.tsx
@@ -11,10 +11,12 @@ export default function TodayClient({
   experiment,
   blueprint,
   experimentBlueprint,
+  checkinDate,
 }: {
   experiment: WeeklyExperiment | null;
   blueprint: CurrentBlueprintContext | null;
   experimentBlueprint: ExperimentBlueprintContext | null;
+  checkinDate: string | null;
 }) {
   useEffect(() => {
     fetch("/api/provision-user", { method: "POST" }).catch((error) => {
@@ -29,6 +31,7 @@ export default function TodayClient({
           initialExperiment={experiment}
           blueprint={blueprint}
           experimentBlueprint={experimentBlueprint}
+          initialCompletionDate={checkinDate}
         />
 
         <section id="daily-log" aria-label="Quick check-in">

--- a/app/(app)/today/page.tsx
+++ b/app/(app)/today/page.tsx
@@ -6,13 +6,16 @@ import GoalsTargetsEditor from "@/src/components/dashboard/GoalsTargetsEditor";
 import TodayClient from "./TodayClient";
 import type { WeeklyExperiment } from "@/lib/activation";
 import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
+import { parseLocalDate } from "@/lib/today";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-export default async function Page() {
+export default async function Page({ searchParams }: { searchParams: Promise<{ checkin?: string }> }) {
   // Keep your existing gating (premium or trial)
   await requireTier(["premium", "trial"]);
+  const params = await searchParams;
+  const checkinDate = parseLocalDate(params.checkin ?? null);
 
   // Server-side: fetch current user + goals (no changes to your client)
   const supabase = createServerComponentClient({ cookies });
@@ -53,6 +56,7 @@ export default async function Page() {
         experiment={activeExperiment}
         blueprint={blueprint}
         experimentBlueprint={activeExperiment ? experimentBlueprints[activeExperiment.id] ?? null : null}
+        checkinDate={checkinDate}
       />
 
       {(targetWeight == null && targetSleep == null && targetEnergy == null) ? (

--- a/app/api/activation/route.ts
+++ b/app/api/activation/route.ts
@@ -14,6 +14,7 @@ import { resolveBlueprintActionFromRequest } from "@/lib/blueprintActionHandoff"
 import { isHour, isIanaTimeZone } from "@/lib/accountSettings";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
+import { isReminderTiming } from "@/lib/reminderSchedule";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -27,6 +28,8 @@ type ActivationBody = {
   frequency_per_week?: unknown;
   minimum_version?: unknown;
   reminder_preference?: unknown;
+  reminder_timing?: unknown;
+  reminder_hour?: unknown;
   timezone?: unknown;
   cue_hour?: unknown;
 };
@@ -141,7 +144,7 @@ export async function PUT(req: NextRequest) {
     }
 
     const experiment = await getOrCreateExperiment(req, auth.user.id);
-    if (experiment.status === "active") {
+    if (experiment.status === "active" && step !== 5) {
       return NextResponse.json({ ok: true, experiment });
     }
 
@@ -191,10 +194,19 @@ export async function PUT(req: NextRequest) {
       if (body?.reminder_preference !== "none" && body?.reminder_preference !== "email") {
         return NextResponse.json({ ok: false, error: "choose_reminder_preference" }, { status: 400 });
       }
-      if (body.reminder_preference === "email" && (!isIanaTimeZone(body.timezone) || !isHour(body.cue_hour))) {
+      if (!isReminderTiming(body.reminder_timing)) {
+        return NextResponse.json({ ok: false, error: "choose_reminder_timing" }, { status: 400 });
+      }
+      const usesPracticeHour = body.reminder_preference === "email" && body.reminder_timing !== "account_default";
+      if (
+        body.reminder_preference === "email"
+        && (!isIanaTimeZone(body.timezone) || (usesPracticeHour && !isHour(body.reminder_hour)))
+      ) {
         return NextResponse.json({ ok: false, error: "choose_reminder_time" }, { status: 400 });
       }
       changes.reminder_preference = body.reminder_preference;
+      changes.reminder_timing = body.reminder_timing;
+      changes.reminder_hour = usesPracticeHour ? body.reminder_hour : null;
     }
 
     if (step === 6) {
@@ -241,7 +253,6 @@ export async function PUT(req: NextRequest) {
           reminder_preference: body?.reminder_preference,
           ...(body?.reminder_preference === "email" ? {
             timezone: body.timezone,
-            cue_hour: body.cue_hour,
           } : {}),
           updated_at: new Date().toISOString(),
         },

--- a/app/api/cron/reminders/route.ts
+++ b/app/api/cron/reminders/route.ts
@@ -3,10 +3,14 @@ import { NextResponse, type NextRequest } from "next/server";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
 import {
   addDays,
+  effectiveReminderHour,
   evaluateReminder,
   reminderIdempotencyKey,
   sendReminderEmail,
+  shouldLedgerSkip,
+  skippedReminderIdempotencyKey,
 } from "@/lib/reminders";
+import { isReminderTiming, type ReminderKind, type ReminderTiming } from "@/lib/reminderSchedule";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export const dynamic = "force-dynamic";
@@ -16,6 +20,11 @@ type ExperimentRow = {
   id: string;
   user_id: string;
   week_start: string;
+  action_label: string;
+  minimum_version: string;
+  frequency_per_week: number;
+  reminder_timing: ReminderTiming | null;
+  reminder_hour: number | null;
 };
 
 export async function GET(req: NextRequest) {
@@ -27,7 +36,7 @@ export async function GET(req: NextRequest) {
   const admin = getSupabaseAdmin();
   const { data: experiments, error } = await admin
     .from("weekly_experiments")
-    .select("id, user_id, week_start")
+    .select("id, user_id, week_start, action_label, minimum_version, frequency_per_week, reminder_timing, reminder_hour")
     .eq("status", "active")
     .eq("reminder_preference", "email")
     .limit(500);
@@ -117,30 +126,74 @@ export async function GET(req: NextRequest) {
         throw completionsError ?? reviewError;
       }
 
+      const timing = isReminderTiming(experiment.reminder_timing)
+        ? experiment.reminder_timing
+        : "account_default";
+      const cueHour = effectiveReminderHour(timing, experiment.reminder_hour, preference.cue_hour);
+      const completedDates = (completions ?? []).map((item) => item.completion_date);
       const evaluation = evaluateReminder({
         now,
         timezone: preference.timezone,
-        cueHour: preference.cue_hour,
+        cueHour,
         quietStartHour: preference.quiet_start_hour,
         quietEndHour: preference.quiet_end_hour,
         weekStart: experiment.week_start,
-        completedDates: (completions ?? []).map((item) => item.completion_date),
+        completedDates,
         reviewCompleted: review?.status === "completed",
+        targetCount: experiment.frequency_per_week ?? 1,
+        timing,
       });
       if (!evaluation.decision) {
         countSkip(evaluation.reason);
+        if (shouldLedgerSkip(evaluation.reason)) {
+          const skipKind: ReminderKind = evaluation.reason === "review_complete"
+            ? "weekly_review"
+            : timing === "next_day"
+              ? "next_day_checkin"
+              : "practice";
+          const skipKey = skippedReminderIdempotencyKey(
+            experiment.id,
+            evaluation.localDate,
+            evaluation.reason,
+          );
+          const { error: skipError } = await admin.from("reminder_deliveries").insert({
+            user_id: experiment.user_id,
+            experiment_id: experiment.id,
+            reminder_kind: skipKind,
+            reminder_timing: timing,
+            local_date: evaluation.localDate,
+            target_date: timing === "next_day" ? addDays(evaluation.localDate, -1) : evaluation.localDate,
+            idempotency_key: skipKey,
+            status: "skipped",
+            skip_reason: evaluation.reason,
+            attempted_at: new Date().toISOString(),
+          });
+          if (skipError && skipError.code !== "23505") {
+            console.error("[reminders] skip ledger failed", {
+              experimentId: experiment.id,
+              code: skipError.code,
+            });
+          }
+        }
         continue;
       }
       const decision = evaluation.decision;
 
-      const key = reminderIdempotencyKey(decision.kind, experiment.id, decision.localDate);
+      const key = reminderIdempotencyKey(
+        decision.kind,
+        experiment.id,
+        decision.localDate,
+        decision.targetDate,
+      );
       const { data: delivery, error: claimError } = await admin
         .from("reminder_deliveries")
         .insert({
           user_id: experiment.user_id,
           experiment_id: experiment.id,
           reminder_kind: decision.kind,
+          reminder_timing: timing,
           local_date: decision.localDate,
+          target_date: decision.targetDate,
           idempotency_key: key,
         })
         .select("id")
@@ -154,28 +207,33 @@ export async function GET(req: NextRequest) {
       const appUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://lve360.com").replace(/\/$/, "");
       const path = decision.kind === "weekly_review"
         ? `/review?experiment=${encodeURIComponent(experiment.id)}&source=reminder`
-        : `/today?experiment=${encodeURIComponent(experiment.id)}&source=reminder`;
+        : decision.kind === "next_day_checkin"
+          ? `/today?checkin=${encodeURIComponent(decision.targetDate)}&source=reminder`
+          : `/today?experiment=${encodeURIComponent(experiment.id)}&source=reminder`;
       const result = await sendReminderEmail({
         to: profile.email,
         kind: decision.kind,
+        timing,
+        actionLabel: experiment.action_label || "Your focused weekly practice",
+        minimumVersion: experiment.minimum_version || "Take the smallest useful step",
         deepLink: `${appUrl}${path}`,
         idempotencyKey: key,
       });
       await admin.from("reminder_deliveries").update({
         status: result.status,
-        provider_id: result.status === "sent" ? result.providerId : null,
+        provider_id: result.status === "accepted" ? result.providerId : null,
         attempted_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       }).eq("id", delivery.id);
 
       await recordProductEventSafely({
-        event_name: result.status === "sent" ? "reminder_sent" : "reminder_failed",
+        event_name: result.status === "accepted" ? "reminder_sent" : "reminder_failed",
         source: "reminders",
         user_id: experiment.user_id,
         experiment_id: experiment.id,
         event_key: `${key}:${result.status}`,
       });
-      if (result.status === "sent") sent += 1;
+      if (result.status === "accepted") sent += 1;
       else countFailure(`email_${result.reason}`);
     } catch (dispatchError) {
       countFailure("dispatch_error");

--- a/app/api/routine/hormones/route.ts
+++ b/app/api/routine/hormones/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+import { upsertReportedHormone } from "@/lib/currentRegimen";
+import { normalizeHormoneRecordInput } from "@/lib/medicationRecord";
+import { requirePaidApi } from "@/lib/serverEntitlements";
+
+export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  try {
+    const input = normalizeHormoneRecordInput(await req.json().catch(() => null));
+    const item = await upsertReportedHormone(entitlement.user.id, input);
+    return NextResponse.json({ ok: true, item });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "hormone_add_failed";
+    const invalid = /required|invalid/.test(message);
+    return NextResponse.json({ ok: false, error: message }, { status: invalid ? 400 : 500 });
+  }
+}

--- a/app/api/stacks/update/route.ts
+++ b/app/api/stacks/update/route.ts
@@ -24,21 +24,16 @@ export async function POST(req: Request) {
 
     if (existingError) return NextResponse.json({ ok: false, error: existingError.message }, { status: 400 });
     if (!existing) return NextResponse.json({ ok: false, error: "regimen_item_not_found" }, { status: 404 });
-    if (typeof dose !== "undefined" && existing.item_kind === "hormone") {
-      return NextResponse.json(
-        { ok: false, error: "dose_updates_unavailable_for_hormones" },
-        { status: 400 },
-      );
-    }
-    const changesMedicationInstructions = existing.item_kind === "medication"
+    const prescribedItem = existing.item_kind === "medication" || existing.item_kind === "hormone";
+    const changesPrescribedInstructions = prescribedItem
       && [purpose, dose, timing].some((value) => typeof value !== "undefined");
-    if (changesMedicationInstructions && !isMedicationInstructionAuthority(instructionAuthority)) {
+    if (changesPrescribedInstructions && !isMedicationInstructionAuthority(instructionAuthority)) {
       return NextResponse.json(
-        { ok: false, error: "medication_instruction_source_required" },
+        { ok: false, error: `${existing.item_kind}_instruction_source_required` },
         { status: 400 },
       );
     }
-    if (typeof instructionAuthority !== "undefined" && existing.item_kind !== "medication") {
+    if (typeof instructionAuthority !== "undefined" && !prescribedItem) {
       return NextResponse.json({ ok: false, error: "instruction_source_not_supported" }, { status: 400 });
     }
 
@@ -50,7 +45,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: "no_supported_changes" }, { status: 400 });
     }
     patch.instruction_source = "member_update";
-    if (changesMedicationInstructions) patch.instruction_authority = instructionAuthority;
+    if (changesPrescribedInstructions) patch.instruction_authority = instructionAuthority;
     patch.updated_at = new Date().toISOString();
 
     const { data, error } = await admin

--- a/app/api/webhooks/resend/route.ts
+++ b/app/api/webhooks/resend/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { Webhook } from "svix";
+
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+
+type ReminderProviderEvent = {
+  type?: string;
+  created_at?: string;
+  data?: { email_id?: string };
+};
+
+const STATUS_BY_EVENT: Record<string, "delivered" | "bounced" | "failed"> = {
+  "email.delivered": "delivered",
+  "email.bounced": "bounced",
+  "email.failed": "failed",
+};
+
+export async function POST(req: NextRequest) {
+  const webhookSecret = process.env.RESEND_WEBHOOK_SECRET?.trim();
+  if (!webhookSecret) {
+    return NextResponse.json({ ok: false, error: "webhook_not_configured" }, { status: 503 });
+  }
+
+  try {
+    const payload = await req.text();
+    const event = new Webhook(webhookSecret).verify(payload, {
+      "svix-id": req.headers.get("svix-id") ?? "",
+      "svix-timestamp": req.headers.get("svix-timestamp") ?? "",
+      "svix-signature": req.headers.get("svix-signature") ?? "",
+    }) as ReminderProviderEvent;
+
+    const status = event.type ? STATUS_BY_EVENT[event.type] : null;
+    const providerId = event.data?.email_id;
+    if (!status || !providerId) return NextResponse.json({ ok: true, ignored: true });
+
+    const { error } = await getSupabaseAdmin()
+      .from("reminder_deliveries")
+      .update({
+        status,
+        provider_event_type: event.type,
+        provider_event_at: event.created_at ?? new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("provider_id", providerId);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[resend-webhook] invalid or failed event", error);
+    return NextResponse.json({ ok: false, error: "invalid_webhook" }, { status: 400 });
+  }
+}

--- a/app/onboarding/OnboardingHandoffClient.tsx
+++ b/app/onboarding/OnboardingHandoffClient.tsx
@@ -12,6 +12,7 @@ import {
   type ReminderPreference,
   type WeeklyExperiment,
 } from "@/lib/activation";
+import type { ReminderTiming } from "@/lib/reminderSchedule";
 
 type FormState = {
   identity_direction: IdentityDirection | null;
@@ -20,8 +21,9 @@ type FormState = {
   frequency_per_week: number;
   minimum_version: string;
   reminder_preference: ReminderPreference;
+  reminder_timing: ReminderTiming;
+  reminder_hour: number;
   timezone: string;
-  cue_hour: number;
 };
 
 const EMPTY_FORM: FormState = {
@@ -31,8 +33,9 @@ const EMPTY_FORM: FormState = {
   frequency_per_week: 3,
   minimum_version: "",
   reminder_preference: "none",
+  reminder_timing: "at_cue",
+  reminder_hour: 18,
   timezone: "UTC",
-  cue_hour: 18,
 };
 
 export default function OnboardingHandoffClient() {
@@ -79,7 +82,7 @@ export default function OnboardingHandoffClient() {
       if (!response.ok || !json?.experiment) throw new Error(errorMessage(json?.error));
       const updated = json.experiment as WeeklyExperiment;
       setExperiment(updated);
-      setForm({ ...formFromExperiment(updated), timezone: form.timezone, cue_hour: form.cue_hour });
+      setForm({ ...formFromExperiment(updated), timezone: form.timezone });
       if (step < 6) setStep(step + 1);
     } catch (saveError: any) {
       setError(saveError?.message ?? "We could not save that step. Please try again.");
@@ -106,7 +109,7 @@ export default function OnboardingHandoffClient() {
           <p className="mt-1 text-sm text-slate-500">About three minutes</p>
         </div>
         <div className="text-right">
-          <p className="text-sm font-semibold text-[#041B2D]">{active ? "Ready" : `Step ${step} of 6`}</p>
+          <p className="text-sm font-semibold text-[#041B2D]">{active && step === 6 ? "Ready" : `Step ${step} of 6`}</p>
           <div className="mt-2 flex gap-1" aria-label={`Step ${step} of 6`}>
             {[1, 2, 3, 4, 5, 6].map((item) => <span key={item} className={`h-1.5 w-7 rounded-full ${item <= step ? "bg-[#08A88A]" : "bg-slate-200"}`} />)}
           </div>
@@ -119,13 +122,14 @@ export default function OnboardingHandoffClient() {
       {step === 4 && <MinimumStep value={form.minimum_version} action={form.action_label} onChange={(minimum_version) => setForm({ ...form, minimum_version })} />}
       {step === 5 && (
         <ReminderStep
-          value={form.reminder_preference}
-          cueHour={form.cue_hour}
+          preference={form.reminder_preference}
+          timing={form.reminder_timing}
+          reminderHour={form.reminder_hour}
           timezone={form.timezone}
           onChange={(changes) => setForm({ ...form, ...changes })}
         />
       )}
-      {step === 6 && <ConfirmationStep form={form} active={active} />}
+      {step === 6 && <ConfirmationStep form={form} active={active} onEditReminders={() => setStep(5)} />}
 
       {error && <p className="mt-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">{error}</p>}
 
@@ -135,12 +139,12 @@ export default function OnboardingHandoffClient() {
             <ArrowLeft className="mr-2 h-4 w-4" /> Back
           </button>
         ) : <span />}
-        {active ? (
+        {active && step === 6 ? (
           <a href="/today" className="inline-flex items-center justify-center rounded-xl bg-[#08A88A] px-6 py-3 font-bold text-white shadow-sm hover:bg-[#078B74]">Open Today <ArrowRight className="ml-2 h-5 w-5" /></a>
         ) : (
           <button type="button" onClick={saveStep} disabled={saving} className="inline-flex items-center justify-center rounded-xl bg-[#08A88A] px-6 py-3 font-bold text-white shadow-sm hover:bg-[#078B74] disabled:opacity-60">
             {saving ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : null}
-            {step === 6 ? "Start my week" : "Save and continue"} <ArrowRight className="ml-2 h-5 w-5" />
+            {active && step === 5 ? "Save reminder plan" : step === 6 ? "Start my week" : "Save and continue"} <ArrowRight className="ml-2 h-5 w-5" />
           </button>
         )}
       </div>
@@ -173,49 +177,63 @@ function MinimumStep({ value, action, onChange }: { value: string; action: strin
 }
 
 function ReminderStep({
-  value,
-  cueHour,
+  preference,
+  timing,
+  reminderHour,
   timezone,
   onChange,
 }: {
-  value: ReminderPreference;
-  cueHour: number;
+  preference: ReminderPreference;
+  timing: ReminderTiming;
+  reminderHour: number;
   timezone: string;
-  onChange: (changes: Partial<Pick<FormState, "reminder_preference" | "cue_hour">>) => void;
+  onChange: (changes: Partial<Pick<FormState, "reminder_preference" | "reminder_timing" | "reminder_hour">>) => void;
 }) {
+  const options: Array<{
+    preference: ReminderPreference;
+    timing: ReminderTiming;
+    title: string;
+    copy: string;
+    defaultHour?: number;
+  }> = [
+    { preference: "email", timing: "prepare_before", title: "Help me prepare beforehand", copy: "Send a setup cue before the moment so the practice is easier later.", defaultHour: 20 },
+    { preference: "email", timing: "at_cue", title: "Remind me at the cue", copy: "Send the practice and its minimum version when I plan to act.", defaultHour: 18 },
+    { preference: "email", timing: "next_day", title: "Check in the next morning", copy: "Useful for bedtime or phone-free practices. Record it the next day without reopening your phone afterward.", defaultHour: 8 },
+    { preference: "none", timing: "at_cue", title: "No reminder for this practice", copy: "I will use my own cue and dashboard." },
+  ];
   return (
     <section>
       <Mail className="h-8 w-8 text-[#08A88A]" />
-      <h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">How should we support you?</h1>
-      <p className="mt-3 leading-7 text-slate-600">Choose whether a small email cue would help. You can change or turn it off anytime.</p>
+      <h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">When would support actually help?</h1>
+      <p className="mt-3 leading-7 text-slate-600">Match the email to this practice. A bedtime habit can use an earlier preparation cue or a next-morning check-in so your phone stays out of the routine.</p>
       <div className="mt-6 grid gap-3">
-        {[
-          { value: "email" as const, title: "Helpful email cues", copy: "Practice, gentle restart, and weekly review reminders." },
-          { value: "none" as const, title: "No reminders", copy: "I will use my own cue and dashboard." },
-        ].map((option) => (
-          <button key={option.value} type="button" onClick={() => onChange({ reminder_preference: option.value })} aria-pressed={value === option.value} className={`flex items-center justify-between rounded-2xl border p-5 text-left ${value === option.value ? "border-[#08A88A] bg-[#EAFBF8]" : "border-slate-200 hover:border-[#9DCFC3]"}`}>
+        {options.map((option) => {
+          const selected = preference === option.preference && (option.preference === "none" || timing === option.timing);
+          return (
+          <button key={`${option.preference}:${option.timing}`} type="button" onClick={() => onChange({ reminder_preference: option.preference, reminder_timing: option.timing, ...(option.defaultHour ? { reminder_hour: option.defaultHour } : {}) })} aria-pressed={selected} className={`flex items-center justify-between rounded-2xl border p-5 text-left ${selected ? "border-[#08A88A] bg-[#EAFBF8]" : "border-slate-200 hover:border-[#9DCFC3]"}`}>
             <span><span className="block font-bold text-[#041B2D]">{option.title}</span><span className="mt-1 block text-sm text-slate-600">{option.copy}</span></span>
-            {value === option.value ? <Check className="h-5 w-5 text-[#087F72]" /> : null}
+            {selected ? <Check className="h-5 w-5 text-[#087F72]" /> : null}
           </button>
-        ))}
+        )})}
       </div>
-      {value === "email" && (
+      {preference === "email" && timing !== "account_default" && (
         <label className="mt-5 block text-sm font-bold text-[#041B2D]">
-          Send around
-          <select value={cueHour} onChange={(event) => onChange({ cue_hour: Number(event.target.value) })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal">
-            {Array.from({ length: 15 }, (_, index) => index + 7).map((hour) => (
+          {timing === "next_day" ? "Check in around" : timing === "prepare_before" ? "Help me prepare around" : "Send at"}
+          <select value={reminderHour} onChange={(event) => onChange({ reminder_hour: Number(event.target.value) })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal">
+            {Array.from({ length: 14 }, (_, index) => index + 7).map((hour) => (
               <option key={hour} value={hour}>{new Intl.DateTimeFormat("en-US", { hour: "numeric", timeZone: "UTC" }).format(new Date(Date.UTC(2026, 0, 1, hour)))}</option>
             ))}
           </select>
-          <span className="mt-2 block font-normal text-slate-500">Local time in {timezone}. Quiet hours default to 9 PM through 7 AM.</span>
+          <span className="mt-2 block font-normal text-slate-500">Local time in {timezone}. We keep emails outside your 9 PM through 7 AM quiet window.</span>
         </label>
       )}
+      {preference === "email" && timing === "account_default" ? <p className="mt-5 rounded-xl bg-slate-50 p-4 text-sm text-slate-600">This existing practice uses your account default time. Choose another option above to tailor it.</p> : null}
     </section>
   );
 }
 
-function ConfirmationStep({ form, active }: { form: FormState; active: boolean }) {
-  return <section><CheckCircle2 className="h-10 w-10 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">{active ? "Your week is active" : "Your first week is ready"}</h1><p className="mt-3 leading-7 text-slate-600">This is one vote for the person you are becoming. Keep it small, notice what works, and review after the week.</p><div className="mt-6 space-y-4 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5"><Summary label="Identity" value={identityLabel(form.identity_direction)} /><Summary label="This week I will" value={form.action_label} /><Summary label="My cue" value={`After I ${form.cue}`} /><Summary label="Target" value={`${form.frequency_per_week} ${form.frequency_per_week === 1 ? "day" : "days"} this week`} /><Summary label="On a hard day" value={form.minimum_version} /></div></section>;
+function ConfirmationStep({ form, active, onEditReminders }: { form: FormState; active: boolean; onEditReminders: () => void }) {
+  return <section><CheckCircle2 className="h-10 w-10 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">{active ? "Your week is active" : "Your first week is ready"}</h1><p className="mt-3 leading-7 text-slate-600">This is one vote for the person you are becoming. Keep it small, notice what works, and review after the week.</p><div className="mt-6 space-y-4 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5"><Summary label="Identity" value={identityLabel(form.identity_direction)} /><Summary label="This week I will" value={form.action_label} /><Summary label="My cue" value={`After I ${form.cue}`} /><Summary label="Target" value={`${form.frequency_per_week} ${form.frequency_per_week === 1 ? "day" : "days"} this week`} /><Summary label="On a hard day" value={form.minimum_version} /><Summary label="Reminder plan" value={reminderSummary(form)} /></div>{active ? <button type="button" onClick={onEditReminders} className="mt-5 min-h-11 rounded-xl border border-[#9DCFC3] px-4 py-2 font-bold text-[#087F72] hover:bg-[#EAFBF8]">Change reminder plan</button> : null}</section>;
 }
 
 function Summary({ label, value }: { label: string; value: string }) {
@@ -230,8 +248,9 @@ function formFromExperiment(experiment: WeeklyExperiment): FormState {
     frequency_per_week: experiment.frequency_per_week ?? 3,
     minimum_version: experiment.minimum_version ?? "",
     reminder_preference: experiment.reminder_preference ?? "none",
+    reminder_timing: experiment.reminder_timing ?? "account_default",
+    reminder_hour: experiment.reminder_hour ?? 18,
     timezone: "UTC",
-    cue_hour: 18,
   };
 }
 
@@ -243,8 +262,9 @@ function payloadForStep(step: number, form: FormState) {
   if (step === 5) return {
     step,
     reminder_preference: form.reminder_preference,
+    reminder_timing: form.reminder_timing,
+    reminder_hour: form.reminder_hour,
     timezone: form.timezone,
-    cue_hour: form.cue_hour,
   };
   return { step: 6 };
 }
@@ -254,7 +274,18 @@ function errorMessage(code: string | undefined) {
   if (code === "choose_safe_lifestyle_action") return "Choose a lifestyle action. Supplement and medication changes stay in your Blueprint for professional review.";
   if (code === "add_cue_and_frequency") return "Add a clear cue and choose how many days you want to practice.";
   if (code === "add_safe_minimum_version") return "Add a small lifestyle version that can count on a hard day.";
+  if (code === "choose_reminder_timing") return "Choose when reminder support would be useful for this practice.";
   if (code === "choose_reminder_time") return "Choose a valid local reminder time.";
   if (code === "complete_required_steps") return "One of the earlier steps is incomplete. Go back and review your plan.";
   return "We could not save that step. Please try again.";
+}
+
+function reminderSummary(form: FormState): string {
+  if (form.reminder_preference === "none") return "No email for this practice";
+  if (form.reminder_timing === "account_default") return "Use my account default";
+  const time = new Intl.DateTimeFormat("en-US", { hour: "numeric", timeZone: "UTC" })
+    .format(new Date(Date.UTC(2026, 0, 1, form.reminder_hour)));
+  if (form.reminder_timing === "prepare_before") return `Prepare beforehand around ${time}`;
+  if (form.reminder_timing === "next_day") return `Check in the next morning around ${time}`;
+  return `Remind me at the cue around ${time}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "remark-html": "^16.0.1",
         "resend": "^6.0.3",
         "stripe": "^16.12.0",
+        "svix": "1.99.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -1087,6 +1088,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -2644,6 +2651,12 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -5018,6 +5031,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -5095,6 +5118,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.99.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.99.1.tgz",
+      "integrity": "sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "qa:current-regimen": "node src/_tests_/currentRegimen.assert.mjs",
     "qa:routine": "node --experimental-strip-types src/_tests_/routine.assert.ts && node src/_tests_/routinePage.assert.mjs",
     "qa:pr74": "node --experimental-strip-types src/_tests_/pr74.assert.ts && node src/_tests_/pr74Page.assert.mjs",
+    "qa:pr75": "node --experimental-strip-types src/_tests_/pr75.assert.ts && node src/_tests_/pr75Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"
@@ -52,6 +53,7 @@
     "remark-html": "^16.0.1",
     "resend": "^6.0.3",
     "stripe": "^16.12.0",
+    "svix": "1.99.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/src/_tests_/pr74Page.assert.mjs
+++ b/src/_tests_/pr74Page.assert.mjs
@@ -32,10 +32,10 @@ const routine = read("app/(app)/routine/RoutineClient.tsx");
 const migration = read("supabase/migrations/20260801182027_pr74_medication_instruction_authority.sql");
 assert.match(medicationRoute, /normalizeMedicationRecordInput/, "New medications must use the strict provenance validator.");
 assert.match(medicationRoute, /upsertReportedMedication/, "New medications must enter the canonical regimen.");
-assert.match(updateRoute, /medication_instruction_source_required/, "Medication updates must require provenance.");
-assert.match(updateRoute, /existing\.item_kind === "hormone"/, "Hormone dose edits must remain blocked.");
-assert.match(routine, /Add a prescribed medication/, "Routine must let members add a new medication.");
-assert.match(routine, /LVE360 is not advising you to discontinue it/, "Stop tracking must not imply discontinuation advice.");
+assert.match(updateRoute, /instruction_source_required/, "Prescribed-item updates must require provenance.");
+assert.match(updateRoute, /prescribedItem/, "Prescribed regimen edits must retain the provenance gate.");
+assert.match(routine, /Add a medication/, "Routine must let members add a new medication.");
+assert.match(routine, /LVE360 is not advising you to discontinue or change it/, "Stop tracking must not imply discontinuation advice.");
 assert.match(routine, /Review your Blueprint after this change/, "Medication changes must point members back to Blueprint review.");
 assert.match(migration, /instruction_authority in \('clinician', 'pharmacist', 'medication_label'\)/, "Medication provenance must be constrained in Postgres.");
 

--- a/src/_tests_/pr75.assert.ts
+++ b/src/_tests_/pr75.assert.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+
+import { normalizeHormoneRecordInput } from "../lib/medicationRecord.ts";
+import { evaluateReminder, reminderIdempotencyKey } from "../lib/reminderSchedule.ts";
+
+const base = {
+  timezone: "America/Denver",
+  cueHour: 8,
+  quietStartHour: 21,
+  quietEndHour: 7,
+  weekStart: "2026-08-03",
+  completedDates: [] as string[],
+  reviewCompleted: false,
+  targetCount: 3,
+};
+
+const nextDay = evaluateReminder({
+  ...base,
+  timing: "next_day",
+  now: new Date("2026-08-04T14:15:00.000Z"),
+});
+assert.equal(nextDay.decision?.kind, "next_day_checkin");
+assert.equal(nextDay.decision?.targetDate, "2026-08-03");
+
+const completedYesterday = evaluateReminder({
+  ...base,
+  timing: "next_day",
+  completedDates: ["2026-08-03"],
+  now: new Date("2026-08-04T14:15:00.000Z"),
+});
+assert.equal(completedYesterday.decision, null);
+assert.equal(completedYesterday.reason, "completed_target");
+
+const targetMet = evaluateReminder({
+  ...base,
+  timing: "at_cue",
+  completedDates: ["2026-08-03", "2026-08-04", "2026-08-05"],
+  now: new Date("2026-08-06T14:15:00.000Z"),
+});
+assert.equal(targetMet.decision, null);
+assert.equal(targetMet.reason, "target_met");
+
+assert.equal(
+  reminderIdempotencyKey("next_day_checkin", "experiment-1", "2026-08-04", "2026-08-03"),
+  "reminder:next_day_checkin:experiment-1:2026-08-04:2026-08-03",
+);
+
+const hormone = normalizeHormoneRecordInput({
+  name: "Testosterone cypionate",
+  dose: "80 mg",
+  timing: "Monday and Thursday evenings",
+  purpose: "Hormone replacement",
+  instruction_authority: "clinician",
+});
+assert.equal(hormone.name, "Testosterone cypionate");
+assert.equal(hormone.instruction_authority, "clinician");
+assert.throws(
+  () => normalizeHormoneRecordInput({ name: "Testosterone", instruction_authority: "lve360" }),
+  /hormone_instruction_source_required/,
+);
+
+console.log("PR75 schedule and hormone assertions passed");

--- a/src/_tests_/pr75Page.assert.mjs
+++ b/src/_tests_/pr75Page.assert.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(path, "utf8");
+const onboarding = read("app/onboarding/OnboardingHandoffClient.tsx");
+const cron = read("app/api/cron/reminders/route.ts");
+const reminderEmail = read("src/lib/reminders.ts");
+const webhook = read("app/api/webhooks/resend/route.ts");
+const routine = read("app/(app)/routine/RoutineClient.tsx");
+const hormoneRoute = read("app/api/routine/hormones/route.ts");
+const updateRoute = read("app/api/stacks/update/route.ts");
+const today = read("src/components/dashboard/TodayExperience.tsx");
+const migration = read("supabase/migrations/20260801192204_pr75_practice_aware_reminders.sql");
+
+assert.match(onboarding, /Help me prepare beforehand/, "Members must be able to prepare before a practice.");
+assert.match(onboarding, /Check in the next morning/, "Members must be able to protect phone-free bedtime practices.");
+assert.match(onboarding, /Change reminder plan/, "An active practice must remain editable.");
+assert.match(cron, /target_date/, "Next-day reminders must retain the practice date they refer to.");
+assert.match(cron, /shouldLedgerSkip/, "Meaningful reminder skips must be observable.");
+assert.match(reminderEmail, /Your practice:/, "Reminder email must name the exact practice.");
+assert.match(reminderEmail, /Minimum version:/, "Reminder email must include the minimum version.");
+assert.match(webhook, /new Webhook\(webhookSecret\)\.verify/, "Resend events must be signature verified.");
+assert.match(webhook, /email\.delivered/, "Delivered reminder status must be observable.");
+assert.match(webhook, /email\.bounced/, "Bounced reminder status must be observable.");
+assert.match(today, /Phone-free check-in:/, "Next-day links must support recording the prior practice date.");
+assert.match(routine, /Add a hormone/, "Routine must let members add a hormone therapy.");
+assert.match(routine, /kind="hormone"/, "Hormones must use the prescribed-item workflow.");
+assert.match(hormoneRoute, /normalizeHormoneRecordInput/, "New hormones must use strict provenance validation.");
+assert.match(updateRoute, /existing\.item_kind === "hormone"/, "Hormone changes must be treated as prescribed instructions.");
+assert.match(migration, /reminder_timing in \('account_default', 'prepare_before', 'at_cue', 'next_day'\)/, "Reminder intent must be constrained in Postgres.");
+assert.match(migration, /status in \('queued', 'accepted', 'delivered', 'bounced', 'failed', 'skipped'\)/, "Reminder outcomes must be constrained and observable.");
+
+console.log("PR75 page, reminder, and hormone assertions passed");

--- a/src/_tests_/reminders.assert.mjs
+++ b/src/_tests_/reminders.assert.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const reminders = fs.readFileSync("src/lib/reminders.ts", "utf8");
+const schedule = fs.readFileSync("src/lib/reminderSchedule.ts", "utf8");
 const cron = fs.readFileSync("app/api/cron/reminders/route.ts", "utf8");
 const settings = fs.readFileSync("app/(app)/settings/page.tsx", "utf8");
 const onboarding = fs.readFileSync("app/onboarding/OnboardingHandoffClient.tsx", "utf8");
@@ -15,14 +16,14 @@ assert.match(cron, /skipReasons/, "Cron route must report non-sensitive skip rea
 assert.match(cron, /failureReasons/, "Cron route must distinguish lookup failures from opt-outs");
 assert.match(cron, /preference_lookup_failed/, "Preference query failures must not be treated as opt-outs");
 assert.match(cron, /user_preferences[\s\S]*limit\(1\)/, "Preference lookup must use a bounded collection result");
-assert.match(reminders, /evaluateReminder/, "Reminder decisions must expose a testable reason");
+assert.match(schedule, /evaluateReminder/, "Reminder decisions must expose a testable reason");
 assert.match(reminders, /Missing a day is information, not failure/, "Recovery language must be nonjudgmental");
-assert.match(reminders, /isQuietHour/, "Dispatcher must respect quiet hours");
-assert.match(reminders, /weekly_review[\s\S]*:due/, "A weekly review cue must only send once per experiment");
+assert.match(schedule, /isQuietHour/, "Dispatcher must respect quiet hours");
+assert.match(schedule, /weekly_review[\s\S]*:due/, "A weekly review cue must only send once per experiment");
 assert.match(settings, /My timezone/, "Settings must expose reminder timezone");
 assert.match(settings, /No email reminders/, "Settings must retain an explicit opt-out");
 assert.match(onboarding, /resolvedOptions\(\)\.timeZone/, "Opt-in must capture the member's device timezone");
-assert.match(onboarding, /cue_hour/, "Opt-in must capture a local cue hour");
+assert.match(onboarding, /reminder_hour/, "Opt-in must capture a local practice reminder hour");
 assert.match(migration, /enable row level security/i, "Reminder ledger must enable RLS");
 assert.match(migration, /idempotency_key text not null unique/i, "Reminder ledger must prevent duplicates");
 assert.match(workflow, /cron: "5 \* \* \* \*"/, "Reminder workflow must run hourly");

--- a/src/_tests_/routinePage.assert.mjs
+++ b/src/_tests_/routinePage.assert.mjs
@@ -23,14 +23,14 @@ assert.match(routineModel, /supplement: "Supplements"/, "Routine must separate s
 assert.match(routineModel, /endocrine_active_supplement: "Hormone-active items"/, "Routine must separate hormone-active items.");
 assert.match(client, /Ideas to consider/, "Routine must separate proposed ideas.");
 assert.match(client, /Record prescribed change/, "Members must be able to record clinician-directed medication changes.");
-assert.match(client, /Hormone dose changes remain outside this tool/, "Hormone dose changes must remain unavailable.");
+assert.match(client, /kind="hormone"/, "Members must be able to record clinician-directed hormone changes.");
 assert.match(client, /Schedule not recorded/, "Missing schedules must be stated plainly.");
 assert.match(client, /RotateCcw[\s\S]*Undo/, "State changes must expose text and icon Undo.");
 assert.match(client, /min-h-12/, "Primary mobile controls must use large tap targets.");
 assert.match(routineModel, /source_type === "blueprint_proposal"/, "Proposal grouping must not depend on historical current flags.");
 const updateRoute = read("app/api/stacks/update/route.ts");
-assert.match(updateRoute, /dose_updates_unavailable_for_hormones/, "Protected hormone dose edits must also be rejected by the API.");
-assert.match(updateRoute, /medication_instruction_source_required/, "Medication edits must preserve their instruction source.");
+assert.match(updateRoute, /changesPrescribedInstructions/, "Medication and hormone instruction changes must share the provenance gate.");
+assert.match(updateRoute, /instruction_source_required/, "Prescribed-item edits must preserve their instruction source.");
 
 const today = read("app/(app)/today/TodayClient.tsx");
 assert.doesNotMatch(today, /Disclosure|details|summary/, "Today must not retain the collapsed regimen manager.");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -34,10 +34,12 @@ export default function TodayExperience({
   initialExperiment,
   blueprint,
   experimentBlueprint,
+  initialCompletionDate,
 }: {
   initialExperiment: WeeklyExperiment | null;
   blueprint: CurrentBlueprintContext | null;
   experimentBlueprint: ExperimentBlueprintContext | null;
+  initialCompletionDate: string | null;
 }) {
   const [localDate, setLocalDate] = useState("");
   const [experiment, setExperiment] = useState(initialExperiment);
@@ -48,7 +50,7 @@ export default function TodayExperience({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const date = toLocalDate(new Date());
+    const date = initialCompletionDate ?? toLocalDate(new Date());
     setLocalDate(date);
     if (!initialExperiment) {
       setLoadingState(false);
@@ -75,7 +77,7 @@ export default function TodayExperience({
         if (!cancelled) setLoadingState(false);
       });
     return () => { cancelled = true; };
-  }, [initialExperiment]);
+  }, [initialExperiment, initialCompletionDate]);
 
   const todayCompletion = useMemo(
     () => completions.find((item) => item.completion_date === localDate) ?? null,
@@ -142,6 +144,7 @@ export default function TodayExperience({
   }
 
   const target = experiment.frequency_per_week ?? 1;
+  const recordingPastDate = !!initialCompletionDate && initialCompletionDate !== toLocalDate(new Date());
   const targetMet = completedCount >= target;
   const reviewDue = !!localDate && isReviewDue(experiment.week_start, localDate);
   const weekEnded = !!localDate && localDate > reviewDueDate(experiment.week_start);
@@ -187,6 +190,11 @@ export default function TodayExperience({
       ) : null}
 
       <div className="p-6 sm:p-8">
+        {recordingPastDate ? (
+          <div className="mb-6 rounded-2xl border border-violet-200 bg-violet-50 p-4 text-sm leading-6 text-violet-950">
+            <strong>Phone-free check-in:</strong> Record whether the practice happened on {formatCheckinDate(localDate)}. You did not need to reopen LVE360 after the habit.
+          </div>
+        ) : null}
         {blueprint ? <CurrentBlueprintPanel blueprint={blueprint} experimentBlueprint={experimentBlueprint} /> : null}
         <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-2xl">
@@ -223,7 +231,7 @@ export default function TodayExperience({
                 <CheckCircle2 className="mt-0.5 h-6 w-6 shrink-0 text-[#087F72]" />
                 <div>
                   <p className="font-bold text-[#041B2D]">
-                    {todayCompletion.completion_kind === "minimum" ? "Your minimum version counts." : "Today's practice is complete."}
+                    {todayCompletion.completion_kind === "minimum" ? "Your minimum version counts." : recordingPastDate ? "That practice is recorded." : "Today's practice is complete."}
                   </p>
                   <p className="mt-1 text-sm text-slate-600">You kept the promise small and moved your identity forward.</p>
                 </div>
@@ -242,7 +250,7 @@ export default function TodayExperience({
           ) : (
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
               <button onClick={() => saveCompletion("full")} disabled={busy || !localDate} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#08A88A] px-6 py-3 text-base font-bold text-white shadow-sm hover:bg-[#078B74] disabled:opacity-60">
-                {busy ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : <Check className="mr-2 h-5 w-5" />} I did it today
+                {busy ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : <Check className="mr-2 h-5 w-5" />} {recordingPastDate ? "I did it that day" : "I did it today"}
               </button>
               <button onClick={() => saveCompletion("minimum")} disabled={busy || !localDate} className="min-h-12 rounded-xl border border-[#9DCFC3] px-5 py-3 text-sm font-bold text-[#087F72] hover:bg-[#F4FAF8] disabled:opacity-60">
                 I did the minimum version
@@ -331,6 +339,11 @@ function toLocalDate(date: Date): string {
 
 function formatBlueprintDate(value: string): string {
   return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
+}
+
+function formatCheckinDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", { weekday: "long", month: "short", day: "numeric", timeZone: "UTC" })
+    .format(new Date(`${value}T12:00:00.000Z`));
 }
 
 function weekdayLabel(date: string): string {

--- a/src/lib/activation.ts
+++ b/src/lib/activation.ts
@@ -1,4 +1,5 @@
 import { isSafetySensitiveBlueprintAction } from "./blueprintActions";
+import { isReminderTiming, type ReminderTiming } from "./reminderSchedule";
 
 export const IDENTITY_OPTIONS = [
   { value: "movement", label: "Someone who moves consistently" },
@@ -27,6 +28,8 @@ export type WeeklyExperiment = {
   frequency_per_week: number | null;
   minimum_version: string | null;
   reminder_preference: ReminderPreference;
+  reminder_timing: ReminderTiming;
+  reminder_hour: number | null;
   onboarding_step: number;
   status: ExperimentStatus;
   week_start: string;
@@ -75,7 +78,13 @@ export function isReadyToActivate(experiment: Partial<WeeklyExperiment>): boolea
     && Number(experiment.frequency_per_week) >= 1
     && Number(experiment.frequency_per_week) <= 7
     && !!cleanText(experiment.minimum_version, 160)
-    && (experiment.reminder_preference === "none" || experiment.reminder_preference === "email");
+    && (experiment.reminder_preference === "none" || experiment.reminder_preference === "email")
+    && isReminderTiming(experiment.reminder_timing)
+    && (
+      experiment.reminder_preference === "none"
+      || experiment.reminder_timing === "account_default"
+      || (Number.isInteger(experiment.reminder_hour) && Number(experiment.reminder_hour) >= 0 && Number(experiment.reminder_hour) <= 23)
+    );
 }
 
 export function identityLabel(value: IdentityDirection | null | undefined): string {

--- a/src/lib/currentRegimen.ts
+++ b/src/lib/currentRegimen.ts
@@ -177,3 +177,34 @@ export async function upsertReportedMedication(userId: string, input: {
   if (error) throw error;
   return data as unknown as CurrentRegimenItem;
 }
+
+export async function upsertReportedHormone(userId: string, input: {
+  name: string;
+  dose: string | null;
+  timing: string | null;
+  purpose: string | null;
+  instruction_authority: MedicationInstructionAuthority;
+}) {
+  await ensureLatestUserRegimen(userId);
+  const row = {
+    user_id: userId,
+    source_submission_id: null,
+    source_stack_item_id: null,
+    item_kind: "hormone" as const,
+    name: input.name,
+    normalized_name: normalizeRegimenName(input.name),
+    purpose: input.purpose,
+    dose: input.dose,
+    timing: input.timing,
+    instruction_source: "manual_add" satisfies CurrentRegimenSource,
+    instruction_authority: input.instruction_authority,
+    active: true,
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error } = await getSupabaseAdmin().from("current_regimen_items")
+    .upsert(row, { onConflict: "user_id,item_kind,normalized_name" })
+    .select(REGIMEN_COLUMNS)
+    .maybeSingle();
+  if (error) throw error;
+  return data as unknown as CurrentRegimenItem;
+}

--- a/src/lib/medicationRecord.ts
+++ b/src/lib/medicationRecord.ts
@@ -9,7 +9,7 @@ export type MedicationInstructionAuthority = (typeof MEDICATION_INSTRUCTION_AUTH
 export const MEDICATION_AUTHORITY_LABELS: Record<MedicationInstructionAuthority, string> = {
   clinician: "My clinician or prescriber",
   pharmacist: "My pharmacist",
-  medication_label: "My current medication label",
+  medication_label: "My current prescription label",
 };
 
 export function isMedicationInstructionAuthority(value: unknown): value is MedicationInstructionAuthority {
@@ -24,14 +24,22 @@ function clean(value: unknown, maxLength: number): string | null {
 }
 
 export function normalizeMedicationRecordInput(value: unknown) {
+  return normalizePrescribedRecordInput(value, "medication");
+}
+
+export function normalizeHormoneRecordInput(value: unknown) {
+  return normalizePrescribedRecordInput(value, "hormone");
+}
+
+function normalizePrescribedRecordInput(value: unknown, kind: "medication" | "hormone") {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("invalid_medication_record");
+    throw new Error(`invalid_${kind}_record`);
   }
   const input = value as Record<string, unknown>;
   const name = clean(input.name, 120);
-  if (!name || name.length < 2) throw new Error("medication_name_required");
+  if (!name || name.length < 2) throw new Error(`${kind}_name_required`);
   if (!isMedicationInstructionAuthority(input.instruction_authority)) {
-    throw new Error("medication_instruction_source_required");
+    throw new Error(`${kind}_instruction_source_required`);
   }
   return {
     name,

--- a/src/lib/reminderSchedule.ts
+++ b/src/lib/reminderSchedule.ts
@@ -1,0 +1,148 @@
+export const REMINDER_TIMINGS = [
+  "account_default",
+  "prepare_before",
+  "at_cue",
+  "next_day",
+] as const;
+
+export type ReminderTiming = (typeof REMINDER_TIMINGS)[number];
+export type ReminderKind = "practice" | "recovery" | "next_day_checkin" | "weekly_review";
+export type ReminderSkipReason =
+  | "wrong_hour"
+  | "quiet_hours"
+  | "before_week"
+  | "before_first_checkin"
+  | "review_complete"
+  | "completed_today"
+  | "completed_target"
+  | "target_met";
+
+export type ReminderDecision = {
+  kind: ReminderKind;
+  localDate: string;
+  targetDate: string;
+};
+
+type ReminderDecisionInput = {
+  now: Date;
+  timezone: string;
+  cueHour: number;
+  quietStartHour: number;
+  quietEndHour: number;
+  weekStart: string;
+  completedDates: string[];
+  reviewCompleted: boolean;
+  targetCount: number;
+  timing: ReminderTiming;
+};
+
+export function isReminderTiming(value: unknown): value is ReminderTiming {
+  return typeof value === "string" && REMINDER_TIMINGS.includes(value as ReminderTiming);
+}
+
+export function localClock(now: Date, timezone: string): { date: string; hour: number } {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((item) => item.type === type)?.value ?? "";
+  return { date: `${part("year")}-${part("month")}-${part("day")}`, hour: Number(part("hour")) };
+}
+
+export function isQuietHour(hour: number, start: number, end: number): boolean {
+  if (start === end) return false;
+  return start < end ? hour >= start && hour < end : hour >= start || hour < end;
+}
+
+export function addDays(date: string, amount: number): string {
+  const value = new Date(`${date}T12:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + amount);
+  return value.toISOString().slice(0, 10);
+}
+
+export function evaluateReminder(input: ReminderDecisionInput):
+  | { decision: ReminderDecision; reason: null }
+  | { decision: null; reason: ReminderSkipReason; localDate: string } {
+  const clock = localClock(input.now, input.timezone);
+  if (clock.hour !== input.cueHour) return { decision: null, reason: "wrong_hour", localDate: clock.date };
+  if (isQuietHour(clock.hour, input.quietStartHour, input.quietEndHour)) {
+    return { decision: null, reason: "quiet_hours", localDate: clock.date };
+  }
+
+  const weekEnd = addDays(input.weekStart, 6);
+  if (clock.date < input.weekStart) return { decision: null, reason: "before_week", localDate: clock.date };
+  if (clock.date >= weekEnd) {
+    return input.reviewCompleted
+      ? { decision: null, reason: "review_complete", localDate: clock.date }
+      : { decision: { kind: "weekly_review", localDate: clock.date, targetDate: weekEnd }, reason: null };
+  }
+
+  const uniqueCompletions = new Set(input.completedDates);
+  if (uniqueCompletions.size >= input.targetCount) {
+    return { decision: null, reason: "target_met", localDate: clock.date };
+  }
+
+  if (input.timing === "next_day") {
+    const targetDate = addDays(clock.date, -1);
+    if (targetDate < input.weekStart) {
+      return { decision: null, reason: "before_first_checkin", localDate: clock.date };
+    }
+    if (uniqueCompletions.has(targetDate)) {
+      return { decision: null, reason: "completed_target", localDate: clock.date };
+    }
+    return {
+      decision: { kind: "next_day_checkin", localDate: clock.date, targetDate },
+      reason: null,
+    };
+  }
+
+  if (uniqueCompletions.has(clock.date)) {
+    return { decision: null, reason: "completed_today", localDate: clock.date };
+  }
+  const yesterday = addDays(clock.date, -1);
+  const missedYesterday = yesterday >= input.weekStart && !uniqueCompletions.has(yesterday);
+  return {
+    decision: {
+      kind: missedYesterday ? "recovery" : "practice",
+      localDate: clock.date,
+      targetDate: clock.date,
+    },
+    reason: null,
+  };
+}
+
+export function effectiveReminderHour(
+  timing: ReminderTiming,
+  practiceHour: number | null | undefined,
+  accountHour: number,
+): number {
+  return timing === "account_default" || !Number.isInteger(practiceHour)
+    ? accountHour
+    : Number(practiceHour);
+}
+
+export function reminderIdempotencyKey(
+  kind: ReminderKind,
+  experimentId: string,
+  localDate: string,
+  targetDate = localDate,
+): string {
+  if (kind === "weekly_review") return `reminder:${kind}:${experimentId}:due`;
+  return `reminder:${kind}:${experimentId}:${localDate}:${targetDate}`;
+}
+
+export function skippedReminderIdempotencyKey(
+  experimentId: string,
+  localDate: string,
+  reason: ReminderSkipReason,
+): string {
+  return `reminder:skipped:${experimentId}:${localDate}:${reason}`;
+}
+
+export function shouldLedgerSkip(reason: ReminderSkipReason): boolean {
+  return ["quiet_hours", "review_complete", "completed_today", "completed_target", "target_met"].includes(reason);
+}

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -1,101 +1,33 @@
 import "server-only";
 
 import { Resend } from "resend";
+import type { ReminderKind, ReminderTiming } from "@/lib/reminderSchedule";
 
-export type ReminderKind = "practice" | "recovery" | "weekly_review";
-export type ReminderSkipReason =
-  | "wrong_hour"
-  | "quiet_hours"
-  | "before_week"
-  | "review_complete"
-  | "completed_today";
+export {
+  addDays,
+  effectiveReminderHour,
+  evaluateReminder,
+  isQuietHour,
+  reminderIdempotencyKey,
+  shouldLedgerSkip,
+  skippedReminderIdempotencyKey,
+} from "@/lib/reminderSchedule";
 
-type LocalClock = {
-  date: string;
-  hour: number;
-};
-
-type ReminderDecisionInput = {
-  now: Date;
-  timezone: string;
-  cueHour: number;
-  quietStartHour: number;
-  quietEndHour: number;
-  weekStart: string;
-  completedDates: string[];
-  reviewCompleted: boolean;
-};
-
-export function localClock(now: Date, timezone: string): LocalClock {
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    hourCycle: "h23",
-  }).formatToParts(now);
-  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((item) => item.type === type)?.value ?? "";
-  return {
-    date: `${part("year")}-${part("month")}-${part("day")}`,
-    hour: Number(part("hour")),
-  };
-}
-
-export function isQuietHour(hour: number, start: number, end: number): boolean {
-  if (start === end) return false;
-  return start < end ? hour >= start && hour < end : hour >= start || hour < end;
-}
-
-export function addDays(date: string, amount: number): string {
-  const value = new Date(`${date}T12:00:00.000Z`);
-  value.setUTCDate(value.getUTCDate() + amount);
-  return value.toISOString().slice(0, 10);
-}
-
-export function evaluateReminder(input: ReminderDecisionInput):
-  | { decision: { kind: ReminderKind; localDate: string }; reason: null }
-  | { decision: null; reason: ReminderSkipReason } {
-  const clock = localClock(input.now, input.timezone);
-  if (clock.hour !== input.cueHour) return { decision: null, reason: "wrong_hour" };
-  if (isQuietHour(clock.hour, input.quietStartHour, input.quietEndHour)) {
-    return { decision: null, reason: "quiet_hours" };
-  }
-
-  const weekEnd = addDays(input.weekStart, 6);
-  if (clock.date < input.weekStart) return { decision: null, reason: "before_week" };
-  if (clock.date >= weekEnd) {
-    return input.reviewCompleted
-      ? { decision: null, reason: "review_complete" }
-      : { decision: { kind: "weekly_review", localDate: clock.date }, reason: null };
-  }
-  if (input.completedDates.includes(clock.date)) return { decision: null, reason: "completed_today" };
-
-  const yesterday = addDays(clock.date, -1);
-  const missedYesterday = yesterday >= input.weekStart && !input.completedDates.includes(yesterday);
-  return {
-    decision: { kind: missedYesterday ? "recovery" : "practice", localDate: clock.date },
-    reason: null,
-  };
-}
-
-export function decideReminder(input: ReminderDecisionInput): { kind: ReminderKind; localDate: string } | null {
-  return evaluateReminder(input).decision;
-}
-
-export function reminderIdempotencyKey(kind: ReminderKind, experimentId: string, localDate: string): string {
-  return kind === "weekly_review"
-    ? `reminder:${kind}:${experimentId}:due`
-    : `reminder:${kind}:${experimentId}:${localDate}`;
-}
-
-function content(kind: ReminderKind) {
+function content(kind: ReminderKind, timing: ReminderTiming) {
   if (kind === "weekly_review") {
     return {
       subject: "Your LVE360 weekly review is ready",
       heading: "Notice what worked this week",
       body: "Your weekly review is ready. Take a few minutes to notice what helped, adjust what did not, and shape your next focused week.",
       cta: "Open weekly review",
+    };
+  }
+  if (kind === "next_day_checkin") {
+    return {
+      subject: "A quick check-in for yesterday's practice",
+      heading: "Did yesterday's practice happen?",
+      body: "You did not need to use your phone after the practice. Record it now if it happened, or simply use the information to shape today.",
+      cta: "Check in for yesterday",
     };
   }
   if (kind === "recovery") {
@@ -106,9 +38,17 @@ function content(kind: ReminderKind) {
       cta: "Open today",
     };
   }
+  if (timing === "prepare_before") {
+    return {
+      subject: "Make your next LVE360 practice easier",
+      heading: "Prepare before your cue",
+      body: "A small setup now can protect the practice later without asking you to interrupt the moment itself.",
+      cta: "Open today's practice",
+    };
+  }
   return {
-    subject: "Your small LVE360 practice for today",
-    heading: "Make the next repetition easy",
+    subject: "Your LVE360 practice cue is here",
+    heading: timing === "at_cue" ? "Your cue is here" : "Make the next repetition easy",
     body: "Your focused practice is ready when you are. A small version counts, especially on a full day.",
     cta: "Open today",
   };
@@ -117,14 +57,19 @@ function content(kind: ReminderKind) {
 export async function sendReminderEmail(input: {
   to: string;
   kind: ReminderKind;
+  timing: ReminderTiming;
+  actionLabel: string;
+  minimumVersion: string;
   deepLink: string;
   idempotencyKey: string;
-}): Promise<{ status: "sent"; providerId: string } | { status: "failed"; reason: string }> {
+}): Promise<{ status: "accepted"; providerId: string } | { status: "failed"; reason: string }> {
   const apiKey = process.env.RESEND_API_KEY?.trim();
   if (!apiKey) return { status: "failed", reason: "resend_not_configured" };
-  const copy = content(input.kind);
+  const copy = content(input.kind, input.timing);
   const safeLink = input.deepLink.replace(/"/g, "&quot;");
   const settingsLink = new URL("/settings", input.deepLink).toString().replace(/"/g, "&quot;");
+  const safeAction = escapeHtml(input.actionLabel);
+  const safeMinimum = escapeHtml(input.minimumVersion);
   try {
     const resend = new Resend(apiKey);
     const { data, error } = await resend.emails.send({
@@ -136,14 +81,29 @@ export async function sendReminderEmail(input: {
         <p style="font-weight:700;color:#087f72">LVE360</p>
         <h1 style="font-size:24px">${copy.heading}</h1>
         <p style="font-size:16px;line-height:1.6">${copy.body}</p>
+        <div style="margin-top:20px;padding:16px;border:1px solid #bce3da;border-radius:12px;background:#f4faf8">
+          <p style="margin:0;font-size:12px;font-weight:700;text-transform:uppercase;color:#087f72">Your practice</p>
+          <p style="margin:8px 0 0;font-size:16px;font-weight:700">${safeAction}</p>
+          <p style="margin:12px 0 0;font-size:13px;color:#475569"><strong>Minimum version:</strong> ${safeMinimum}</p>
+        </div>
         <a href="${safeLink}" style="display:inline-block;margin-top:12px;background:#08a88a;color:white;text-decoration:none;padding:12px 18px;border-radius:9px;font-weight:700">${copy.cta}</a>
         <p style="margin-top:28px;font-size:12px;color:#64748b">Manage or turn off reminders in <a href="${settingsLink}">Settings</a>.</p>
       </div>`,
-      text: `${copy.heading}\n\n${copy.body}\n\n${copy.cta}: ${input.deepLink}\n\nManage reminders in LVE360 Settings.`,
+      text: `${copy.heading}\n\n${copy.body}\n\nYour practice: ${input.actionLabel}\nMinimum version: ${input.minimumVersion}\n\n${copy.cta}: ${input.deepLink}\n\nManage reminders in LVE360 Settings.`,
     }, { idempotencyKey: input.idempotencyKey });
     if (error || !data?.id) return { status: "failed", reason: "provider_rejected" };
-    return { status: "sent", providerId: data.id };
+    return { status: "accepted", providerId: data.id };
   } catch {
     return { status: "failed", reason: "send_failed" };
   }
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[character] ?? character);
 }

--- a/supabase/migrations/20260801192204_pr75_practice_aware_reminders.sql
+++ b/supabase/migrations/20260801192204_pr75_practice_aware_reminders.sql
@@ -1,0 +1,147 @@
+alter table public.weekly_experiments
+  add column if not exists reminder_timing text not null default 'account_default',
+  add column if not exists reminder_hour smallint;
+
+alter table public.weekly_experiments
+  add constraint weekly_experiments_reminder_timing check (
+    reminder_timing in ('account_default', 'prepare_before', 'at_cue', 'next_day')
+  ),
+  add constraint weekly_experiments_reminder_hour check (
+    reminder_hour is null or reminder_hour between 0 and 23
+  );
+
+comment on column public.weekly_experiments.reminder_timing is
+  'Member-selected reminder intent for this practice. account_default retains the account-level cue.';
+comment on column public.weekly_experiments.reminder_hour is
+  'Optional local delivery hour for this practice. The member timezone remains in user_preferences.';
+
+alter table public.reminder_deliveries
+  add column if not exists target_date date,
+  add column if not exists reminder_timing text,
+  add column if not exists skip_reason text,
+  add column if not exists provider_event_type text,
+  add column if not exists provider_event_at timestamptz;
+
+alter table public.reminder_deliveries drop constraint if exists reminder_deliveries_kind;
+alter table public.reminder_deliveries add constraint reminder_deliveries_kind check (
+  reminder_kind in ('practice', 'recovery', 'next_day_checkin', 'weekly_review')
+);
+
+alter table public.reminder_deliveries drop constraint if exists reminder_deliveries_status;
+
+update public.reminder_deliveries set status = 'accepted' where status = 'sent';
+
+alter table public.reminder_deliveries add constraint reminder_deliveries_status check (
+  status in ('queued', 'accepted', 'delivered', 'bounced', 'failed', 'skipped')
+);
+
+alter table public.reminder_deliveries add constraint reminder_deliveries_timing check (
+  reminder_timing is null
+  or reminder_timing in ('account_default', 'prepare_before', 'at_cue', 'next_day')
+);
+
+create index if not exists reminder_deliveries_provider_idx
+  on public.reminder_deliveries (provider_id)
+  where provider_id is not null;
+
+create or replace function public.complete_weekly_review(
+  p_user_id uuid,
+  p_experiment_id uuid,
+  p_difficulty smallint,
+  p_value_rating smallint,
+  p_decision text,
+  p_action_label text default null,
+  p_cue text default null,
+  p_frequency_per_week smallint default null,
+  p_minimum_version text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_experiment public.weekly_experiments%rowtype;
+  next_id uuid;
+  completed_reps smallint;
+  next_week_start date;
+begin
+  if p_difficulty not between 1 and 5
+    or p_value_rating not between 1 and 5
+    or p_decision not in ('keep', 'shrink', 'swap', 'pause', 'advance') then
+    raise exception 'invalid_review';
+  end if;
+
+  select * into current_experiment
+  from public.weekly_experiments
+  where id = p_experiment_id and user_id = p_user_id and status = 'active'
+  for update;
+
+  if not found then raise exception 'active_experiment_not_found'; end if;
+  if current_date < current_experiment.week_start + 6 then raise exception 'review_not_due'; end if;
+  if exists (
+    select 1 from public.weekly_experiment_reviews
+    where experiment_id = p_experiment_id and status = 'completed'
+  ) then raise exception 'review_already_completed'; end if;
+
+  select count(distinct completion_date)::smallint into completed_reps
+  from public.daily_practice_completions
+  where user_id = p_user_id
+    and experiment_id = p_experiment_id
+    and completion_date between current_experiment.week_start and current_experiment.week_start + 6;
+
+  update public.weekly_experiments
+  set status = 'completed', completed_at = now(), updated_at = now()
+  where id = p_experiment_id;
+
+  if p_decision <> 'pause' then
+    if p_action_label is null or char_length(btrim(p_action_label)) not between 4 and 240
+      or p_cue is null or char_length(btrim(p_cue)) not between 2 and 160
+      or p_frequency_per_week not between 1 and 7
+      or p_minimum_version is null or char_length(btrim(p_minimum_version)) not between 2 and 160 then
+      raise exception 'invalid_next_experiment';
+    end if;
+
+    next_week_start := greatest(
+      current_experiment.week_start + 7,
+      date_trunc('week', current_date)::date
+    );
+
+    insert into public.weekly_experiments (
+      user_id, identity_direction, action_label, cue, frequency_per_week,
+      minimum_version, reminder_preference, reminder_timing, reminder_hour,
+      onboarding_step, status, week_start, activated_at
+    ) values (
+      p_user_id, current_experiment.identity_direction, btrim(p_action_label), btrim(p_cue),
+      p_frequency_per_week, btrim(p_minimum_version), current_experiment.reminder_preference,
+      current_experiment.reminder_timing, current_experiment.reminder_hour,
+      6, 'active', next_week_start, now()
+    ) returning id into next_id;
+  end if;
+
+  insert into public.weekly_experiment_reviews (
+    user_id, experiment_id, completion_count, target_count, difficulty,
+    value_rating, decision, status, next_experiment_id, completed_at, updated_at
+  ) values (
+    p_user_id, p_experiment_id, completed_reps, current_experiment.frequency_per_week,
+    p_difficulty, p_value_rating, p_decision, 'completed', next_id, now(), now()
+  ) on conflict (experiment_id) do update set
+    completion_count = excluded.completion_count,
+    target_count = excluded.target_count,
+    difficulty = excluded.difficulty,
+    value_rating = excluded.value_rating,
+    decision = excluded.decision,
+    status = 'completed',
+    next_experiment_id = excluded.next_experiment_id,
+    completed_at = excluded.completed_at,
+    updated_at = excluded.updated_at;
+
+  return next_id;
+end;
+$$;
+
+comment on table public.reminder_deliveries is
+  'Privacy-minimized reminder ledger for one-time claims, skip reasons, and provider delivery outcomes. Email content is not stored.';
+
+-- Rollback: remove the PR75 reminder columns and restore the prior delivery
+-- constraints and complete_weekly_review definition.

--- a/supabase/migrations/20260801195232_pr75_reminder_delivery_experiment_index.sql
+++ b/supabase/migrations/20260801195232_pr75_reminder_delivery_experiment_index.sql
@@ -1,0 +1,4 @@
+create index if not exists reminder_deliveries_experiment_created_idx
+  on public.reminder_deliveries (experiment_id, created_at desc);
+
+-- Rollback: drop index public.reminder_deliveries_experiment_created_idx.


### PR DESCRIPTION
## What changed

- adds practice-level reminder intent: prepare beforehand, remind at the cue, check in the next morning, or no reminder
- retains the account cue as the fallback for existing practices
- lets active members revise their reminder plan
- adds a phone-free next-day completion link for bedtime practices
- includes the exact practice and minimum version in reminder emails
- records accepted, delivered, bounced, failed, and meaningful skipped outcomes
- verifies Resend provider events before updating the delivery ledger
- lets members add hormones and record clinician-directed dose or schedule changes in Routine
- requires clinician, pharmacist, or prescription-label provenance for hormone changes
- supports neutral stop-tracking language and Undo for hormones

## Why

A single generic account reminder can arrive at the wrong moment. Bedtime meditation is a clear example: an early cue is irrelevant, while a cue after the practice encourages phone use when the member wants to sleep. Reminder timing now follows the practice.

Hormones also need the same safe member-maintenance path as medications. This records externally directed instructions without presenting LVE360 as the prescriber.

## Safety and privacy

- reminder emails contain only the member's lifestyle practice and minimum version, not Blueprint health details
- prescribed dose changes require an external instruction source
- LVE360 never recommends a medication or hormone dose
- regimen changes make the current Blueprint stale through the canonical snapshot
- provider webhooks use signed request verification

## Validation

- `npm.cmd run qa:pr75`
- `npm.cmd run qa:reminders`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr74`
- `npm.cmd run qa:settings`
- `npm.cmd run qa:journey`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run typecheck`
- production build compiled and passed type validation; local page-data collection still requires the existing `OPENAI_API_KEY`

## Database

Both PR75 migrations were applied and verified against the connected Supabase project. Existing `sent` reminder rows were migrated to `accepted`, and the advisor-recommended experiment index was added.

## Post-deploy configuration

Configure `RESEND_WEBHOOK_SECRET` and register `https://app.lve360.com/api/webhooks/resend` for `email.delivered`, `email.bounced`, and `email.failed` before treating provider delivery outcomes as fully active.