### PR TITLE
PR78 — Canonicalize paid post-intake handoff

### DIFF
--- a/app/(app)/results/premium/page.tsx
+++ b/app/(app)/results/premium/page.tsx
@@ -1,547 +1,166 @@
 "use client";
 
-import { motion } from "framer-motion";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import CTAButton from "@/components/CTAButton";
-import { AFFILIATE_DISCLOSURE_NEAR_LINKS, AFFILIATE_DISCLOSURE_SUPPORT } from "@/lib/reportDisclosures";
+import { AlertCircle, ArrowRight, CheckCircle2, FileText, Loader2, RefreshCw } from "lucide-react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 
-/* ───────── helpers ───────── */
-function sanitizeMarkdown(md: string): string {
-  return md
-    ? md.replace(/^```[a-z]*\n/i, "").replace(/```$/, "").trim()
-    : md;
-}
-function escapeRegExp(s: string) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-function extractSection(md: string, heads: string[]): string | null {
-  if (!md) return null;
-  let start = -1;
-  for (const h of heads) {
-    const re = new RegExp(`^##\\s*${escapeRegExp(h)}\\b.*`, "mi");
-    const m = re.exec(md);
-    if (m && (start === -1 || (m.index ?? -1) < start)) start = m.index;
-  }
-  if (start === -1) return null;
-  const tail = md.slice(start + 1);
-  const next = /\n##\s+/m.exec(tail);
-  const end = next ? start + 1 + next.index : md.length;
-  let slice = md.slice(start, end);
-  return slice.replace(/^##\s*[^\n]+\n?/, "").trim();
-}
+import { trackProductEvent } from "@/lib/productAnalyticsClient";
 
-/* Markdown renderer */
-function Prose({ children }: { children: string }) {
-  return (
-    <div className="prose prose-gray max-w-none">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          h2: ({ node, ...props }) => (
-            <h2
-              className="text-2xl font-bold text-teal-600 mt-8 mb-4 border-b border-gray-200 pb-1"
-              {...props}
-            />
-          ),
-          table: ({ node, ...props }) => (
-            <table
-              className="w-full border-collapse my-4 text-sm shadow-sm"
-              {...props}
-            />
-          ),
-          thead: ({ node, ...props }) => (
-            <thead className="bg-[#06C1A0] text-white" {...props} />
-          ),
-          th: ({ node, ...props }) => (
-            <th className="px-3 py-0.5 text-left font-semibold" {...props} />
-          ),
-          td: ({ node, ...props }) => (
-            <td className="px-3 py-0.5 border-t border-gray-200 align-middle" {...props} />
-          ),
-          tr: ({ node, ...props }) => (
-            <tr className="even:bg-gray-50" {...props} />
-          ),
-          strong: ({ node, ...props }) => (
-            <strong className="font-semibold text-[#041B2D]" {...props} />
-          ),
-        }}
-      >
-        {children}
-      </ReactMarkdown>
-    </div>
-  );
-}
+type HandoffState =
+  | { name: "loading" }
+  | { name: "no_submission" }
+  | { name: "generating"; submissionId: string }
+  | { name: "ready"; stackId: string }
+  | { name: "error"; message: string; submissionId?: string };
 
-/* Evidence + Shopping table */
-function LinksTable({
-  raw,
-  type,
-}: {
-  raw: string;
-  type: "evidence" | "shopping";
-}) {
-  const linkRe = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+const POLL_INTERVAL_MS = 4_000;
+const GENERATION_WAIT_MS = 240_000;
 
-  const lines = raw.split("\n").map((l) => l.trim());
-  const bulletLines = lines.filter((l) => l.startsWith("-"));
-  const analysisIndex = lines.findIndex((l) =>
-    l.toLowerCase().startsWith("**analysis")
-  );
-  const analysis =
-    analysisIndex !== -1 ? lines.slice(analysisIndex).join(" ") : null;
+function PremiumResultsHandoff() {
+  const searchParams = useSearchParams();
+  const requestedSubmissionId = searchParams.get("submission_id");
+  const [state, setState] = useState<HandoffState>({ name: "loading" });
+  const [pollAttempt, setPollAttempt] = useState(0);
+  const startedAtRef = useRef(Date.now());
 
-  const rows = bulletLines
-    .map((line) => {
-      const matches = Array.from(line.matchAll(linkRe));
-      if (matches.length === 0) return null;
+  const checkStatus = useCallback(async () => {
+    const query = requestedSubmissionId
+      ? `?submission_id=${encodeURIComponent(requestedSubmissionId)}`
+      : "";
+    const response = await fetch(`/api/blueprint-handoff${query}`, { cache: "no-store" });
+    const json = await response.json().catch(() => null);
+    if (!response.ok || !json?.ok) throw new Error("We could not check your Blueprint status.");
 
-      const namePart = line.replace(/^-+\s*/, "").split(":")[0].trim();
-      if (namePart.toLowerCase().includes("evidence pending")) {
-        return null; // ✅ skip placeholder rows
-      }
-
-      const links = matches.map((m) => ({
-        text: m[1],
-        url: m[2],
-      }));
-
-      return { name: namePart, links };
-    })
-    .filter(Boolean) as { name: string; links: { text: string; url: string }[] }[];
-
-  // Add-All-to-Cart
-  let allCartUrl: string | null = null;
-  if (type === "shopping") {
-    const asinRegex = /(?:dp|gp\/product|gp\/aw\/d)\/([A-Z0-9]{10})(?=[/?]|$)/;
-    const asins = rows
-      .flatMap((r) =>
-        r.links.map((link) => {
-          const m = asinRegex.exec(link.url);
-          return m ? m[1] : null;
-        })
-      )
-      .filter(Boolean) as string[];
-
-    if (asins.length > 0) {
-      const parts = asins.map(
-        (asin, i) => `ASIN.${i + 1}=${asin}&Quantity.${i + 1}=1`
-      );
-      allCartUrl = `https://www.amazon.com/gp/aws/cart/add.html?${parts.join("&")}&tag=lve360-20`;
+    if (json.status === "no_submission") {
+      setState({ name: "no_submission" });
+      return "done";
     }
-  }
+    if (json.status === "ready" && json.stack?.id) {
+      setState({ name: "ready", stackId: json.stack.id });
+      trackProductEvent({ event_name: "blueprint_handoff_ready", source: "results" });
+      return "done";
+    }
 
-  return (
-    <div>
-      {type === "shopping" && (
-        <div className="mb-4 rounded-xl border border-[#9DCFC3] bg-[#E6F7F3] px-4 py-3 text-sm leading-6 text-[#173B43]">
-          <strong>Affiliate disclosure:</strong> {AFFILIATE_DISCLOSURE_NEAR_LINKS}
-        </div>
-      )}
-      <table className="w-full border-collapse my-2 text-sm shadow-sm">
-        <thead className="bg-[#06C1A0] text-white">
-          <tr>
-            <th className="px-3 py-0.5 text-left">Item</th>
-            <th className="px-3 py-0.5 text-left">Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r, i) => (
-            <tr key={i} className="even:bg-gray-50 border-t">
-              <td className="px-3 py-0.5">{r.name}</td>
-              <td className="px-3 py-0.5 space-x-2">
-                {r.links.map((link, j) => (
-                  <CTAButton
-                    key={j}
-                    href={link.url}
-                    variant={type === "shopping" ? "primary" : "secondary"}
-                    size="sm"
-                    className="report-link-action px-2 py-0.5 text-xs min-w-0"
-                  >
-                    {type === "shopping"
-                      ? `Buy on ${link.text}`
-                      : link.text}
-                  </CTAButton>
-                ))}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      {allCartUrl && (
-        <div className="report-add-all mt-3">
-          <CTAButton
-            href={allCartUrl}
-            variant="premium"
-            size="md"
-            className="px-4 py-2 text-sm"
-          >
-            🛒 Add All to Cart
-          </CTAButton>
-        </div>
-      )}
-
-      {analysis && (
-        <p className="mt-3 text-sm text-gray-700 leading-relaxed">{analysis}</p>
-      )}
-    </div>
-  );
-}
-
-/* Section card wrapper */
-function SectionCard({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="bg-white rounded-2xl shadow-md p-6 mb-8">
-      <h2 className="text-xl font-semibold text-[#06C1A0] mb-4">{title}</h2>
-      {children}
-    </div>
-  );
-}
-// --- 2-minute countdown (starts when `running` is true) ---
-function TwoMinuteCountdown({
-  running,
-  onDone,
-  seconds = 120,
-}: {
-  running: boolean;
-  onDone?: () => void;
-  seconds?: number;
-}) {
-  const [remaining, setRemaining] = useState(seconds);
+    const submissionId = String(json.submission?.id ?? requestedSubmissionId ?? "");
+    setState({ name: "generating", submissionId });
+    return "pending";
+  }, [requestedSubmissionId]);
 
   useEffect(() => {
-    if (!running) {
-      setRemaining(seconds);     // reset when not running
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    startedAtRef.current = Date.now();
+
+    async function poll() {
+      try {
+        const result = await checkStatus();
+        if (cancelled || result === "done") return;
+        if (Date.now() - startedAtRef.current >= GENERATION_WAIT_MS) {
+          setState((current) => ({
+            name: "error",
+            message: "Your Blueprint is taking longer than expected. You can safely retry generation.",
+            submissionId: current.name === "generating" ? current.submissionId : undefined,
+          }));
+          return;
+        }
+        timer = setTimeout(poll, POLL_INTERVAL_MS);
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            name: "error",
+            message: error instanceof Error ? error.message : "Blueprint status is temporarily unavailable.",
+            submissionId: requestedSubmissionId ?? undefined,
+          });
+        }
+      }
+    }
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [checkStatus, pollAttempt, requestedSubmissionId]);
+
+  async function retryGeneration(submissionId: string | undefined) {
+    if (!submissionId) {
+      startedAtRef.current = Date.now();
+      setState({ name: "loading" });
+      setPollAttempt((attempt) => attempt + 1);
       return;
     }
-    setRemaining(seconds);       // fresh start when toggled on
-    const id = setInterval(() => {
-      setRemaining((t) => {
-        if (t <= 1) {
-          clearInterval(id);
-          onDone?.();
-          return 0;
-        }
-        return t - 1;
+
+    setState({ name: "generating", submissionId });
+    trackProductEvent({ event_name: "blueprint_handoff_retry", source: "results" });
+    try {
+      const response = await fetch("/api/generate-stack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          submission_id: submissionId,
+          generation_source: "premium-handoff-retry",
+        }),
       });
-    }, 1000);
-    return () => clearInterval(id);
-  }, [running, seconds, onDone]);
-
-  if (!running) return null;
-
-  const m = Math.floor(remaining / 60);
-  const s = (remaining % 60).toString().padStart(2, "0");
-  const pct = ((seconds - remaining) / seconds) * 100;
-
-  return (
-    <div className="text-center mt-3">
-      <p className="text-gray-600">
-        ⏱ Estimated time remaining:{" "}
-        <span className="font-semibold text-teal-600">
-          {m}:{s}
-        </span>
-      </p>
-      {/* Progress bar */}
-      <div className="w-64 h-2 bg-gray-200 rounded-full mt-2 mx-auto">
-        <div
-          className="h-2 bg-teal-500 rounded-full transition-all duration-1000"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
-/* ───────── page ───────── */
-function ResultsContent() {
-  const [error, setError] = useState<string | null>(null);
-  const [markdown, setMarkdown] = useState<string | null>(null);
-  const [warmingUp, setWarmingUp] = useState(false);
-  const [generating, setGenerating] = useState(false);
-  const [ready, setReady] = useState(true);
-
-  const searchParams = useSearchParams();
-  const tallyId = searchParams?.get("tally_submission_id") ?? null;
-
-  async function api(path: string, body?: any) {
-    const res = await fetch(
-      path,
-      body
-        ? {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(body),
-          }
-        : {}
-    );
-    if (!res.ok) throw new Error(`API ${res.status}`);
-    return res.json();
-  }
-
-  useEffect(() => {
-    if (!tallyId) return;
-    (async () => {
-      try {
-        const data = await api(
-          `/api/get-stack?submission_id=${encodeURIComponent(tallyId)}`
-        );
-        const raw =
-          data?.stack?.sections?.markdown ?? data?.stack?.summary ?? "";
-        setMarkdown(sanitizeMarkdown(raw));
-      } catch (e: any) {
-        console.warn(e);
+      const json = await response.json().catch(() => null);
+      if (!response.ok || !json?.ok) {
+        throw new Error(json?.error || "Blueprint generation did not complete.");
       }
-    })();
-  }, [tallyId]);
-
-  async function generateStack() {
-    if (!tallyId) return setError("Missing submission ID.");
-    try {
-      setWarmingUp(true);
-      setError(null);
-      await new Promise((r) => setTimeout(r, 3000));
-      setWarmingUp(false);
-      setGenerating(true);
-
-      const data = await api("/api/generate-stack", {
-        tally_submission_id: tallyId,
-        generation_source: "premium-results-page",
+      const stackId = json?.stack?.raw?.stack_id ?? json?.ai?.raw?.stack_id;
+      if (stackId) {
+        setState({ name: "ready", stackId: String(stackId) });
+      } else {
+        startedAtRef.current = Date.now();
+        setPollAttempt((attempt) => attempt + 1);
+      }
+    } catch (error) {
+      setState({
+        name: "error",
+        message: error instanceof Error ? error.message : "Blueprint generation did not complete.",
+        submissionId,
       });
-
-      const raw =
-        data?.stack?.sections?.markdown ??
-        data?.ai?.markdown ??
-        data?.stack?.summary ??
-        "";
-      setMarkdown(sanitizeMarkdown(raw));
-    } catch (e: any) {
-      setError(e.message ?? "Unknown error");
-    } finally {
-      setGenerating(false);
-      setWarmingUp(false);
     }
   }
 
-  async function exportPDF() {
-    if (!tallyId) return;
-    try {
-      const res = await fetch(`/api/export-pdf?submission_id=${tallyId}`);
-      if (!res.ok) throw new Error(`PDF export failed (${res.status})`);
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      window.open(url, "_blank");
-      setTimeout(() => URL.revokeObjectURL(url), 5_000);
-    } catch (e: any) {
-      setError(e.message ?? "PDF export failed");
-    }
-  }
-
-  const sec = useMemo(() => {
-    const md = markdown ?? "";
-    return {
-      intro: extractSection(md, ["Intro Summary", "Summary"]),
-      goals: extractSection(md, ["Goals"]),
-      contra: extractSection(md, [
-        "Contraindications & Med Interactions",
-        "Contraindications",
-      ]),
-      current: extractSection(md, ["Current Stack"]),
-      blueprint: extractSection(md, [
-        "Your Blueprint Recommendations",
-        'High-Impact "Bang-for-Buck" Additions',
-        "High-Impact Bang-for-Buck Additions",
-      ]),
-      dosing: extractSection(md, ["Dosing & Notes", "Dosing"]),
-      evidence: extractSection(md, ["Evidence & References"]),
-      shopping: extractSection(md, ["Shopping Links"]),
-      follow: extractSection(md, ["Follow-up Plan"]),
-      lifestyle: extractSection(md, ["Lifestyle Prescriptions"]),
-      longevity: extractSection(md, ["Longevity Levers"]),
-      weekTry: extractSection(md, ["This Week Try", "Weekly Experiment"]),
-    };
- }, [markdown]);
-
-      // ✅ make sure framer-motion is imported at the top of the file:
-      // import { motion } from "framer-motion";
-      
-return (
-  <motion.main
-    className="relative isolate overflow-hidden min-h-screen bg-gradient-to-br from-[#F8F5FB] via-white to-[#EAFBF8]"
-    initial={{ opacity: 0, y: 20 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ duration: 0.6 }}
-  >
-    {/* Ambient Background — matching home aesthetic */}
-    <div
-      className="pointer-events-none absolute -top-32 -left-24 h-96 w-96 rounded-full
-                 bg-[#A8F0E4] opacity-40 blur-3xl animate-[float_8s_ease-in-out_infinite]"
-      aria-hidden
-    />
-    <div
-      className="pointer-events-none absolute top-[20rem] -right-24 h-[28rem] w-[28rem] rounded-full
-                 bg-[#D9C2F0] opacity-30 blur-3xl animate-[float_10s_ease-in-out_infinite]"
-      aria-hidden
-    />
-
-    {/* Content Container */}
-    <div className="relative z-10 max-w-4xl mx-auto py-20 px-6 font-sans">
-      <div className="text-center mb-10">
-        <h1 className="text-5xl sm:text-6xl font-extrabold bg-gradient-to-r from-[#041B2D] via-[#06C1A0] to-purple-600 bg-clip-text text-transparent">
-          Your LVE360 Blueprint
-        </h1>
-        <p className="text-gray-600 mt-4 text-lg">
-          Personalized insights for Longevity • Vitality • Energy
-        </p>
-        <p className="mt-2 text-gray-500 text-sm">$15/month Premium Access</p>
-      </div>
-
-      {/* actions */}
-      <SectionCard title="Actions">
-        <div className="flex flex-wrap gap-4 justify-center">
-          <CTAButton
-            onClick={generateStack}
-            variant="gradient"
-            disabled={warmingUp || generating || !ready}
-          >
-            {warmingUp
-              ? "⏳ Warming up…"
-              : generating
-              ? "🤖 Generating..."
-              : ready
-              ? "✨ Generate Free Report"
-              : "⏳ Preparing…"}
-          </CTAButton>
-
-          <CTAButton href="/upgrade" variant="premium">
-            Upgrade to Premium
-          </CTAButton>
-        </div>
-
-        {(warmingUp || generating) && (
-          <p className="text-center text-gray-500 mt-3 text-sm animate-pulse">
-            {warmingUp
-              ? "⚡ Warming up the AI engines..."
-              : "💪 Crunching the numbers… this usually takes about 2 minutes."}
-          </p>
-        )}
-
-        <TwoMinuteCountdown running={generating} />
-      </SectionCard>
-
-      {error && <div className="text-center text-red-600 mb-6">{error}</div>}
-
-      {/* sections */}
-      {sec.intro && (
-        <SectionCard title="Intro Summary">
-          <Prose>{sec.intro}</Prose>
-        </SectionCard>
-      )}
-      {sec.goals && (
-        <SectionCard title="Goals">
-          <Prose>{sec.goals}</Prose>
-        </SectionCard>
-      )}
-      {sec.contra && (
-        <SectionCard title="Contraindications & Med Interactions">
-          <Prose>{sec.contra}</Prose>
-        </SectionCard>
-      )}
-      {sec.current && (
-        <SectionCard title="Current Stack">
-          <Prose>{sec.current}</Prose>
-        </SectionCard>
-      )}
-      {sec.blueprint && (
-        <SectionCard title="Your Blueprint Recommendations">
-          <Prose>{sec.blueprint}</Prose>
-        </SectionCard>
-      )}
-      {sec.dosing && (
-        <SectionCard title="Dosing & Notes">
-          <Prose>{sec.dosing}</Prose>
-        </SectionCard>
-      )}
-      {sec.evidence && (
-        <SectionCard title="Evidence & References">
-          <LinksTable raw={sec.evidence} type="evidence" />
-        </SectionCard>
-      )}
-      {sec.shopping && (
-        <SectionCard title="Shopping Links">
-          <LinksTable raw={sec.shopping} type="shopping" />
-        </SectionCard>
-      )}
-      {sec.follow && (
-        <SectionCard title="Follow-up Plan">
-          <Prose>{sec.follow}</Prose>
-        </SectionCard>
-      )}
-      {sec.lifestyle && (
-        <SectionCard title="Lifestyle Prescriptions">
-          <Prose>{sec.lifestyle}</Prose>
-        </SectionCard>
-      )}
-      {sec.longevity && (
-        <SectionCard title="Longevity Levers">
-          <Prose>{sec.longevity}</Prose>
-        </SectionCard>
-      )}
-      {sec.weekTry && (
-        <SectionCard title="This Week Try">
-          <Prose>{sec.weekTry}</Prose>
-        </SectionCard>
-      )}
-
-      {/* disclaimer */}
-      <SectionCard title="Important Wellness Disclaimer">
-        <p className="text-sm text-gray-700 leading-relaxed">
-          This plan from <strong>LVE360 (Longevity | Vitality | Energy)</strong>{" "}
-          is for educational purposes only and is not medical advice. It is not
-          intended to diagnose, treat, cure, or prevent any disease. Always
-          consult with your healthcare provider before starting new supplements
-          or making significant lifestyle changes, especially if you are
-          pregnant, nursing, managing a medical condition, or taking
-          prescriptions. Supplements are regulated under the Dietary Supplement
-          Health and Education Act (DSHEA); results vary and no outcomes are
-          guaranteed. If you experience unexpected effects, discontinue use and
-          seek professional care. By using this report, you agree that decisions
-          about your health remain your responsibility and that LVE360 is not
-          liable for how information is applied.
-        </p>
-        <p className="mt-4 border-t border-slate-200 pt-4 text-sm leading-relaxed text-gray-700">
-          <strong>Affiliate disclosure:</strong> {AFFILIATE_DISCLOSURE_NEAR_LINKS} {AFFILIATE_DISCLOSURE_SUPPORT}
-        </p>
-      </SectionCard>
-
-      {/* export PDF */}
-      <div className="flex justify-center mt-8">
-        <button
-          onClick={exportPDF}
-          aria-label="Export PDF"
-          className="w-10 h-10 flex items-center justify-center rounded-md border border-gray-300 bg-white shadow-sm hover:shadow-md transition"
-        >
-          PDF
-        </button>
-      </div>
+  return (
+    <div className="mx-auto flex min-h-[70vh] w-full max-w-3xl items-center justify-center py-8">
+      <section className="w-full rounded-3xl border border-[#CDE9E3] bg-white p-6 shadow-xl sm:p-10">
+        <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">Your LVE360 Blueprint</p>
+        {state.name === "loading" ? <LoadingState /> : null}
+        {state.name === "generating" ? <GeneratingState /> : null}
+        {state.name === "ready" ? <ReadyState stackId={state.stackId} /> : null}
+        {state.name === "no_submission" ? <NoSubmissionState /> : null}
+        {state.name === "error" ? (
+          <ErrorState
+            message={state.message}
+            onRetry={() => void retryGeneration(state.submissionId)}
+          />
+        ) : null}
+      </section>
     </div>
-  </motion.main>
-);
+  );
 }
 
-export default function ResultsPageWrapper() {
-  return (
-    <Suspense fallback={<p className="text-center py-8">Loading...</p>}>
-      <ResultsContent />
-    </Suspense>
-  );
+function LoadingState() {
+  return <div className="py-12 text-center" role="status" aria-live="polite"><Loader2 className="mx-auto h-9 w-9 animate-spin text-[#08A88A]" /><h1 className="mt-5 text-3xl font-extrabold text-[#041B2D]">Connecting your intake</h1><p className="mx-auto mt-3 max-w-xl leading-7 text-slate-600">We are locating your latest answers and checking your Blueprint status.</p></div>;
+}
+
+function GeneratingState() {
+  return <div className="py-10 text-center" role="status" aria-live="polite"><div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-[#EAFBF8]"><Loader2 className="h-8 w-8 animate-spin text-[#08A88A]" /></div><h1 className="mt-6 text-3xl font-extrabold text-[#041B2D]">Your Blueprint is being prepared</h1><p className="mx-auto mt-3 max-w-xl leading-7 text-slate-600">We are reviewing your goals, routines, supplements, medications, and safety context. This can take a few minutes. You can leave this page and return to Blueprints at any time.</p><div className="mx-auto mt-7 h-2 max-w-md overflow-hidden rounded-full bg-slate-100"><div className="h-full w-2/3 animate-pulse rounded-full bg-[#08A88A]" /></div><Link href="/blueprints" className="mt-7 inline-flex min-h-11 items-center justify-center rounded-xl border border-[#9DCFC3] px-5 py-3 font-bold text-[#087F72] hover:bg-[#EAFBF8]">Go to Blueprints</Link></div>;
+}
+
+function ReadyState({ stackId }: { stackId: string }) {
+  return <div className="py-10 text-center"><CheckCircle2 className="mx-auto h-12 w-12 text-[#08A88A]" /><h1 className="mt-5 text-3xl font-extrabold text-[#041B2D]">Your Blueprint is ready</h1><p className="mx-auto mt-3 max-w-xl leading-7 text-slate-600">Open your interactive workspace to review your priorities, safety notes, lifestyle actions, and current routine.</p><div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row"><Link href={`/blueprints/${encodeURIComponent(stackId)}`} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-6 py-3 font-bold text-white hover:bg-[#06695F]"><FileText className="mr-2 h-5 w-5" />Open my Blueprint <ArrowRight className="ml-2 h-5 w-5" /></Link><Link href="/today" className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 px-6 py-3 font-bold text-[#041B2D] hover:bg-slate-50">Go to Today</Link></div></div>;
+}
+
+function NoSubmissionState() {
+  return <div className="py-10 text-center"><FileText className="mx-auto h-11 w-11 text-[#087F72]" /><h1 className="mt-5 text-3xl font-extrabold text-[#041B2D]">Complete your health intake</h1><p className="mx-auto mt-3 max-w-xl leading-7 text-slate-600">Your intake gives LVE360 the context needed to create your first Blueprint.</p><Link href="/quiz" className="mt-7 inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-6 py-3 font-bold text-white hover:bg-[#06695F]">Complete my intake <ArrowRight className="ml-2 h-5 w-5" /></Link></div>;
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return <div className="py-10 text-center" role="alert"><AlertCircle className="mx-auto h-11 w-11 text-amber-600" /><h1 className="mt-5 text-3xl font-extrabold text-[#041B2D]">Your Blueprint needs another try</h1><p className="mx-auto mt-3 max-w-xl leading-7 text-slate-600">{message}</p><div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row"><button type="button" onClick={onRetry} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-6 py-3 font-bold text-white hover:bg-[#06695F]"><RefreshCw className="mr-2 h-5 w-5" />Retry generation</button><Link href="/blueprints" className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 px-6 py-3 font-bold text-[#041B2D] hover:bg-slate-50">Go to Blueprints</Link></div><p className="mt-6 text-sm text-slate-500">Retrying does not change your intake answers.</p></div>;
+}
+
+export default function PremiumResultsPage() {
+  return <Suspense fallback={<LoadingState />}><PremiumResultsHandoff /></Suspense>;
 }

--- a/app/api/analytics/event/route.ts
+++ b/app/api/analytics/event/route.ts
@@ -16,6 +16,8 @@ const CLIENT_EVENTS = new Set([
   "blueprint_version_selected",
   "blueprint_input_change_started",
   "blueprint_pdf_opened",
+  "blueprint_handoff_ready",
+  "blueprint_handoff_retry",
   "checkout_started",
 ]);
 

--- a/app/api/blueprint-handoff/route.ts
+++ b/app/api/blueprint-handoff/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export async function GET(req: NextRequest) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  const admin = getSupabaseAdmin();
+  const requestedSubmissionId = req.nextUrl.searchParams.get("submission_id")?.trim();
+
+  let submissionQuery = admin
+    .from("submissions")
+    .select("id,created_at")
+    .eq("user_id", entitlement.user.id);
+
+  submissionQuery = requestedSubmissionId
+    ? submissionQuery.eq("id", requestedSubmissionId)
+    : submissionQuery.order("created_at", { ascending: false }).limit(1);
+
+  const { data: submission, error: submissionError } = await submissionQuery.maybeSingle();
+  if (submissionError) {
+    console.error("[blueprint-handoff] submission lookup failed", submissionError.message);
+    return NextResponse.json({ ok: false, error: "handoff_unavailable" }, { status: 500 });
+  }
+  if (!submission) {
+    return NextResponse.json({ ok: true, status: "no_submission" });
+  }
+
+  const { data: stack, error: stackError } = await admin
+    .from("stacks")
+    .select("id,created_at")
+    .eq("submission_id", submission.id)
+    .eq("user_id", entitlement.user.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (stackError) {
+    console.error("[blueprint-handoff] stack lookup failed", stackError.message);
+    return NextResponse.json({ ok: false, error: "handoff_unavailable" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    status: stack ? "ready" : "generating",
+    submission: { id: submission.id, created_at: submission.created_at },
+    stack: stack ? { id: stack.id, created_at: stack.created_at } : null,
+  });
+}

--- a/app/api/generate-stack/route.ts
+++ b/app/api/generate-stack/route.ts
@@ -318,7 +318,11 @@ export async function POST(req: NextRequest) {
       const user = await fetchUserTierById(submission.user_id);
       tier = user?.tier === "premium" || user?.tier === "trial" ? user.tier : "free";
     }
-    if (isPaidTier(tier)) {
+    const internalSecret = process.env.CRON_SECRET;
+    const trustedInternalRequest = Boolean(
+      internalSecret && req.headers.get("authorization") === `Bearer ${internalSecret}`
+    );
+    if (isPaidTier(tier) && !trustedInternalRequest) {
       const entitlement = await getRequestEntitlement();
       if (!entitlement.user) {
         return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });

--- a/app/api/tally-webhook/route.ts
+++ b/app/api/tally-webhook/route.ts
@@ -6,7 +6,7 @@
 // Optional HMAC signature verification + replay guard.
 // -----------------------------------------------------------------------------
 
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin as supa } from "@/lib/supabaseAdmin";
 import { TALLY_KEYS, NormalizedSubmissionSchema } from "@/types/tally-normalized";
 import { parseList, parseSupplements } from "@/lib/parseLists";
@@ -17,6 +17,10 @@ import { recordProductEventSafely } from "@/lib/productAnalytics";
 // ---------- Config ----------
 const TALLY_HMAC_SECRET = process.env.TALLY_WEBHOOK_SECRET || ""; // optional
 const REPLAY_TTL_SECONDS = 10 * 60; // 10 minutes window
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
 
 // ---------- Utilities ----------
 function cleanSingle(val: any): string | undefined {
@@ -440,19 +444,28 @@ const submissionRow = {
       userEmail ?? ""
     )}`;
 
-    // Fire-and-forget stack generation
-    try {
-      fetch(`${appUrl}/api/generate-stack`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          submission_id: submissionId,
-          generation_source: "tally-webhook",
-        }),
-      }).catch((err) => console.error("Background generate-stack failed:", err));
-    } catch (e) {
-      console.error("Failed to trigger generate-stack:", e);
-    }
+    // Keep generation alive after the webhook response without making Tally wait.
+    const internalSecret = process.env.CRON_SECRET;
+    after(async () => {
+      try {
+        const response = await fetch(`${appUrl}/api/generate-stack`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(internalSecret ? { Authorization: `Bearer ${internalSecret}` } : {}),
+          },
+          body: JSON.stringify({
+            submission_id: submissionId,
+            generation_source: "tally-webhook",
+          }),
+        });
+        if (!response.ok) {
+          console.error("Background generate-stack rejected:", response.status);
+        }
+      } catch (error) {
+        console.error("Background generate-stack failed:", error);
+      }
+    });
 
     // Respond to Tally immediately
     return NextResponse.json({

--- a/app/layout.js
+++ b/app/layout.js
@@ -2,6 +2,7 @@ import "./globals.css";
 import Link from "next/link";
 import { SpeedInsights } from "@vercel/speed-insights/next"; // ✅ Added import
 import { Analytics } from "@vercel/analytics/react";
+import { PublicSiteFooter, PublicSiteHeader } from "@/components/PublicSiteChrome";
 
 const canonicalUrl = "https://app.lve360.com";
 
@@ -33,46 +34,13 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className="min-h-screen flex flex-col bg-white text-gray-900">
-        {/* Minimal header - transparent, floating */}
-        <header className="absolute top-0 left-0 w-full z-40">
-          <nav className="max-w-6xl mx-auto flex items-center justify-between py-5 px-6">
-            {/* Logo */}
-            <Link
-              href="/"
-              className="font-extrabold text-xl tracking-tight text-purple-600"
-            >
-              LVE360
-            </Link>
-
-            {/* Nav Links */}
-            <div className="space-x-6 text-sm sm:text-base flex items-center">
-              <Link
-                href="/"
-                className="hover:text-purple-600 transition-colors"
-              >
-                Home
-              </Link>
-              <Link
-                href="/pricing"
-                className="hover:text-purple-600 transition-colors"
-              >
-                Pricing
-              </Link>
-              <Link
-                href="/login"
-                className="bg-purple-600 px-3 py-1.5 rounded-lg font-medium text-white hover:bg-purple-700 transition-colors shadow-sm"
-              >
-                Log in
-              </Link>
-            </div>
-          </nav>
-        </header>
+        <PublicSiteHeader />
 
         {/* Main body */}
         <main className="flex-1">{children}</main>
 
         {/* Footer */}
-        <footer className="bg-gray-50 text-gray-600 border-t border-gray-200">
+        <PublicSiteFooter><footer className="bg-gray-50 text-gray-600 border-t border-gray-200">
           <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 py-6 px-4 text-sm">
             <p>
               © {new Date().getFullYear()}{" "}
@@ -94,7 +62,7 @@ export default function RootLayout({ children }) {
               </Link>
             </div>
           </div>
-        </footer>
+        </footer></PublicSiteFooter>
 
         {/* ✅ Add Speed Insights tracker at the very bottom */}
         <SpeedInsights />

--- a/app/results/layout.tsx
+++ b/app/results/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
+
+import { getUserAndTier } from "@/src/lib/getUserAndTier";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function PublicResultsLayout({ children }: { children: ReactNode }) {
+  const { user, tier } = await getUserAndTier();
+  if (user && (tier === "premium" || tier === "trial")) {
+    redirect("/results/premium");
+  }
+  return children;
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "qa:pr75": "node --experimental-strip-types src/_tests_/pr75.assert.ts && node src/_tests_/pr75Page.assert.mjs",
     "qa:pr76": "node --experimental-strip-types src/_tests_/pr76.assert.ts && node src/_tests_/pr76Page.assert.mjs",
     "qa:pr77": "node --experimental-strip-types src/_tests_/pr77.assert.ts && node src/_tests_/pr77Page.assert.mjs",
+    "qa:pr78": "node src/_tests_/pr78Handoff.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr78Handoff.assert.mjs
+++ b/src/_tests_/pr78Handoff.assert.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const premiumPage = read("app/(app)/results/premium/page.tsx");
+for (const forbidden of ["$15/month", "Upgrade to Premium", "Generate Free Report", "Log in"]) {
+  assert.doesNotMatch(premiumPage, new RegExp(forbidden.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+}
+assert.match(premiumPage, /Your Blueprint is being prepared/);
+assert.match(premiumPage, /Retry generation/);
+assert.match(premiumPage, /\/blueprints\/\$\{encodeURIComponent\(stackId\)\}/);
+assert.match(premiumPage, /\/api\/blueprint-handoff/);
+
+const handoffRoute = read("app/api/blueprint-handoff/route.ts");
+assert.match(handoffRoute, /requirePaidApi/);
+assert.match(handoffRoute, /eq\("user_id", entitlement\.user\.id\)/);
+assert.match(handoffRoute, /status: stack \? "ready" : "generating"/);
+
+const publicResultsLayout = read("app/results/layout.tsx");
+assert.match(publicResultsLayout, /tier === "premium" \|\| tier === "trial"/);
+assert.match(publicResultsLayout, /redirect\("\/results\/premium"\)/);
+
+const webhook = read("app/api/tally-webhook/route.ts");
+const generator = read("app/api/generate-stack/route.ts");
+assert.match(webhook, /Authorization: `Bearer \$\{internalSecret\}`/);
+assert.match(webhook, /after\(async \(\) =>/);
+assert.match(generator, /trustedInternalRequest/);
+assert.match(generator, /isPaidTier\(tier\) && !trustedInternalRequest/);
+
+const chrome = read("src/components/PublicSiteChrome.tsx");
+assert.match(chrome, /"\/results\/premium"/);
+
+console.log("PR78 paid post-intake handoff assertions passed");

--- a/src/components/PublicSiteChrome.tsx
+++ b/src/components/PublicSiteChrome.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+const MEMBER_ROUTE_PREFIXES = [
+  "/today",
+  "/routine",
+  "/journey",
+  "/blueprints",
+  "/settings",
+  "/onboarding",
+  "/results/premium",
+];
+
+function isMemberRoute(pathname: string): boolean {
+  return MEMBER_ROUTE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
+export function PublicSiteHeader() {
+  const pathname = usePathname();
+  if (isMemberRoute(pathname)) return null;
+
+  return (
+    <header className="absolute left-0 top-0 z-40 w-full">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
+        <Link href="/" className="text-xl font-extrabold tracking-tight text-purple-600">
+          LVE360
+        </Link>
+        <div className="flex items-center space-x-6 text-sm sm:text-base">
+          <Link href="/" className="transition-colors hover:text-purple-600">Home</Link>
+          <Link href="/pricing" className="transition-colors hover:text-purple-600">Pricing</Link>
+          <Link
+            href="/login"
+            className="rounded-lg bg-purple-600 px-3 py-1.5 font-medium text-white shadow-sm transition-colors hover:bg-purple-700"
+          >
+            Log in
+          </Link>
+        </div>
+      </nav>
+    </header>
+  );
+}
+
+export function PublicSiteFooter({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  if (isMemberRoute(pathname)) return null;
+  return <>{children}</>;
+}

--- a/src/lib/productAnalyticsTypes.ts
+++ b/src/lib/productAnalyticsTypes.ts
@@ -13,6 +13,8 @@ export const PRODUCT_EVENT_NAMES = [
   "blueprint_refresh_completed",
   "blueprint_refresh_failed",
   "blueprint_pdf_opened",
+  "blueprint_handoff_ready",
+  "blueprint_handoff_retry",
   "checkout_started",
   "checkout_completed",
   "activation_started",


### PR DESCRIPTION
## Outcome
Premium members move from intake submission to one clear Blueprint handoff without public pricing, upgrade prompts, or a second generation click.

## What changed
- routes authenticated premium and trial members away from the public results page
- authenticates Tally's background generation call with the existing internal secret
- keeps background generation alive after the webhook response
- adds an owner-scoped status endpoint for the latest submission and Blueprint
- replaces the legacy premium report page with clear waiting, ready, retry, and no-intake states
- sends ready members to their interactive Blueprint workspace, with Today as a secondary destination
- hides public site navigation and footer on member routes
- records handoff-ready and retry analytics

## Safety and scope
- no database migration
- no new environment variable
- paid generation remains owner-scoped for browser requests
- Stripe live-mode cutover remains out of scope

## Validation
- npm.cmd run qa:pr78
- npm.cmd run qa:gating
- npm.cmd run qa:blueprints
- npm.cmd run typecheck
- npm.cmd run build (with non-secret local build placeholders for missing Supabase/OpenAI variables)