### PR TITLE
PR76: Build a flexible regimen organizer and clinician printout

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -11,9 +11,9 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   if (!user) redirect("/login");
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB] text-gray-900">
-      <DashboardHeader tier={tier} />
-      <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen flex-col bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB] text-gray-900 print:block print:min-h-0 print:bg-white">
+      <div className="print:hidden"><DashboardHeader tier={tier} /></div>
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 print:max-w-none print:p-0 sm:px-6 lg:px-8">
         {children}
       </main>
     </div>

--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Pencil,
   Pill,
+  Printer,
   RotateCcw,
   Search,
   ShieldAlert,
@@ -34,8 +35,18 @@ import {
 import {
   MEDICATION_AUTHORITY_LABELS,
   MEDICATION_INSTRUCTION_AUTHORITIES,
+  REGIMEN_AUTHORITY_LABELS,
+  REGIMEN_INSTRUCTION_AUTHORITIES,
   type MedicationInstructionAuthority,
+  type RegimenInstructionAuthority,
 } from "@/lib/medicationRecord";
+import ScheduleEditor, {
+  scheduleDraft,
+  scheduleDraftIsReady,
+  scheduleDraftPayload,
+  type ScheduleDraft,
+} from "./ScheduleEditor";
+import TodayDoses from "./TodayDoses";
 
 type LatestStack = { id: string; submission_id: string | null; created_at: string } | null;
 type ToastState = { message: string; undo?: () => Promise<void> } | null;
@@ -71,6 +82,7 @@ export default function RoutineClient({
   const [showAddHormone, setShowAddHormone] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [toast, setToast] = useState<ToastState>(null);
+  const [doseRefreshToken, setDoseRefreshToken] = useState(0);
   const grouped = useMemo(() => groupRoutineItems(items), [items]);
 
   useEffect(() => {
@@ -84,6 +96,7 @@ export default function RoutineClient({
     const body = await response.json().catch(() => null);
     if (!response.ok || !body?.ok) throw new Error(body?.error ?? "routine_unavailable");
     setItems(body.items ?? []);
+    setDoseRefreshToken((current) => current + 1);
   }
 
   async function updateItem(id: string, patch: Record<string, unknown>) {
@@ -96,9 +109,9 @@ export default function RoutineClient({
     if (!response.ok || !body?.ok) throw new Error(body?.error ?? "routine_update_failed");
   }
 
-  async function saveEdit(item: RoutineItem, patch: { dose?: string | null; timing: string | null; instructionAuthority?: MedicationInstructionAuthority }) {
+  async function saveEdit(item: RoutineItem, patch: { dose?: string | null; schedule?: RoutineItem["schedule"]; instructionAuthority?: RegimenInstructionAuthority }) {
     setBusyId(item.id);
-    const previous = { dose: item.dose, timing: item.timing };
+    const previous = { dose: item.dose, schedule: item.schedule ?? null, instructionAuthority: item.instruction_authority ?? undefined };
     try {
       await updateItem(item.id, patch);
       await refreshRoutine();
@@ -108,8 +121,8 @@ export default function RoutineClient({
         undo: async () => {
           await updateItem(item.id, {
             ...previous,
-            ...((item.item_kind === "medication" || item.item_kind === "hormone") && patch.instructionAuthority
-              ? { instructionAuthority: patch.instructionAuthority }
+            ...(previous.instructionAuthority || patch.instructionAuthority
+              ? { instructionAuthority: previous.instructionAuthority ?? patch.instructionAuthority }
               : {}),
           });
           await refreshRoutine();
@@ -185,6 +198,8 @@ export default function RoutineClient({
 
   return (
     <>
+      <TodayDoses refreshToken={doseRefreshToken} />
+
       <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-xl font-bold text-[#041B2D]">Your current routine</h2>
@@ -194,6 +209,15 @@ export default function RoutineClient({
           </p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
+          <a
+            href="/routine/print"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 bg-white px-5 py-3 font-bold text-slate-700 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
+          >
+            <Printer className="mr-2 h-5 w-5" aria-hidden="true" />
+            Print clinician list
+          </a>
           <button
             type="button"
             onClick={() => setShowAddMedication(true)}
@@ -407,7 +431,7 @@ function RoutineCard({
           onClick={() => onEdit(item)}
           className="inline-flex min-h-12 items-center justify-center rounded-xl border border-[#9DCFC3] bg-white px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]"
         >
-          <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> {prescribedItem ? "Record prescribed change" : "Edit details"}
+          <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> {prescribedItem ? "Record dose or schedule change" : "Edit dose or schedule"}
         </button>
         <button
           type="button"
@@ -463,13 +487,19 @@ function IdeasSection({ items, busyId, onAdopt }: { items: RoutineItem[]; busyId
   );
 }
 
-function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineItem; saving: boolean; onClose: () => void; onSave: (item: RoutineItem, patch: { dose?: string | null; timing: string | null; instructionAuthority?: MedicationInstructionAuthority }) => void }) {
+function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineItem; saving: boolean; onClose: () => void; onSave: (item: RoutineItem, patch: { dose?: string | null; schedule?: RoutineItem["schedule"]; instructionAuthority?: RegimenInstructionAuthority }) => void }) {
   const prescribedItem = item.item_kind === "medication" || item.item_kind === "hormone";
   const [dose, setDose] = useState(item.dose ?? "");
-  const [timing, setTiming] = useState(item.timing ?? "");
-  const [instructionAuthority, setInstructionAuthority] = useState<MedicationInstructionAuthority | "">(
+  const [schedule, setSchedule] = useState<ScheduleDraft>(() => scheduleDraft(item.schedule));
+  const [instructionAuthority, setInstructionAuthority] = useState<RegimenInstructionAuthority | "">(
     item.instruction_authority ?? ""
   );
+  const authorities = prescribedItem
+    ? MEDICATION_INSTRUCTION_AUTHORITIES
+    : REGIMEN_INSTRUCTION_AUTHORITIES.filter((authority) => authority !== "medication_label");
+  const hasStructuredSchedule = Boolean(schedule.cadence);
+  const scheduleReady = !hasStructuredSchedule || scheduleDraftIsReady(schedule);
+  const sourceRequired = prescribedItem || hasStructuredSchedule;
   return (
     <DialogShell title={prescribedItem ? `Record a prescribed change for ${item.name}` : `Update ${item.name}`} onClose={onClose}>
       <p className="text-sm leading-6 text-slate-600">
@@ -478,19 +508,24 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
           : "Record what you currently do. This does not create a medical instruction or replace a product label."}
       </p>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">{prescribedItem ? "Prescribed dose" : "Amount you take"}<input autoFocus value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={item.item_kind === "hormone" ? "For example, 80 mg" : "For example, 2 capsules"} /></label>
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">When you take it<input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, Monday and Thursday evenings" /></label>
-      {prescribedItem ? (
+      {!item.schedule && item.timing ? <p className="mt-4 rounded-xl bg-slate-50 p-3 text-sm text-slate-700"><span className="font-bold">Current written schedule:</span> {item.timing}. Choose a structured cadence below to use the daily checklist.</p> : null}
+      <ScheduleEditor value={schedule} onChange={setSchedule} />
+      {sourceRequired ? (
         <label className="mt-5 block text-sm font-bold text-[#041B2D]">
           Where did this instruction come from?
-          <select value={instructionAuthority} onChange={(event) => setInstructionAuthority(event.target.value as MedicationInstructionAuthority)} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20">
+          <select value={instructionAuthority} onChange={(event) => setInstructionAuthority(event.target.value as RegimenInstructionAuthority)} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20">
             <option value="">Choose a source</option>
-            {MEDICATION_INSTRUCTION_AUTHORITIES.map((authority) => <option key={authority} value={authority}>{MEDICATION_AUTHORITY_LABELS[authority]}</option>)}
+            {authorities.map((authority) => <option key={authority} value={authority}>{REGIMEN_AUTHORITY_LABELS[authority]}</option>)}
           </select>
         </label>
       ) : null}
       <div className="mt-6 grid gap-2 sm:grid-cols-2">
         <button type="button" onClick={onClose} disabled={saving} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
-        <button type="button" disabled={saving || (prescribedItem && !instructionAuthority)} onClick={() => onSave(item, { dose: dose.trim() || null, timing: timing.trim() || null, ...(prescribedItem && instructionAuthority ? { instructionAuthority } : {}) })} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
+        <button type="button" disabled={saving || !scheduleReady || (sourceRequired && !instructionAuthority)} onClick={() => onSave(item, {
+          dose: dose.trim() || null,
+          ...(hasStructuredSchedule ? { schedule: scheduleDraftPayload(schedule) } : {}),
+          ...(instructionAuthority ? { instructionAuthority } : {}),
+        })} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
           {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Save record
         </button>
       </div>
@@ -502,6 +537,7 @@ function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication
   const [name, setName] = useState("");
   const [dose, setDose] = useState("");
   const [timing, setTiming] = useState("");
+  const [schedule, setSchedule] = useState<ScheduleDraft>(() => scheduleDraft(null));
   const [purpose, setPurpose] = useState("");
   const [instructionAuthority, setInstructionAuthority] = useState<MedicationInstructionAuthority | "">("");
   const [busy, setBusy] = useState(false);
@@ -520,6 +556,7 @@ function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication
           name,
           dose,
           timing,
+          ...(schedule.cadence ? { schedule: scheduleDraftPayload(schedule) } : {}),
           purpose,
           instruction_authority: instructionAuthority,
         }),
@@ -542,6 +579,7 @@ function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">{kind === "hormone" ? "Hormone name" : "Medication name"}<input autoFocus value={name} onChange={(event) => setName(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, testosterone cypionate" : "For example, Zepbound"} /></label>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Prescribed dose<input value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, 80 mg" : "For example, 10 mg / 0.5 mL"} /></label>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Schedule<input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, Monday and Thursday evenings" : "For example, once weekly on Sunday"} /></label>
+      <ScheduleEditor value={schedule} onChange={setSchedule} />
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Purpose you were given <span className="font-normal text-slate-500">(optional)</span><input value={purpose} onChange={(event) => setPurpose(event.target.value)} maxLength={200} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, hormone replacement" : "For example, weight management"} /></label>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Where did this instruction come from?
         <select value={instructionAuthority} onChange={(event) => setInstructionAuthority(event.target.value as MedicationInstructionAuthority)} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20">
@@ -552,7 +590,7 @@ function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication
       {error ? <p className="mt-4 rounded-xl bg-rose-50 p-3 text-sm font-semibold text-rose-800">{error}</p> : null}
       <div className="mt-6 grid gap-2 sm:grid-cols-2">
         <button type="button" onClick={onClose} disabled={busy} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
-        <button type="button" disabled={busy || !name.trim() || !instructionAuthority} onClick={() => void addPrescribedItem()} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
+        <button type="button" disabled={busy || !name.trim() || !instructionAuthority || (Boolean(schedule.cadence) && !scheduleDraftIsReady(schedule))} onClick={() => void addPrescribedItem()} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white disabled:opacity-60">
           {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Add reported {label}
         </button>
       </div>

--- a/app/(app)/routine/ScheduleEditor.tsx
+++ b/app/(app)/routine/ScheduleEditor.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { CirclePlus, Trash2 } from "lucide-react";
+
+import { localDateString, normalizeRegimenSchedule, type RegimenCadence, type RegimenSchedule } from "@/lib/regimenSchedule";
+
+export type ScheduleDraft = {
+  cadence: RegimenCadence | "";
+  times: string[];
+  weekdays: number[];
+  interval_days: number | null;
+  anchor_date: string | null;
+};
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export function scheduleDraft(schedule: RegimenSchedule | null | undefined): ScheduleDraft {
+  return schedule ? { ...schedule, times: [...schedule.times], weekdays: [...schedule.weekdays] } : {
+    cadence: "",
+    times: [""],
+    weekdays: [],
+    interval_days: 2,
+    anchor_date: localDateString(),
+  };
+}
+
+export function scheduleDraftPayload(draft: ScheduleDraft): RegimenSchedule | null {
+  if (!draft.cadence) return null;
+  return normalizeRegimenSchedule(draft);
+}
+
+export function scheduleDraftIsReady(draft: ScheduleDraft): boolean {
+  try {
+    return Boolean(scheduleDraftPayload(draft));
+  } catch {
+    return false;
+  }
+}
+
+export default function ScheduleEditor({ value, onChange }: { value: ScheduleDraft; onChange: (value: ScheduleDraft) => void }) {
+  function setCadence(cadence: ScheduleDraft["cadence"]) {
+    onChange({
+      ...value,
+      cadence,
+      times: cadence === "as_needed" ? [] : value.times.length ? value.times : [""],
+      weekdays: cadence === "weekly" ? value.weekdays.slice(0, 1) : value.weekdays,
+    });
+  }
+
+  function toggleDay(day: number) {
+    const selected = value.weekdays.includes(day);
+    const next = selected ? value.weekdays.filter((candidate) => candidate !== day) : [...value.weekdays, day].sort();
+    onChange({ ...value, weekdays: value.cadence === "weekly" && !selected ? [day] : next });
+  }
+
+  return (
+    <fieldset className="mt-5 rounded-2xl border border-slate-200 p-4">
+      <legend className="px-1 text-sm font-bold text-[#041B2D]">Structured schedule</legend>
+      <p className="text-sm leading-6 text-slate-600">Copy the cadence and times from your existing instructions. LVE360 does not choose them for you.</p>
+      <label className="mt-4 block text-sm font-bold text-[#041B2D]">
+        Cadence
+        <select value={value.cadence} onChange={(event) => setCadence(event.target.value as ScheduleDraft["cadence"])} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20">
+          <option value="">Not structured yet</option>
+          <option value="daily">Every day</option>
+          <option value="every_n_days">Every number of days</option>
+          <option value="weekdays">Selected days of the week</option>
+          <option value="weekly">Once weekly</option>
+          <option value="as_needed">As needed</option>
+        </select>
+      </label>
+
+      {value.cadence === "every_n_days" ? (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <label className="text-sm font-bold text-[#041B2D]">Repeat every
+            <span className="mt-2 flex items-center gap-2"><input type="number" min={2} max={30} value={value.interval_days ?? 2} onChange={(event) => onChange({ ...value, interval_days: Number(event.target.value) })} className="min-h-12 w-24 rounded-xl border border-slate-300 px-3 py-2 font-normal" /><span className="font-normal text-slate-600">days</span></span>
+          </label>
+          <label className="text-sm font-bold text-[#041B2D]">Starting date
+            <input type="date" value={value.anchor_date ?? ""} onChange={(event) => onChange({ ...value, anchor_date: event.target.value })} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-3 py-2 font-normal" />
+          </label>
+        </div>
+      ) : null}
+
+      {value.cadence === "weekdays" || value.cadence === "weekly" ? (
+        <div className="mt-4">
+          <p className="text-sm font-bold text-[#041B2D]">{value.cadence === "weekly" ? "Day of the week" : "Days of the week"}</p>
+          <div className="mt-2 grid grid-cols-4 gap-2 sm:grid-cols-7">
+            {DAYS.map((label, day) => <button key={label} type="button" aria-pressed={value.weekdays.includes(day)} onClick={() => toggleDay(day)} className={`min-h-12 rounded-xl border px-2 py-3 text-sm font-bold ${value.weekdays.includes(day) ? "border-[#087F72] bg-[#EAFBF8] text-[#06695F]" : "border-slate-300 text-slate-700 hover:bg-slate-50"}`}>{label}</button>)}
+          </div>
+        </div>
+      ) : null}
+
+      {value.cadence && value.cadence !== "as_needed" ? (
+        <div className="mt-4">
+          <p className="text-sm font-bold text-[#041B2D]">Dose times</p>
+          <div className="mt-2 space-y-2">
+            {value.times.map((time, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <label className="sr-only" htmlFor={`schedule-time-${index}`}>Dose time {index + 1}</label>
+                <input id={`schedule-time-${index}`} type="time" value={time} onChange={(event) => onChange({ ...value, times: value.times.map((candidate, candidateIndex) => candidateIndex === index ? event.target.value : candidate) })} className="min-h-12 flex-1 rounded-xl border border-slate-300 px-4 py-3" />
+                {value.times.length > 1 ? <button type="button" onClick={() => onChange({ ...value, times: value.times.filter((_, candidateIndex) => candidateIndex !== index) })} className="inline-flex min-h-12 min-w-12 items-center justify-center rounded-xl border border-slate-300 text-slate-600 hover:bg-slate-50" aria-label={`Remove dose time ${index + 1}`}><Trash2 className="h-5 w-5" aria-hidden="true" /></button> : null}
+              </div>
+            ))}
+          </div>
+          {value.times.length < 6 ? <button type="button" onClick={() => onChange({ ...value, times: [...value.times, ""] })} className="mt-2 inline-flex min-h-12 items-center rounded-xl px-3 py-2 font-bold text-[#087F72] hover:bg-[#EAFBF8]"><CirclePlus className="mr-2 h-5 w-5" aria-hidden="true" /> Add another time</button> : null}
+        </div>
+      ) : null}
+
+      {value.cadence === "as_needed" ? <p className="mt-4 rounded-xl bg-slate-50 p-3 text-sm text-slate-700">As-needed items do not create scheduled or overdue occurrences. You can record a dose only when you choose to take it under your existing instructions.</p> : null}
+    </fieldset>
+  );
+}

--- a/app/(app)/routine/TodayDoses.tsx
+++ b/app/(app)/routine/TodayDoses.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { Check, Clock3, History, Loader2, RotateCcw, SkipForward } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import type { AsNeededRegimenItem, RegimenDoseDay, RegimenDoseOccurrence, RegimenDoseStatus } from "@/lib/regimenDose";
+import { localDateString } from "@/lib/regimenSchedule";
+
+export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
+  const [day, setDay] = useState<RegimenDoseDay | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const date = localDateString();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/routine/doses?date=${encodeURIComponent(date)}`, { cache: "no-store" });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? "routine_doses_unavailable");
+      setDay(body.day);
+    } catch {
+      setError("We could not load today's dose list. Your routine records are unchanged.");
+    } finally {
+      setLoading(false);
+    }
+  }, [date]);
+
+  useEffect(() => {
+    void load();
+  }, [load, refreshToken]);
+
+  async function record(occurrence: RegimenDoseOccurrence, status: RegimenDoseStatus) {
+    const key = `${occurrence.regimenItemId}:${occurrence.slotKey}`;
+    setBusyKey(key);
+    setError(null);
+    try {
+      const response = await fetch("/api/routine/doses", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          regimen_item_id: occurrence.regimenItemId,
+          date,
+          slot_key: occurrence.slotKey,
+          status,
+        }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? "dose_record_failed");
+      await load();
+    } catch {
+      setError("We could not save that dose record. Please try again.");
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function recordAsNeeded(item: AsNeededRegimenItem) {
+    setBusyKey(`as-needed:${item.regimenItemId}`);
+    setError(null);
+    try {
+      const response = await fetch("/api/routine/doses", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ regimen_item_id: item.regimenItemId, date, slot_key: "as_needed", status: "taken" }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? "dose_record_failed");
+      await load();
+    } catch {
+      setError("We could not save that as-needed record. Please try again.");
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function undo(eventId: string) {
+    setBusyKey(eventId);
+    setError(null);
+    try {
+      const response = await fetch("/api/routine/doses", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event_id: eventId }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? "dose_undo_failed");
+      await load();
+    } catch {
+      setError("We could not undo that record. Please try again.");
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-[#9DCFC3] bg-white p-5 shadow-sm sm:p-6" aria-labelledby="today-doses-heading">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Today</p>
+          <h2 id="today-doses-heading" className="mt-1 text-2xl font-bold text-[#041B2D]">Your dose checklist</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-600">
+            Mark each scheduled occurrence separately. This records what happened and does not change your instructions.
+          </p>
+        </div>
+        <p className="rounded-full bg-[#EAFBF8] px-3 py-2 text-sm font-bold text-[#06695F]">{formatDay(date)}</p>
+      </div>
+
+      {error ? <p className="mt-4 rounded-xl bg-rose-50 p-3 text-sm font-semibold text-rose-800" role="alert">{error}</p> : null}
+      {loading ? <p className="mt-5 flex items-center text-sm font-semibold text-slate-600"><Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> Loading your dose list...</p> : null}
+
+      {!loading && day ? (
+        <>
+          <div className="mt-5 space-y-3">
+            {day.occurrences.map((occurrence) => {
+              const key = `${occurrence.regimenItemId}:${occurrence.slotKey}`;
+              const busy = busyKey === key || (Boolean(occurrence.eventId) && busyKey === occurrence.eventId);
+              return (
+                <article key={key} className="rounded-2xl border border-slate-200 p-4 sm:flex sm:items-center sm:justify-between sm:gap-5">
+                  <div>
+                    <p className="flex items-center text-sm font-bold text-[#087F72]"><Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> {occurrence.timeLabel}</p>
+                    <h3 className="mt-1 text-lg font-bold text-[#041B2D]">{occurrence.itemName}</h3>
+                    <p className="mt-1 text-sm text-slate-600">{occurrence.dose || "Dose not recorded"}</p>
+                  </div>
+                  {occurrence.status ? (
+                    <div className="mt-3 flex flex-col gap-2 sm:mt-0 sm:items-end">
+                      <span className={`inline-flex min-h-11 items-center rounded-xl px-4 py-2 text-sm font-bold ${occurrence.status === "taken" ? "bg-emerald-100 text-emerald-900" : "bg-slate-200 text-slate-800"}`}>
+                        {occurrence.status === "taken" ? <Check className="mr-2 h-4 w-4" aria-hidden="true" /> : <SkipForward className="mr-2 h-4 w-4" aria-hidden="true" />}
+                        {occurrence.status === "taken" ? "Taken" : "Skipped"}
+                      </span>
+                      <button type="button" disabled={busy || !occurrence.eventId} onClick={() => occurrence.eventId && void undo(occurrence.eventId)} className="inline-flex min-h-11 items-center justify-center rounded-xl px-3 py-2 text-sm font-bold text-[#087F72] hover:bg-[#EAFBF8] disabled:opacity-60">
+                        <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" /> Undo
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="mt-4 grid grid-cols-2 gap-2 sm:mt-0 sm:w-64">
+                      <button type="button" disabled={busy} onClick={() => void record(occurrence, "taken")} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white hover:bg-[#06695F] disabled:opacity-60">
+                        {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Taken
+                      </button>
+                      <button type="button" disabled={busy} onClick={() => void record(occurrence, "skipped")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
+                        <SkipForward className="mr-2 h-4 w-4" aria-hidden="true" /> Skip
+                      </button>
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+            {!day.occurrences.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No scheduled doses are due today.</p> : null}
+          </div>
+
+          {day.asNeeded.length ? (
+            <div className="mt-6 border-t border-slate-200 pt-5">
+              <h3 className="font-bold text-[#041B2D]">As needed</h3>
+              <p className="mt-1 text-sm text-slate-600">These items never appear overdue. Record one only when you take it under your existing instructions.</p>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                {day.asNeeded.map((item) => {
+                  const busy = busyKey === `as-needed:${item.regimenItemId}`;
+                  return <div key={item.regimenItemId} className="rounded-xl border border-slate-200 p-4"><h4 className="font-bold text-[#041B2D]">{item.itemName}</h4><p className="mt-1 text-sm text-slate-600">{item.dose || "Dose not recorded"}</p><button type="button" disabled={busy} onClick={() => void recordAsNeeded(item)} className="mt-3 inline-flex min-h-12 w-full items-center justify-center rounded-xl border border-[#087F72] px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">{busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Record taken</button></div>;
+                })}
+              </div>
+            </div>
+          ) : null}
+
+          {day.scheduleReview ? <p className="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm font-semibold text-amber-950">{day.scheduleReview} current item{day.scheduleReview === 1 ? " needs" : "s need"} a structured schedule before it can appear in this checklist. Use Edit schedule below.</p> : null}
+
+          <details className="mt-6 border-t border-slate-200 pt-5">
+            <summary className="flex min-h-12 cursor-pointer items-center font-bold text-[#041B2D]"><History className="mr-2 h-5 w-5" aria-hidden="true" /> Recent dose history</summary>
+            <div className="mt-3 space-y-2">
+              {day.history.map((entry) => <div key={entry.eventId} className="flex flex-col gap-1 rounded-xl bg-slate-50 p-3 text-sm sm:flex-row sm:items-center sm:justify-between"><span className="font-semibold text-[#041B2D]">{entry.itemName}{entry.dose ? `, ${entry.dose}` : ""}</span><span className="text-slate-600">{formatDay(entry.date)}{entry.time ? ` at ${entry.time}` : ""} · {entry.status === "taken" ? "Taken" : "Skipped"}</span></div>)}
+              {!day.history.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No dose records yet.</p> : null}
+            </div>
+          </details>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function formatDay(value: string): string {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Intl.DateTimeFormat("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric", timeZone: "UTC" })
+    .format(new Date(Date.UTC(year, month - 1, day)));
+}

--- a/app/(app)/routine/print/PrintButton.tsx
+++ b/app/(app)/routine/print/PrintButton.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { Printer } from "lucide-react";
+
+export default function PrintButton() {
+  return (
+    <button type="button" onClick={() => window.print()} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white hover:bg-[#06695F] print:hidden">
+      <Printer className="mr-2 h-5 w-5" aria-hidden="true" /> Print or save as PDF
+    </button>
+  );
+}

--- a/app/(app)/routine/print/page.tsx
+++ b/app/(app)/routine/print/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+
+import { requireTier } from "@/app/_auth/requireTier";
+import { groupRoutineItems, ROUTINE_SECTION_LABELS, ROUTINE_SECTION_ORDER, routineInstructionAuthorityLabel, routineScheduleLabel } from "@/lib/routine";
+import { getRoutineData } from "@/lib/routineData";
+
+import PrintButton from "./PrintButton";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function RoutinePrintPage() {
+  const { user } = await requireTier(["premium", "trial"], { next: "/routine/print" });
+  const data = await getRoutineData(user.id);
+  const grouped = groupRoutineItems(data.items);
+  const generatedAt = new Date();
+
+  return (
+    <article className="mx-auto max-w-4xl rounded-2xl bg-white p-5 shadow-sm print:max-w-none print:rounded-none print:p-0 print:shadow-none sm:p-8">
+      <div className="mb-6 flex flex-col gap-3 border-b border-slate-300 pb-5 sm:flex-row sm:items-center sm:justify-between print:hidden">
+        <Link href="/routine" className="inline-flex min-h-12 items-center font-bold text-[#087F72]">Back to Routine</Link>
+        <PrintButton />
+      </div>
+
+      <header className="border-b-2 border-[#041B2D] pb-5">
+        <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">LVE360 member record</p>
+        <h1 className="mt-2 text-3xl font-extrabold text-[#041B2D]">Current regimen for clinician review</h1>
+        <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
+          <div><dt className="font-bold text-[#041B2D]">Generated</dt><dd>{formatDateTime(generatedAt)}</dd></div>
+          <div><dt className="font-bold text-[#041B2D]">Current items</dt><dd>{grouped.current.length}</dd></div>
+        </dl>
+        <p className="mt-4 text-sm leading-6 text-slate-700">
+          This list reflects information recorded by the member. It is provided to support review and reconciliation. LVE360 does not prescribe, change, or verify medication, hormone, or supplement instructions.
+        </p>
+      </header>
+
+      <div className="mt-6 space-y-7">
+        {ROUTINE_SECTION_ORDER.map((kind) => {
+          const items = grouped.byKind[kind];
+          if (!items.length) return null;
+          return (
+            <section key={kind} className="break-inside-avoid" aria-labelledby={`print-${kind}`}>
+              <h2 id={`print-${kind}`} className="border-b border-slate-300 pb-2 text-xl font-bold text-[#041B2D]">{ROUTINE_SECTION_LABELS[kind]}</h2>
+              <div className="mt-3 space-y-3">
+                {items.map((item) => {
+                  const authority = routineInstructionAuthorityLabel(item.instruction_authority);
+                  return (
+                    <div key={item.id} className="break-inside-avoid rounded-xl border border-slate-300 p-4 print:rounded-none">
+                      <h3 className="text-lg font-bold text-[#041B2D]">{item.name}</h3>
+                      <dl className="mt-2 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+                        <div><dt className="font-bold">Recorded dose or amount</dt><dd>{item.dose?.trim() || "Not recorded"}</dd></div>
+                        <div><dt className="font-bold">Recorded schedule</dt><dd>{routineScheduleLabel(item)}</dd></div>
+                        <div><dt className="font-bold">Instruction source</dt><dd>{authority || "Not recorded"}</dd></div>
+                        <div><dt className="font-bold">Last updated</dt><dd>{item.updated_at ? formatDate(item.updated_at) : "Not available"}</dd></div>
+                        {item.purpose ? <div className="sm:col-span-2"><dt className="font-bold">Purpose reported by member</dt><dd>{item.purpose}</dd></div> : null}
+                      </dl>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+
+      <section className="mt-8 break-inside-avoid border-t border-slate-300 pt-5">
+        <h2 className="text-lg font-bold text-[#041B2D]">Clinician or pharmacist notes</h2>
+        <div className="mt-3 h-28 border-b border-dashed border-slate-400" />
+        <div className="mt-4 h-10 border-b border-dashed border-slate-400" />
+      </section>
+    </article>
+  );
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
+}
+
+function formatDateTime(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit" }).format(value);
+}

--- a/app/api/account/export/route.ts
+++ b/app/api/account/export/route.ts
@@ -38,6 +38,8 @@ export async function GET() {
     { label: "practice_completions", table: "daily_practice_completions", column: "user_id", value: user.id },
     { label: "activation_events", table: "activation_events", column: "user_id", value: user.id },
     { label: "intake_events", table: "intake_events", column: "user_id", value: user.id },
+    { label: "current_regimen", table: "current_regimen_items", column: "user_id", value: user.id },
+    { label: "regimen_dose_events", table: "regimen_dose_events", column: "user_id", value: user.id },
     { label: "product_events", table: "product_events", column: "user_id", value: user.id },
   ];
 

--- a/app/api/routine/doses/route.ts
+++ b/app/api/routine/doses/route.ts
@@ -1,0 +1,205 @@
+import { NextResponse } from "next/server";
+
+import { getCurrentRegimen } from "@/lib/currentRegimen";
+import type { RegimenDoseDay, RegimenDoseHistoryItem, RegimenDoseOccurrence, RegimenDoseStatus } from "@/lib/regimenDose";
+import { formatTime, isLocalDate, normalizeRegimenSchedule, regimenDoseSlots } from "@/lib/regimenSchedule";
+import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+type DoseEventRow = {
+  id: string;
+  regimen_item_id: string;
+  scheduled_date: string;
+  slot_key: string;
+  scheduled_time: string | null;
+  status: RegimenDoseStatus;
+  recorded_at: string;
+};
+
+export async function GET(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  try {
+    const date = new URL(req.url).searchParams.get("date");
+    if (!isLocalDate(date)) return NextResponse.json({ ok: false, error: "valid_date_required" }, { status: 400 });
+
+    const userId = entitlement.user.id;
+    const regimen = await getCurrentRegimen(userId);
+    const itemIds = regimen.map((item) => item.id);
+    const admin = getSupabaseAdmin();
+    const historyStart = shiftDate(date, -13);
+    let events: DoseEventRow[] = [];
+
+    if (itemIds.length) {
+      const { data, error } = await admin
+        .from("regimen_dose_events")
+        .select("id,regimen_item_id,scheduled_date,slot_key,scheduled_time,status,recorded_at")
+        .eq("user_id", userId)
+        .gte("scheduled_date", historyStart)
+        .lte("scheduled_date", date)
+        .in("regimen_item_id", itemIds)
+        .order("scheduled_date", { ascending: false })
+        .order("recorded_at", { ascending: false });
+      if (error) throw error;
+      events = (data ?? []) as DoseEventRow[];
+    }
+
+    const itemMap = new Map(regimen.map((item) => [item.id, item]));
+    const eventMap = new Map(events.map((event) => [eventKey(event.regimen_item_id, event.scheduled_date, event.slot_key), event]));
+    const occurrences: RegimenDoseOccurrence[] = [];
+    const asNeeded: RegimenDoseDay["asNeeded"] = [];
+    let scheduleReview = 0;
+
+    for (const item of regimen) {
+      if (!item.schedule) {
+        scheduleReview += 1;
+        continue;
+      }
+      const schedule = normalizeRegimenSchedule(item.schedule);
+      if (schedule.cadence === "as_needed") {
+        asNeeded.push({ regimenItemId: item.id, itemName: item.name, itemKind: item.item_kind, dose: item.dose });
+        continue;
+      }
+      for (const slot of regimenDoseSlots(schedule, date)) {
+        const event = eventMap.get(eventKey(item.id, date, slot.slotKey));
+        occurrences.push({
+          eventId: event?.id ?? null,
+          regimenItemId: item.id,
+          itemName: item.name,
+          itemKind: item.item_kind,
+          dose: item.dose,
+          date,
+          slotKey: slot.slotKey,
+          time: slot.time,
+          timeLabel: slot.label,
+          status: event?.status ?? null,
+        });
+      }
+    }
+
+    occurrences.sort((left, right) => left.time.localeCompare(right.time) || left.itemName.localeCompare(right.itemName));
+    asNeeded.sort((left, right) => left.itemName.localeCompare(right.itemName));
+
+    const history: RegimenDoseHistoryItem[] = events.map((event) => {
+      const item = itemMap.get(event.regimen_item_id)!;
+      return {
+        eventId: event.id,
+        regimenItemId: event.regimen_item_id,
+        itemName: item.name,
+        itemKind: item.item_kind,
+        dose: item.dose,
+        date: event.scheduled_date,
+        time: event.scheduled_time ? formatTime(event.scheduled_time.slice(0, 5)) : null,
+        status: event.status,
+        recordedAt: event.recorded_at,
+      };
+    });
+
+    return NextResponse.json({ ok: true, day: { date, occurrences, asNeeded, history, scheduleReview } satisfies RegimenDoseDay });
+  } catch (error) {
+    console.error("[routine/doses] load failed", error);
+    return NextResponse.json({ ok: false, error: "routine_doses_unavailable" }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  try {
+    const input = await req.json().catch(() => null) as Record<string, unknown> | null;
+    const regimenItemId = typeof input?.regimen_item_id === "string" ? input.regimen_item_id : null;
+    const date = input?.date;
+    const slotKey = typeof input?.slot_key === "string" ? input.slot_key : null;
+    const status = input?.status;
+    if (!regimenItemId || !isLocalDate(date) || !slotKey || (status !== "taken" && status !== "skipped")) {
+      return NextResponse.json({ ok: false, error: "valid_dose_record_required" }, { status: 400 });
+    }
+
+    const userId = entitlement.user.id;
+    const admin = getSupabaseAdmin();
+    const { data: item, error: itemError } = await admin
+      .from("current_regimen_items")
+      .select("id,schedule")
+      .eq("id", regimenItemId)
+      .eq("user_id", userId)
+      .eq("active", true)
+      .maybeSingle();
+    if (itemError) throw itemError;
+    if (!item?.schedule) return NextResponse.json({ ok: false, error: "structured_schedule_required" }, { status: 400 });
+
+    const schedule = normalizeRegimenSchedule(item.schedule);
+    let persistedSlot = slotKey;
+    let scheduledTime: string | null = null;
+    if (schedule.cadence === "as_needed") {
+      if (slotKey !== "as_needed" || status !== "taken") {
+        return NextResponse.json({ ok: false, error: "invalid_as_needed_record" }, { status: 400 });
+      }
+      persistedSlot = `as-needed-${crypto.randomUUID()}`;
+    } else {
+      const expected = regimenDoseSlots(schedule, date).find((slot) => slot.slotKey === slotKey);
+      if (!expected) return NextResponse.json({ ok: false, error: "dose_not_scheduled" }, { status: 400 });
+      scheduledTime = expected.time;
+    }
+
+    const row = {
+      user_id: userId,
+      regimen_item_id: regimenItemId,
+      scheduled_date: date,
+      slot_key: persistedSlot,
+      scheduled_time: scheduledTime,
+      status,
+      recorded_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    const { data, error } = await admin
+      .from("regimen_dose_events")
+      .upsert(row, { onConflict: "user_id,regimen_item_id,scheduled_date,slot_key" })
+      .select("id")
+      .single();
+    if (error) throw error;
+    return NextResponse.json({ ok: true, eventId: data.id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "dose_record_failed";
+    const invalid = /invalid|required|scheduled|cadence|time|weekday|interval/.test(message);
+    return NextResponse.json({ ok: false, error: message }, { status: invalid ? 400 : 500 });
+  }
+}
+
+export async function DELETE(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  try {
+    const input = await req.json().catch(() => null) as Record<string, unknown> | null;
+    const eventId = typeof input?.event_id === "string" ? input.event_id : null;
+    if (!eventId) return NextResponse.json({ ok: false, error: "event_id_required" }, { status: 400 });
+    const { data, error } = await getSupabaseAdmin()
+      .from("regimen_dose_events")
+      .delete()
+      .eq("id", eventId)
+      .eq("user_id", entitlement.user.id)
+      .select("id")
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return NextResponse.json({ ok: false, error: "dose_event_not_found" }, { status: 404 });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "dose_undo_failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+function eventKey(itemId: string, date: string, slotKey: string): string {
+  return `${itemId}:${date}:${slotKey}`;
+}
+
+function shiftDate(value: string, days: number): string {
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return date.toISOString().slice(0, 10);
+}

--- a/app/api/stacks/update/route.ts
+++ b/app/api/stacks/update/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { requirePaidApi } from "@/lib/serverEntitlements";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
-import { isMedicationInstructionAuthority } from "@/lib/medicationRecord";
+import { isMedicationInstructionAuthority, isRegimenInstructionAuthority } from "@/lib/medicationRecord";
+import { normalizeRegimenSchedule, regimenScheduleLabel } from "@/lib/regimenSchedule";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -11,7 +12,7 @@ export async function POST(req: Request) {
     const entitlement = await requirePaidApi();
     if (!entitlement.ok) return entitlement.response;
 
-    const { id, purpose, dose, timing, active, instructionAuthority } = await req.json();
+    const { id, purpose, dose, timing, schedule, active, instructionAuthority } = await req.json();
     if (!id) return NextResponse.json({ ok: false, error: "missing_id" }, { status: 400 });
 
     const admin = getSupabaseAdmin();
@@ -26,26 +27,37 @@ export async function POST(req: Request) {
     if (!existing) return NextResponse.json({ ok: false, error: "regimen_item_not_found" }, { status: 404 });
     const prescribedItem = existing.item_kind === "medication" || existing.item_kind === "hormone";
     const changesPrescribedInstructions = prescribedItem
-      && [purpose, dose, timing].some((value) => typeof value !== "undefined");
+      && [purpose, dose, timing, schedule].some((value) => typeof value !== "undefined");
     if (changesPrescribedInstructions && !isMedicationInstructionAuthority(instructionAuthority)) {
       return NextResponse.json(
         { ok: false, error: `${existing.item_kind}_instruction_source_required` },
         { status: 400 },
       );
     }
-    if (typeof instructionAuthority !== "undefined" && !prescribedItem) {
-      return NextResponse.json({ ok: false, error: "instruction_source_not_supported" }, { status: 400 });
+    const changesSupplementSchedule = !prescribedItem && typeof schedule !== "undefined";
+    if (changesSupplementSchedule
+      && (!isRegimenInstructionAuthority(instructionAuthority) || instructionAuthority === "medication_label")) {
+      return NextResponse.json({ ok: false, error: "supplement_instruction_source_required" }, { status: 400 });
+    }
+    if (typeof instructionAuthority !== "undefined"
+      && !isRegimenInstructionAuthority(instructionAuthority)) {
+      return NextResponse.json({ ok: false, error: "invalid_instruction_source" }, { status: 400 });
     }
 
     const patch: Record<string, unknown> = Object.fromEntries(
       Object.entries({ purpose, dose, timing, active })
         .filter(([, value]) => typeof value !== "undefined")
     );
+    if (typeof schedule !== "undefined") {
+      const normalizedSchedule = schedule === null ? null : normalizeRegimenSchedule(schedule);
+      patch.schedule = normalizedSchedule;
+      if (normalizedSchedule) patch.timing = regimenScheduleLabel(normalizedSchedule);
+    }
     if (!Object.keys(patch).length) {
       return NextResponse.json({ ok: false, error: "no_supported_changes" }, { status: 400 });
     }
     patch.instruction_source = "member_update";
-    if (changesPrescribedInstructions) patch.instruction_authority = instructionAuthority;
+    if (changesPrescribedInstructions || changesSupplementSchedule) patch.instruction_authority = instructionAuthority;
     patch.updated_at = new Date().toISOString();
 
     const { data, error } = await admin
@@ -60,6 +72,8 @@ export async function POST(req: Request) {
     if (!data) return NextResponse.json({ ok: false, error: "regimen_item_not_found" }, { status: 404 });
     return NextResponse.json({ ok: true });
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: e?.message ?? "unknown_error" }, { status: 500 });
+    const message = e?.message ?? "unknown_error";
+    const invalid = /invalid|required|cadence|time|weekday|interval/.test(message);
+    return NextResponse.json({ ok: false, error: message }, { status: invalid ? 400 : 500 });
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qa:routine": "node --experimental-strip-types src/_tests_/routine.assert.ts && node src/_tests_/routinePage.assert.mjs",
     "qa:pr74": "node --experimental-strip-types src/_tests_/pr74.assert.ts && node src/_tests_/pr74Page.assert.mjs",
     "qa:pr75": "node --experimental-strip-types src/_tests_/pr75.assert.ts && node src/_tests_/pr75Page.assert.mjs",
+    "qa:pr76": "node --experimental-strip-types src/_tests_/pr76.assert.ts && node src/_tests_/pr76Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr76.assert.ts
+++ b/src/_tests_/pr76.assert.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+
+import {
+  isRegimenScheduleDue,
+  normalizeRegimenSchedule,
+  regimenDoseSlots,
+  regimenScheduleLabel,
+} from "../lib/regimenSchedule.ts";
+
+const twiceDaily = normalizeRegimenSchedule({ cadence: "daily", times: ["08:00", "20:00"] });
+assert.equal(regimenScheduleLabel(twiceDaily), "Daily at 8:00 AM and 8:00 PM");
+assert.deepEqual(regimenDoseSlots(twiceDaily, "2026-08-01").map((slot) => slot.slotKey), ["08:00", "20:00"]);
+
+const alternateDays = normalizeRegimenSchedule({ cadence: "every_n_days", times: ["18:00"], interval_days: 2, anchor_date: "2026-08-01" });
+assert.equal(isRegimenScheduleDue(alternateDays, "2026-08-01"), true);
+assert.equal(isRegimenScheduleDue(alternateDays, "2026-08-02"), false);
+assert.equal(isRegimenScheduleDue(alternateDays, "2026-08-03"), true);
+
+const weekdays = normalizeRegimenSchedule({ cadence: "weekdays", times: ["07:30"], weekdays: [1, 3, 5] });
+assert.equal(isRegimenScheduleDue(weekdays, "2026-08-03"), true, "Monday must be due");
+assert.equal(isRegimenScheduleDue(weekdays, "2026-08-04"), false, "Tuesday must not be due");
+
+const weekly = normalizeRegimenSchedule({ cadence: "weekly", times: ["09:00"], weekdays: [0] });
+assert.equal(isRegimenScheduleDue(weekly, "2026-08-02"), true, "Sunday must be due");
+assert.equal(regimenDoseSlots(weekly, "2026-08-03").length, 0);
+
+const asNeeded = normalizeRegimenSchedule({ cadence: "as_needed", times: [] });
+assert.equal(regimenDoseSlots(asNeeded, "2026-08-01").length, 0);
+assert.match(regimenScheduleLabel(asNeeded), /As needed/);
+
+assert.throws(() => normalizeRegimenSchedule({ cadence: "daily", times: [] }), /time_required/);
+assert.throws(() => normalizeRegimenSchedule({ cadence: "every_n_days", times: ["08:00"], interval_days: 1, anchor_date: "2026-08-01" }), /interval_required/);
+assert.throws(() => normalizeRegimenSchedule({ cadence: "weekly", times: ["08:00"], weekdays: [1, 2] }), /weekly_day_required/);
+
+console.log("PR76 schedule assertions passed");

--- a/src/_tests_/pr76Page.assert.mjs
+++ b/src/_tests_/pr76Page.assert.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const migration = read("supabase/migrations/20260801202927_pr76_flexible_regimen_organizer.sql");
+assert.match(migration, /add column if not exists schedule jsonb/i, "PR76 must persist structured schedules.");
+assert.match(migration, /create table if not exists public\.regimen_dose_events/i, "PR76 must store dose occurrences separately.");
+assert.match(migration, /unique \(user_id, regimen_item_id, scheduled_date, slot_key\)/i, "One scheduled occurrence must have one owner-scoped record.");
+assert.match(migration, /enable row level security/i, "Dose history must use RLS.");
+assert.match(migration, /grant select on table public\.regimen_dose_events to authenticated/i, "Members may read only through the owner policy.");
+assert.match(migration, /grant select, insert, update, delete on table public\.regimen_dose_events to service_role/i, "Validated server routes must own dose mutations.");
+
+const dosesRoute = read("app/api/routine/doses/route.ts");
+assert.match(dosesRoute, /requirePaidApi/, "Dose records must require paid access.");
+assert.match(dosesRoute, /eq\("user_id", userId\)/, "Dose records must verify ownership.");
+assert.match(dosesRoute, /regimenDoseSlots\(schedule, date\)/, "The server must verify that a scheduled slot is actually due.");
+assert.match(dosesRoute, /status !== "taken"/, "As-needed records must not create skipped or overdue states.");
+assert.match(dosesRoute, /\.eq\("user_id", entitlement\.user\.id\)/, "Undo must remain owner scoped.");
+
+const today = read("app/(app)/routine/TodayDoses.tsx");
+assert.match(today, /Your dose checklist/, "Routine must expose today's scheduled occurrences.");
+assert.match(today, /record\(occurrence, "taken"\)/, "Each occurrence needs a Taken action.");
+assert.match(today, /record\(occurrence, "skipped"\)/, "Each occurrence needs a neutral Skip action.");
+assert.match(today, /Recent dose history/, "Members must be able to review recent records.");
+assert.match(today, /never appear overdue/, "As-needed items must not imply nonadherence.");
+assert.match(today, /min-h-12/, "Dose controls need large tap targets.");
+assert.match(today, /Boolean\(occurrence\.eventId\)/, "Unrecorded occurrences must not inherit the idle null state as busy.");
+
+const editor = read("app/(app)/routine/ScheduleEditor.tsx");
+assert.match(editor, /Every number of days/, "Alternating-day schedules must be supported.");
+assert.match(editor, /Add another time/, "Multiple daily dose times must be supported.");
+assert.match(editor, /aria-pressed/, "Day selection must not rely on color alone.");
+
+const printPage = read("app/(app)/routine/print/page.tsx");
+assert.match(printPage, /requireTier\(\["premium", "trial"\]/, "The clinician list must stay private.");
+assert.match(printPage, /Current regimen for clinician review/, "The printout needs a clear review purpose.");
+assert.match(printPage, /Instruction source/, "The printout must preserve provenance.");
+assert.match(printPage, /does not prescribe, change, or verify/, "The printout must use neutral safety language.");
+
+const accountExport = read("app/api/account/export/route.ts");
+assert.match(accountExport, /regimen_dose_events/, "Dose history must be included in the member data export.");
+assert.match(accountExport, /current_regimen_items/, "The canonical regimen must be included in the member data export.");
+
+console.log("PR76 page, privacy, and safety assertions passed");

--- a/src/_tests_/routinePage.assert.mjs
+++ b/src/_tests_/routinePage.assert.mjs
@@ -22,7 +22,7 @@ assert.match(routineModel, /hormone: "Hormones"/, "Routine must separate hormone
 assert.match(routineModel, /supplement: "Supplements"/, "Routine must separate supplements.");
 assert.match(routineModel, /endocrine_active_supplement: "Hormone-active items"/, "Routine must separate hormone-active items.");
 assert.match(client, /Ideas to consider/, "Routine must separate proposed ideas.");
-assert.match(client, /Record prescribed change/, "Members must be able to record clinician-directed medication changes.");
+assert.match(client, /Record dose or schedule change/, "Members must be able to record clinician-directed medication changes.");
 assert.match(client, /kind="hormone"/, "Members must be able to record clinician-directed hormone changes.");
 assert.match(client, /Schedule not recorded/, "Missing schedules must be stated plainly.");
 assert.match(client, /RotateCcw[\s\S]*Undo/, "State changes must expose text and icon Undo.");

--- a/src/lib/currentRegimen.ts
+++ b/src/lib/currentRegimen.ts
@@ -12,8 +12,9 @@ import {
   type CurrentRegimenSource,
 } from "@/lib/currentRegimenModel";
 import type { MedicationInstructionAuthority } from "@/lib/medicationRecord";
+import { regimenScheduleLabel, type RegimenSchedule } from "@/lib/regimenSchedule";
 
-const REGIMEN_COLUMNS = "id,user_id,source_submission_id,source_stack_item_id,item_kind,name,normalized_name,purpose,dose,timing,instruction_source,instruction_authority,active,created_at,updated_at";
+const REGIMEN_COLUMNS = "id,user_id,source_submission_id,source_stack_item_id,item_kind,name,normalized_name,purpose,dose,timing,schedule,instruction_source,instruction_authority,active,created_at,updated_at";
 
 export async function getCurrentRegimen(userId: string, includeInactive = false): Promise<CurrentRegimenItem[]> {
   const admin = getSupabaseAdmin();
@@ -153,6 +154,7 @@ export async function upsertReportedMedication(userId: string, input: {
   timing: string | null;
   purpose: string | null;
   instruction_authority: MedicationInstructionAuthority;
+  schedule?: RegimenSchedule | null;
 }) {
   await ensureLatestUserRegimen(userId);
   const row = {
@@ -164,7 +166,8 @@ export async function upsertReportedMedication(userId: string, input: {
     normalized_name: normalizeRegimenName(input.name),
     purpose: input.purpose,
     dose: input.dose,
-    timing: input.timing,
+    timing: input.schedule ? regimenScheduleLabel(input.schedule) : input.timing,
+    schedule: input.schedule ?? null,
     instruction_source: "manual_add" satisfies CurrentRegimenSource,
     instruction_authority: input.instruction_authority,
     active: true,
@@ -184,6 +187,7 @@ export async function upsertReportedHormone(userId: string, input: {
   timing: string | null;
   purpose: string | null;
   instruction_authority: MedicationInstructionAuthority;
+  schedule?: RegimenSchedule | null;
 }) {
   await ensureLatestUserRegimen(userId);
   const row = {
@@ -195,7 +199,8 @@ export async function upsertReportedHormone(userId: string, input: {
     normalized_name: normalizeRegimenName(input.name),
     purpose: input.purpose,
     dose: input.dose,
-    timing: input.timing,
+    timing: input.schedule ? regimenScheduleLabel(input.schedule) : input.timing,
+    schedule: input.schedule ?? null,
     instruction_source: "manual_add" satisfies CurrentRegimenSource,
     instruction_authority: input.instruction_authority,
     active: true,

--- a/src/lib/currentRegimenModel.ts
+++ b/src/lib/currentRegimenModel.ts
@@ -1,6 +1,7 @@
 import type { NormalizedCurrentStackLedgerItem } from "@/lib/normalizedCurrentStackLedger";
 import { isEndocrineActiveSupplementName } from "@/lib/supplementEligibility";
-import type { MedicationInstructionAuthority } from "@/lib/medicationRecord";
+import type { RegimenInstructionAuthority } from "@/lib/medicationRecord";
+import type { RegimenSchedule } from "@/lib/regimenSchedule";
 
 export type CurrentRegimenKind = NormalizedCurrentStackLedgerItem["kind"];
 export type CurrentRegimenSource = "intake" | "member_update" | "adopted_recommendation" | "manual_add";
@@ -17,7 +18,8 @@ export type CurrentRegimenItem = {
   dose: string | null;
   timing: string | null;
   instruction_source: CurrentRegimenSource;
-  instruction_authority: MedicationInstructionAuthority | null;
+  instruction_authority: RegimenInstructionAuthority | null;
+  schedule: RegimenSchedule | null;
   active: boolean;
   created_at?: string;
   updated_at?: string;

--- a/src/lib/medicationRecord.ts
+++ b/src/lib/medicationRecord.ts
@@ -1,3 +1,5 @@
+import { normalizeRegimenSchedule } from "./regimenSchedule.ts";
+
 export const MEDICATION_INSTRUCTION_AUTHORITIES = [
   "clinician",
   "pharmacist",
@@ -6,15 +8,32 @@ export const MEDICATION_INSTRUCTION_AUTHORITIES = [
 
 export type MedicationInstructionAuthority = (typeof MEDICATION_INSTRUCTION_AUTHORITIES)[number];
 
+export const REGIMEN_INSTRUCTION_AUTHORITIES = [
+  ...MEDICATION_INSTRUCTION_AUTHORITIES,
+  "product_label",
+] as const;
+
+export type RegimenInstructionAuthority = (typeof REGIMEN_INSTRUCTION_AUTHORITIES)[number];
+
 export const MEDICATION_AUTHORITY_LABELS: Record<MedicationInstructionAuthority, string> = {
   clinician: "My clinician or prescriber",
   pharmacist: "My pharmacist",
   medication_label: "My current prescription label",
 };
 
+export const REGIMEN_AUTHORITY_LABELS: Record<RegimenInstructionAuthority, string> = {
+  ...MEDICATION_AUTHORITY_LABELS,
+  product_label: "My current product label",
+};
+
 export function isMedicationInstructionAuthority(value: unknown): value is MedicationInstructionAuthority {
   return typeof value === "string"
     && MEDICATION_INSTRUCTION_AUTHORITIES.includes(value as MedicationInstructionAuthority);
+}
+
+export function isRegimenInstructionAuthority(value: unknown): value is RegimenInstructionAuthority {
+  return typeof value === "string"
+    && REGIMEN_INSTRUCTION_AUTHORITIES.includes(value as RegimenInstructionAuthority);
 }
 
 function clean(value: unknown, maxLength: number): string | null {
@@ -47,5 +66,6 @@ function normalizePrescribedRecordInput(value: unknown, kind: "medication" | "ho
     timing: clean(input.timing, 160),
     purpose: clean(input.purpose, 200),
     instruction_authority: input.instruction_authority,
+    ...(typeof input.schedule !== "undefined" ? { schedule: normalizeRegimenSchedule(input.schedule) } : {}),
   };
 }

--- a/src/lib/regimenDose.ts
+++ b/src/lib/regimenDose.ts
@@ -1,0 +1,43 @@
+import type { RoutineItemKind } from "@/lib/routine";
+
+export type RegimenDoseStatus = "taken" | "skipped";
+
+export type RegimenDoseOccurrence = {
+  eventId: string | null;
+  regimenItemId: string;
+  itemName: string;
+  itemKind: RoutineItemKind;
+  dose: string | null;
+  date: string;
+  slotKey: string;
+  time: string;
+  timeLabel: string;
+  status: RegimenDoseStatus | null;
+};
+
+export type AsNeededRegimenItem = {
+  regimenItemId: string;
+  itemName: string;
+  itemKind: RoutineItemKind;
+  dose: string | null;
+};
+
+export type RegimenDoseHistoryItem = {
+  eventId: string;
+  regimenItemId: string;
+  itemName: string;
+  itemKind: RoutineItemKind;
+  dose: string | null;
+  date: string;
+  time: string | null;
+  status: RegimenDoseStatus;
+  recordedAt: string;
+};
+
+export type RegimenDoseDay = {
+  date: string;
+  occurrences: RegimenDoseOccurrence[];
+  asNeeded: AsNeededRegimenItem[];
+  history: RegimenDoseHistoryItem[];
+  scheduleReview: number;
+};

--- a/src/lib/regimenSchedule.ts
+++ b/src/lib/regimenSchedule.ts
@@ -1,0 +1,127 @@
+export const REGIMEN_CADENCES = ["daily", "every_n_days", "weekdays", "weekly", "as_needed"] as const;
+
+export type RegimenCadence = (typeof REGIMEN_CADENCES)[number];
+
+export type RegimenSchedule = {
+  cadence: RegimenCadence;
+  times: string[];
+  weekdays: number[];
+  interval_days: number | null;
+  anchor_date: string | null;
+};
+
+export type DoseSlot = {
+  slotKey: string;
+  time: string;
+  label: string;
+};
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+const DAY_LABELS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+function validDate(value: string): boolean {
+  if (!DATE_PATTERN.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day;
+}
+
+export function isLocalDate(value: unknown): value is string {
+  return typeof value === "string" && validDate(value);
+}
+
+export function localDateString(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function normalizeRegimenSchedule(value: unknown): RegimenSchedule {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_regimen_schedule");
+  const input = value as Record<string, unknown>;
+  const cadence = input.cadence;
+  if (typeof cadence !== "string" || !REGIMEN_CADENCES.includes(cadence as RegimenCadence)) {
+    throw new Error("invalid_regimen_cadence");
+  }
+
+  const times = Array.isArray(input.times)
+    ? [...new Set(input.times.filter((time): time is string => typeof time === "string").map((time) => time.trim()))].sort()
+    : [];
+  if (times.some((time) => !TIME_PATTERN.test(time)) || times.length > 6) throw new Error("invalid_regimen_times");
+
+  const weekdays = Array.isArray(input.weekdays)
+    ? [...new Set(input.weekdays.filter((day): day is number => Number.isInteger(day) && day >= 0 && day <= 6))].sort()
+    : [];
+  const intervalDays = typeof input.interval_days === "number" && Number.isInteger(input.interval_days)
+    ? input.interval_days
+    : null;
+  const anchorDate = typeof input.anchor_date === "string" && validDate(input.anchor_date)
+    ? input.anchor_date
+    : null;
+
+  if (cadence !== "as_needed" && (times.length < 1 || times.length > 6)) throw new Error("regimen_time_required");
+  if (cadence === "weekdays" && weekdays.length < 1) throw new Error("regimen_weekday_required");
+  if (cadence === "weekly" && weekdays.length !== 1) throw new Error("regimen_weekly_day_required");
+  if (cadence === "every_n_days" && (!intervalDays || intervalDays < 2 || intervalDays > 30 || !anchorDate)) {
+    throw new Error("regimen_interval_required");
+  }
+
+  return {
+    cadence: cadence as RegimenCadence,
+    times: cadence === "as_needed" ? [] : times,
+    weekdays: cadence === "weekdays" || cadence === "weekly" ? weekdays : [],
+    interval_days: cadence === "every_n_days" ? intervalDays : null,
+    anchor_date: cadence === "every_n_days" ? anchorDate : null,
+  };
+}
+
+export function regimenScheduleLabel(schedule: RegimenSchedule): string {
+  if (schedule.cadence === "as_needed") return "As needed, using your recorded instructions";
+  const times = schedule.times.map(formatTime).join(" and ");
+  if (schedule.cadence === "daily") return `Daily at ${times}`;
+  if (schedule.cadence === "weekdays") {
+    return `${schedule.weekdays.map((day) => DAY_LABELS[day]).join(", ")} at ${times}`;
+  }
+  if (schedule.cadence === "weekly") return `Weekly on ${DAY_LABELS[schedule.weekdays[0]]} at ${times}`;
+  return `Every ${schedule.interval_days} days from ${formatDate(schedule.anchor_date!)} at ${times}`;
+}
+
+export function isRegimenScheduleDue(schedule: RegimenSchedule, date: string): boolean {
+  if (!validDate(date) || schedule.cadence === "as_needed") return false;
+  const day = dateDay(date);
+  if (schedule.cadence === "daily") return true;
+  if (schedule.cadence === "weekdays" || schedule.cadence === "weekly") return schedule.weekdays.includes(day);
+  const elapsed = daysBetween(schedule.anchor_date!, date);
+  return elapsed >= 0 && elapsed % schedule.interval_days! === 0;
+}
+
+export function regimenDoseSlots(schedule: RegimenSchedule, date: string): DoseSlot[] {
+  if (!isRegimenScheduleDue(schedule, date)) return [];
+  return schedule.times.map((time) => ({ slotKey: time, time, label: formatTime(time) }));
+}
+
+export function formatTime(value: string): string {
+  const [hour, minute] = value.split(":").map(Number);
+  const suffix = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 || 12;
+  return `${displayHour}:${String(minute).padStart(2, "0")} ${suffix}`;
+}
+
+function dateDay(value: string): number {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+}
+
+function daysBetween(start: string, end: string): number {
+  const startMs = Date.parse(`${start}T00:00:00Z`);
+  const endMs = Date.parse(`${end}T00:00:00Z`);
+  return Math.floor((endMs - startMs) / 86_400_000);
+}
+
+function formatDate(value: string): string {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" })
+    .format(new Date(Date.UTC(year, month - 1, day)));
+}

--- a/src/lib/routine.ts
+++ b/src/lib/routine.ts
@@ -1,3 +1,12 @@
+import type { RegimenInstructionAuthority } from "./medicationRecord.ts";
+import {
+  isRegimenScheduleDue,
+  localDateString,
+  regimenDoseSlots,
+  regimenScheduleLabel,
+  type RegimenSchedule,
+} from "./regimenSchedule.ts";
+
 export type RoutineItemKind = "medication" | "supplement" | "hormone" | "endocrine_active_supplement";
 export type RoutineSourceType = "regimen" | "blueprint_proposal";
 
@@ -13,7 +22,8 @@ export type RoutineItem = {
   notes: string | null;
   item_kind: RoutineItemKind;
   instruction_source?: "intake" | "member_update" | "adopted_recommendation" | "manual_add" | null;
-  instruction_authority?: "clinician" | "pharmacist" | "medication_label" | null;
+  instruction_authority?: RegimenInstructionAuthority | null;
+  schedule?: RegimenSchedule | null;
   active?: boolean;
   is_current: boolean;
   source_type: RoutineSourceType;
@@ -22,6 +32,7 @@ export type RoutineItem = {
   refill_days_left: number | null;
   last_refilled_at: string | null;
   created_at?: string | null;
+  updated_at?: string | null;
 };
 
 export const ROUTINE_SECTION_ORDER = [
@@ -49,7 +60,8 @@ export function groupRoutineItems(items: RoutineItem[]) {
   };
 }
 
-export function routineScheduleLabel(item: Pick<RoutineItem, "timing" | "timing_text">): string {
+export function routineScheduleLabel(item: Pick<RoutineItem, "timing" | "timing_text" | "schedule">): string {
+  if (item.schedule) return regimenScheduleLabel(item.schedule);
   return item.timing?.trim() || item.timing_text?.trim() || "Schedule not recorded";
 }
 
@@ -64,9 +76,10 @@ const DAY_INDEX: Record<string, number> = {
 };
 
 export function isRoutineItemDueToday(
-  item: Pick<RoutineItem, "timing" | "timing_text">,
+  item: Pick<RoutineItem, "timing" | "timing_text" | "schedule">,
   today = new Date()
 ): boolean {
+  if (item.schedule) return isRegimenScheduleDue(item.schedule, localDateString(today));
   const schedule = routineScheduleLabel(item).toLowerCase();
   if (schedule === "schedule not recorded" || /\b(as needed|prn)\b/.test(schedule)) return false;
   const namedDays = Object.entries(DAY_INDEX)
@@ -79,8 +92,12 @@ export function isRoutineItemDueToday(
 
 export function getRoutineTodaySummary(items: RoutineItem[], today = new Date()) {
   const { current, proposals } = groupRoutineItems(items);
+  const date = localDateString(today);
   return {
-    dueToday: current.filter((item) => isRoutineItemDueToday(item, today)).length,
+    dueToday: current.reduce((total, item) => {
+      if (item.schedule) return total + regimenDoseSlots(item.schedule, date).length;
+      return total + (isRoutineItemDueToday(item, today) ? 1 : 0);
+    }, 0),
     scheduleReview: current.filter((item) => routineScheduleLabel(item) === "Schedule not recorded").length,
     ideasToConsider: proposals.length,
   };
@@ -97,6 +114,7 @@ export function routineInstructionAuthorityLabel(authority: RoutineItem["instruc
   if (authority === "clinician") return "Instruction reported from your clinician or prescriber";
   if (authority === "pharmacist") return "Instruction reported from your pharmacist";
   if (authority === "medication_label") return "Instruction recorded from your medication label";
+  if (authority === "product_label") return "Instruction recorded from your product label";
   return null;
 }
 

--- a/src/lib/routineData.ts
+++ b/src/lib/routineData.ts
@@ -35,6 +35,7 @@ export async function getRoutineData(userId: string): Promise<{
     item_kind: item.item_kind,
     instruction_source: item.instruction_source,
     instruction_authority: item.instruction_authority,
+    schedule: item.schedule,
     active: item.active,
     is_current: true,
     source_type: "regimen",
@@ -43,6 +44,7 @@ export async function getRoutineData(userId: string): Promise<{
     refill_days_left: null,
     last_refilled_at: null,
     created_at: item.created_at ?? item.updated_at ?? null,
+    updated_at: item.updated_at ?? item.created_at ?? null,
   }));
 
   let proposals: RoutineItem[] = [];
@@ -67,6 +69,7 @@ export async function getRoutineData(userId: string): Promise<{
         item_kind: regimenKindForSupplement(item.name),
         instruction_source: null,
         instruction_authority: null,
+        schedule: null,
         active: false,
         is_current: false,
         source_type: "blueprint_proposal",
@@ -75,6 +78,7 @@ export async function getRoutineData(userId: string): Promise<{
         refill_days_left: item.refill_days_left,
         last_refilled_at: item.last_refilled_at,
         created_at: item.created_at,
+        updated_at: item.created_at,
       }));
   }
 

--- a/supabase/migrations/20260801202927_pr76_flexible_regimen_organizer.sql
+++ b/supabase/migrations/20260801202927_pr76_flexible_regimen_organizer.sql
@@ -1,0 +1,68 @@
+-- PR76: structured member-recorded schedules and per-occurrence completion.
+alter table public.current_regimen_items
+  add column if not exists schedule jsonb;
+
+alter table public.current_regimen_items
+  drop constraint if exists current_regimen_items_schedule_check;
+
+alter table public.current_regimen_items
+  add constraint current_regimen_items_schedule_check
+  check (
+    schedule is null
+    or (
+      jsonb_typeof(schedule) = 'object'
+      and schedule->>'cadence' in ('daily', 'every_n_days', 'weekdays', 'weekly', 'as_needed')
+    )
+  );
+
+comment on column public.current_regimen_items.schedule is
+  'Structured schedule copied from a member-reported clinician, pharmacist, prescription label, or product label instruction. Never generated as dosing advice.';
+
+alter table public.current_regimen_items
+  drop constraint if exists current_regimen_items_instruction_authority_check;
+
+alter table public.current_regimen_items
+  add constraint current_regimen_items_instruction_authority_check
+  check (
+    instruction_authority is null
+    or instruction_authority in ('clinician', 'pharmacist', 'medication_label', 'product_label')
+  );
+
+create table if not exists public.regimen_dose_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  regimen_item_id uuid not null references public.current_regimen_items(id) on delete cascade,
+  scheduled_date date not null,
+  slot_key text not null check (char_length(slot_key) between 1 and 80),
+  scheduled_time time,
+  status text not null check (status in ('taken', 'skipped')),
+  recorded_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint regimen_dose_events_user_item_date_slot_key
+    unique (user_id, regimen_item_id, scheduled_date, slot_key)
+);
+
+create index if not exists regimen_dose_events_user_date_idx
+  on public.regimen_dose_events (user_id, scheduled_date desc, recorded_at desc);
+
+create index if not exists regimen_dose_events_regimen_item_idx
+  on public.regimen_dose_events (regimen_item_id, scheduled_date desc);
+
+alter table public.regimen_dose_events enable row level security;
+
+drop policy if exists "regimen_dose_events: select own" on public.regimen_dose_events;
+create policy "regimen_dose_events: select own"
+  on public.regimen_dose_events for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.regimen_dose_events from public, anon, authenticated;
+grant select on table public.regimen_dose_events to authenticated;
+grant select, insert, update, delete on table public.regimen_dose_events to service_role;
+
+comment on table public.regimen_dose_events is
+  'Owner-scoped records of member-confirmed taken or skipped regimen occurrences. A skipped event is not a clinical recommendation or missed-dose instruction.';
+
+-- Rollback notes:
+-- Drop regimen_dose_events first, then remove current_regimen_items.schedule.
+-- Restore the prior instruction-authority constraint without product_label only after
+-- confirming no current row uses that provenance value.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Purpose

Turn Routine into a practical daily regimen organizer that supports real-world schedules and gives members a clean list to review with a clinician or pharmacist.

## What changed

- Adds a per-dose checklist with Taken, Skipped, Undo, and recent history.
- Supports multiple times per day, every N days, selected weekdays, weekly, and as-needed schedules.
- Keeps completion attached to an individual scheduled occurrence instead of marking an entire item complete for the day.
- Adds structured schedule editing for medications, hormones, supplements, and hormone-active supplements.
- Preserves whether an instruction came from a clinician, pharmacist, prescription label, or product label.
- Adds a private clinician-review print page that also works with browser Save as PDF.
- Adds the canonical regimen and dose-event records to the member data export.
- Keeps as-needed items out of overdue or nonadherence states.
- Adds owner-scoped dose-event storage with RLS and server-only mutation privileges.

## Safety and privacy

- LVE360 records member-reported instructions and never chooses dose timing.
- Skipped does not imply a recommendation and the product gives no missed-dose advice.
- Medication and hormone edits continue to require an external instruction source.
- The printout is authenticated and creates no public share URL.
- Dose records are readable only through owner-scoped RLS and writable only through validated paid server routes.

## Database

Applied and verified Supabase migration `pr76_flexible_regimen_organizer`.

Verified:

- `current_regimen_items.schedule` exists as JSONB.
- `regimen_dose_events` exists with RLS enabled.
- The owner-select policy exists.
- Authenticated users can select their own records but cannot insert directly.
- The service role can perform validated server writes.
- Both required lookup indexes exist.
- Post-migration security advisors reported no PR76 table finding. The unused-index notices are expected before initial traffic.

## Verification

Passed:

- `npm.cmd run qa:pr76`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr74`
- `npm.cmd run qa:pr75`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:settings`
- `npm.cmd run typecheck`
- `git diff --check`

The production build compiled and type-checked. Local page-data collection then stopped at the repository's known missing local `OPENAI_API_KEY` and other launch secrets. Vercel provides the real Preview environment and must complete the deployment check.

## QA checklist

- Set one item to two daily times and confirm two separate dose rows appear.
- Mark one occurrence Taken and the other Skipped, then test Undo.
- Set an every-two-days schedule and confirm it appears only on due dates.
- Set a selected-weekday and a weekly schedule.
- Set an item to As needed and confirm it never appears overdue.
- Record an as-needed dose and verify it appears in recent history.
- Open Print clinician list and test browser printing and Save as PDF.
- Confirm dose, schedule, instruction source, and last-updated date appear on the printout.
- Confirm keyboard operation, focus visibility, readable text, and non-color status cues.

## Rollback

Revert the application commit first. The additive dose-event table and schedule column may remain without affecting prior flows. If schema rollback is required, drop `regimen_dose_events`, remove `current_regimen_items.schedule`, and restore the prior instruction-authority constraint only after confirming no row uses `product_label`.
