### PR TITLE
PR79 — Create one premium activation checklist

### DIFF
--- a/app/(app)/blueprints/BlueprintsClient.tsx
+++ b/app/(app)/blueprints/BlueprintsClient.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { FileDown, FileText, History } from "lucide-react";
 
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
+import type { PremiumActivationProgress } from "@/lib/premiumActivation";
+import PremiumActivationChecklist from "@/components/activation/PremiumActivationChecklist";
 
 type StackRow = {
   id: string;
@@ -17,9 +19,11 @@ type StackRow = {
 export default function BlueprintsClient({
   stacks,
   paid,
+  activationProgress,
 }: {
   stacks: StackRow[];
   paid: boolean;
+  activationProgress: PremiumActivationProgress;
 }) {
   const latest = stacks[0] ?? null;
 
@@ -36,19 +40,23 @@ export default function BlueprintsClient({
         </p>
       </header>
 
+      {paid ? <div className="mt-8"><PremiumActivationChecklist progress={activationProgress} surface="blueprints" /></div> : null}
+
       {!latest ? (
-        <section className="mt-8 rounded-2xl border border-[#BCE3DA] bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-bold text-[#041B2D]">Create your first Blueprint</h2>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            Complete the intake to organize your goals, current stack, safety context, and most useful next steps.
-          </p>
-          <Link
-            href="/quiz"
-            className="mt-5 inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white hover:bg-[#06695F] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
-          >
-            Create my Blueprint
-          </Link>
-        </section>
+        paid ? null : (
+          <section className="mt-8 rounded-2xl border border-[#BCE3DA] bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-bold text-[#041B2D]">Create your first Blueprint</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Complete the intake to organize your goals, current stack, safety context, and most useful next steps.
+            </p>
+            <Link
+              href="/quiz"
+              className="mt-5 inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white hover:bg-[#06695F] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
+            >
+              Create my Blueprint
+            </Link>
+          </section>
+        )
       ) : (
         <>
           <section className="mt-8 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/app/(app)/blueprints/page.tsx
+++ b/app/(app)/blueprints/page.tsx
@@ -7,6 +7,7 @@ import {
   deriveBlueprintSafetyStatus,
 } from "@/src/lib/blueprintSafetyStatus";
 import { getUserAndTier } from "@/src/lib/getUserAndTier";
+import { getPremiumActivationProgress } from "@/lib/premiumActivation";
 
 import BlueprintsClient from "./BlueprintsClient";
 
@@ -18,12 +19,15 @@ export default async function Page() {
   if (!user) redirect("/login");
 
   const supabase = createServerComponentClient({ cookies });
-  const { data: stacks, error } = await supabase
-    .from("stacks")
-    .select("*")
-    .eq("user_id", user.id)
-    .order("created_at", { ascending: false })
-    .limit(25);
+  const [{ data: stacks, error }, activationProgress] = await Promise.all([
+    supabase
+      .from("stacks")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(25),
+    getPremiumActivationProgress(user),
+  ]);
 
   if (error) console.error("[blueprints] library lookup failed", error.message);
 
@@ -34,6 +38,7 @@ export default async function Page() {
         safety_status: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(stack)),
       })) as any}
       paid={tier === "premium" || tier === "trial"}
+      activationProgress={activationProgress}
     />
   );
 }

--- a/app/(app)/today/TodayClient.tsx
+++ b/app/(app)/today/TodayClient.tsx
@@ -1,23 +1,34 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import DailyLog from "@/components/dashboard/DailyLog";
 import TodayExperience from "@/components/dashboard/TodayExperience";
 import TodaysPlan from "@/components/dashboard/TodaysPlan";
 import type { WeeklyExperiment } from "@/lib/activation";
 import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "@/lib/blueprintContext";
+import type { PremiumActivationProgress } from "@/lib/premiumActivation";
+import PremiumActivationChecklist from "@/components/activation/PremiumActivationChecklist";
 
 export default function TodayClient({
   experiment,
   blueprint,
   experimentBlueprint,
   checkinDate,
+  activationProgress,
 }: {
   experiment: WeeklyExperiment | null;
   blueprint: CurrentBlueprintContext | null;
   experimentBlueprint: ExperimentBlueprintContext | null;
   checkinDate: string | null;
+  activationProgress: PremiumActivationProgress;
 }) {
+  const [firstActionComplete, setFirstActionComplete] = useState(activationProgress.firstActionComplete);
+  const visibleProgress = { ...activationProgress, firstActionComplete };
+
+  useEffect(() => {
+    setFirstActionComplete(activationProgress.firstActionComplete);
+  }, [activationProgress.firstActionComplete]);
+
   useEffect(() => {
     fetch("/api/provision-user", { method: "POST" }).catch((error) => {
       console.error("Provision user failed:", error);
@@ -27,18 +38,25 @@ export default function TodayClient({
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#EAFBF8] via-white to-[#F8F5FB]">
       <div className="mx-auto max-w-5xl space-y-5 p-4 sm:p-6">
-        <TodayExperience
-          initialExperiment={experiment}
-          blueprint={blueprint}
-          experimentBlueprint={experimentBlueprint}
-          initialCompletionDate={checkinDate}
-        />
+        <PremiumActivationChecklist progress={visibleProgress} surface="today" />
 
-        <section id="daily-log" aria-label="Quick check-in">
-          <DailyLog />
-        </section>
+        {experiment?.status === "active" || firstActionComplete ? (
+          <>
+            <TodayExperience
+              initialExperiment={experiment}
+              blueprint={blueprint}
+              experimentBlueprint={experimentBlueprint}
+              initialCompletionDate={checkinDate}
+              onCompletionStateChange={setFirstActionComplete}
+            />
 
-        <TodaysPlan />
+            <section id="daily-log" aria-label="Quick check-in">
+              <DailyLog />
+            </section>
+
+            <TodaysPlan />
+          </>
+        ) : null}
 
       </div>
     </div>

--- a/app/(app)/today/page.tsx
+++ b/app/(app)/today/page.tsx
@@ -7,6 +7,7 @@ import TodayClient from "./TodayClient";
 import type { WeeklyExperiment } from "@/lib/activation";
 import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
 import { parseLocalDate } from "@/lib/today";
+import { getPremiumActivationProgress } from "@/lib/premiumActivation";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -29,7 +30,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
   }
 
   const blueprintPromise = getCurrentBlueprintContext(user.id);
-  const [{ data: goals }, { data: experiment }, blueprint] = await Promise.all([
+  const [{ data: goals }, { data: experiment }, blueprint, activationProgress] = await Promise.all([
     supabase.from("goals").select("*").eq("user_id", user.id).maybeSingle(),
     supabase
       .from("weekly_experiments")
@@ -40,6 +41,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
       .limit(1)
       .maybeSingle(),
     blueprintPromise,
+    getPremiumActivationProgress(user),
   ]);
   const activeExperiment = (experiment as WeeklyExperiment | null) ?? null;
   const experimentBlueprints = activeExperiment
@@ -57,9 +59,11 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
         blueprint={blueprint}
         experimentBlueprint={activeExperiment ? experimentBlueprints[activeExperiment.id] ?? null : null}
         checkinDate={checkinDate}
+        activationProgress={activationProgress}
       />
 
-      {(targetWeight == null && targetSleep == null && targetEnergy == null) ? (
+      {(activationProgress.practice.status === "active" || activationProgress.firstActionComplete)
+        && (targetWeight == null && targetSleep == null && targetEnergy == null) ? (
         <div className="mx-auto w-full max-w-5xl px-4 pb-8 sm:px-6">
           <GoalsTargetsEditor
             targetWeight={targetWeight}

--- a/app/api/provision-user/route.ts
+++ b/app/api/provision-user/route.ts
@@ -15,11 +15,19 @@ export async function POST() {
 
   const email = user.email?.toLowerCase() ?? null;
 
-  // Single atomic repair + attach step in the DB
-await supabaseAdmin.rpc("reconcile_user_and_attach_v2", {
-  p_email: user.email?.toLowerCase() ?? null,
-  p_new_id: user.id,
-});
+  if (!email || !user.email_confirmed_at) {
+    return NextResponse.json({ ok: false, error: "verified_email_required" }, { status: 409 });
+  }
+
+  // Single atomic repair + attach step in the DB.
+  const { error: reconciliationError } = await supabaseAdmin.rpc("reconcile_user_and_attach_v2", {
+    p_email: email,
+    p_new_id: user.id,
+  });
+  if (reconciliationError) {
+    console.error("[provision-user] reconciliation failed", reconciliationError.message);
+    return NextResponse.json({ ok: false, error: "blueprint_connection_failed" }, { status: 500 });
+  }
 
 
   // Optionally return the user's tier so client can decide immediately
@@ -29,5 +37,5 @@ await supabaseAdmin.rpc("reconcile_user_and_attach_v2", {
     .eq("id", user.id)
     .maybeSingle();
 
-  return NextResponse.json({ ok: true, tier: profile?.tier ?? "free" });
+  return NextResponse.json({ ok: true, tier: profile?.tier ?? "free", reconciled: true });
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "qa:pr76": "node --experimental-strip-types src/_tests_/pr76.assert.ts && node src/_tests_/pr76Page.assert.mjs",
     "qa:pr77": "node --experimental-strip-types src/_tests_/pr77.assert.ts && node src/_tests_/pr77Page.assert.mjs",
     "qa:pr78": "node src/_tests_/pr78Handoff.assert.mjs",
+    "qa:pr79": "node src/_tests_/pr79Activation.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr79Activation.assert.mjs
+++ b/src/_tests_/pr79Activation.assert.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+
+const model = read("src/lib/premiumActivation.ts");
+assert.match(model, /"connected" \| "recoverable" \| "missing"/);
+assert.match(model, /email_confirmed_at/);
+assert.match(model, /eq\("user_email", email\)/);
+assert.match(model, /!isPremiumBlueprint\(stack\.sections\)/);
+assert.match(model, /daily_practice_completions/);
+
+const checklist = read("src/components/activation/PremiumActivationChecklist.tsx");
+for (const label of [
+  "Connect your Blueprint",
+  "Choose one weekly practice",
+  "Complete your first useful action",
+  "Optional while you get started",
+]) {
+  assert.match(checklist, new RegExp(label));
+}
+assert.match(checklist, /Connect this Blueprint/);
+assert.match(checklist, /fetch\("\/api\/provision-user"/);
+assert.match(checklist, /if \(progress\.firstActionComplete\) return null/);
+
+const provision = read("app/api/provision-user/route.ts");
+assert.match(provision, /email_confirmed_at/);
+assert.match(provision, /reconcile_user_and_attach_v2/);
+assert.match(provision, /reconciliationError/);
+
+const today = read("app/(app)/today/TodayClient.tsx");
+const blueprints = read("app/(app)/blueprints/BlueprintsClient.tsx");
+assert.match(today, /PremiumActivationChecklist/);
+assert.match(blueprints, /PremiumActivationChecklist/);
+assert.match(today, /experiment\?\.status === "active" \|\| firstActionComplete/);
+assert.match(today, /onCompletionStateChange=\{setFirstActionComplete\}/);
+assert.match(blueprints, /paid \? null/);
+
+console.log("PR79 premium activation checklist assertions passed");

--- a/src/components/activation/PremiumActivationChecklist.tsx
+++ b/src/components/activation/PremiumActivationChecklist.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { Check, Circle, Link2, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import type { PremiumActivationProgress } from "@/lib/premiumActivation";
+
+export default function PremiumActivationChecklist({
+  progress,
+  surface,
+}: {
+  progress: PremiumActivationProgress;
+  surface: "today" | "blueprints";
+}) {
+  const router = useRouter();
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (progress.firstActionComplete) return null;
+
+  const blueprintComplete = progress.blueprint.status === "connected";
+  const practiceComplete = progress.practice.status === "active";
+  const completed = Number(blueprintComplete) + Number(practiceComplete);
+  const currentStep = !blueprintComplete ? 1 : !practiceComplete ? 2 : 3;
+
+  async function connectBlueprint() {
+    setConnecting(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/provision-user", { method: "POST" });
+      const json = await response.json().catch(() => null);
+      if (!response.ok || !json?.ok) {
+        throw new Error("We could not connect that Blueprint. Please try again.");
+      }
+      router.refresh();
+    } catch (connectError) {
+      setError(connectError instanceof Error ? connectError.message : "We could not connect that Blueprint.");
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-[#9DCFC3] bg-white p-6 shadow-sm sm:p-8" aria-labelledby={`${surface}-activation-title`}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">Start here</p>
+          <h1 id={`${surface}-activation-title`} className="mt-2 text-3xl font-bold tracking-tight text-[#041B2D]">
+            Get LVE360 working for you
+          </h1>
+          <p className="mt-3 max-w-2xl leading-7 text-slate-600">
+            Follow one recommended sequence. You do not need to set up everything at once.
+          </p>
+        </div>
+        <div className="shrink-0 rounded-full bg-[#EAFBF8] px-4 py-2 text-sm font-bold text-[#087F72]">
+          {completed} of 3 complete
+        </div>
+      </div>
+
+      <ol className="mt-7 space-y-3">
+        <ActivationStep
+          number={1}
+          title="Connect your Blueprint"
+          description={blueprintDescription(progress)}
+          complete={blueprintComplete}
+          current={currentStep === 1}
+        >
+          {progress.blueprint.status === "recoverable" ? (
+            <button
+              type="button"
+              onClick={connectBlueprint}
+              disabled={connecting}
+              className="inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F] disabled:opacity-60"
+            >
+              {connecting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Link2 className="mr-2 h-4 w-4" />}
+              Connect this Blueprint
+            </button>
+          ) : progress.blueprint.status === "missing" ? (
+            <Link href="/quiz" className="inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F]">
+              Complete my health intake
+            </Link>
+          ) : progress.blueprint.stackId ? (
+            <Link href={`/blueprints/${encodeURIComponent(progress.blueprint.stackId)}`} className="text-sm font-bold text-[#087F72] hover:underline">
+              Open Blueprint
+            </Link>
+          ) : null}
+        </ActivationStep>
+
+        <ActivationStep
+          number={2}
+          title="Choose one weekly practice"
+          description={practiceComplete
+            ? "Your focused practice is ready for this week."
+            : progress.practice.status === "draft"
+              ? "Finish the practice you started and make the smallest version clear."
+              : "Choose one lifestyle action that supports the person you want to become."}
+          complete={practiceComplete}
+          current={currentStep === 2}
+        >
+          {!practiceComplete && blueprintComplete ? (
+            <Link href="/onboarding" className="inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F]">
+              {progress.practice.status === "draft" ? "Finish practice setup" : "Choose my weekly practice"}
+            </Link>
+          ) : null}
+        </ActivationStep>
+
+        <ActivationStep
+          number={3}
+          title="Complete your first useful action"
+          description={practiceComplete
+            ? "Do the full practice or its minimum version, then record the repetition."
+            : "This unlocks after your weekly practice is ready."}
+          complete={false}
+          current={currentStep === 3}
+        >
+          {practiceComplete ? (
+            <Link href={surface === "today" ? "#focused-practice" : "/today#focused-practice"} className="inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F]">
+              Open today&apos;s action
+            </Link>
+          ) : null}
+        </ActivationStep>
+      </ol>
+
+      {error ? <p className="mt-4 text-sm font-semibold text-rose-700" role="alert">{error}</p> : null}
+
+      <div className="mt-6 rounded-2xl bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+        <strong className="text-[#041B2D]">Optional while you get started:</strong> Daily check-ins,
+        Routine organization, and email reminders can wait. They support your system but do not block activation.
+      </div>
+    </section>
+  );
+}
+
+function ActivationStep({
+  number,
+  title,
+  description,
+  complete,
+  current,
+  children,
+}: {
+  number: number;
+  title: string;
+  description: string;
+  complete: boolean;
+  current: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <li className={`rounded-2xl border p-5 ${current ? "border-[#08A88A] bg-[#F4FAF8]" : "border-slate-200 bg-white"}`}>
+      <div className="flex items-start gap-4">
+        <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full font-bold ${complete ? "bg-[#08A88A] text-white" : current ? "border-2 border-[#08A88A] bg-white text-[#087F72]" : "bg-slate-100 text-slate-500"}`}>
+          {complete ? <Check className="h-5 w-5" aria-label="Complete" /> : current ? number : <Circle className="h-4 w-4" aria-hidden="true" />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-lg font-bold text-[#041B2D]">{title}</h2>
+            {current ? <span className="rounded-full bg-[#DDF7F1] px-2.5 py-1 text-xs font-bold text-[#087F72]">Recommended next</span> : null}
+            {complete ? <span className="text-xs font-bold text-[#087F72]">Complete</span> : null}
+          </div>
+          <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
+          {children ? <div className="mt-4">{children}</div> : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function blueprintDescription(progress: PremiumActivationProgress): string {
+  if (progress.blueprint.status === "connected") return "Your latest Blueprint is connected to this membership.";
+  if (progress.blueprint.status === "recoverable") {
+    return "We found an existing Blueprint for your verified sign-in email. Connect it deliberately to continue.";
+  }
+  return "Complete the health intake so LVE360 can organize your goals, routine, and safety context.";
+}

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -35,11 +35,13 @@ export default function TodayExperience({
   blueprint,
   experimentBlueprint,
   initialCompletionDate,
+  onCompletionStateChange,
 }: {
   initialExperiment: WeeklyExperiment | null;
   blueprint: CurrentBlueprintContext | null;
   experimentBlueprint: ExperimentBlueprintContext | null;
   initialCompletionDate: string | null;
+  onCompletionStateChange?: (complete: boolean) => void;
 }) {
   const [localDate, setLocalDate] = useState("");
   const [experiment, setExperiment] = useState(initialExperiment);
@@ -102,6 +104,7 @@ export default function TodayExperience({
       if (!response.ok || !json?.ok) throw new Error("Your progress was not saved. Please try again.");
       setCompletions(json.completions ?? []);
       setWeekDays(json.bounds?.days ?? []);
+      onCompletionStateChange?.((json.completions ?? []).length > 0);
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : "Your progress was not saved.");
     } finally {
@@ -119,6 +122,7 @@ export default function TodayExperience({
       if (!response.ok || !json?.ok) throw new Error("We could not undo that completion.");
       setCompletions(json.completions ?? []);
       setWeekDays(json.bounds?.days ?? []);
+      onCompletionStateChange?.((json.completions ?? []).length > 0);
     } catch (undoError) {
       setError(undoError instanceof Error ? undoError.message : "We could not undo that completion.");
     } finally {
@@ -128,7 +132,7 @@ export default function TodayExperience({
 
   if (!experiment || experiment.status !== "active") {
     return (
-      <section className="rounded-3xl border border-[#9DCFC3] bg-white p-6 shadow-sm sm:p-8" aria-labelledby="today-heading">
+      <section id="focused-practice" className="rounded-3xl border border-[#9DCFC3] bg-white p-6 shadow-sm sm:p-8" aria-labelledby="today-heading">
         <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">Today</p>
         <h1 id="today-heading" className="mt-2 text-3xl font-bold tracking-tight text-[#041B2D] sm:text-4xl">
           Choose one practice for this week.
@@ -151,7 +155,7 @@ export default function TodayExperience({
   const weekNotStarted = !!localDate && localDate < experiment.week_start;
 
   return (
-    <section className="overflow-hidden rounded-3xl border border-[#9DCFC3] bg-white shadow-sm" aria-labelledby="today-heading">
+    <section id="focused-practice" className="overflow-hidden rounded-3xl border border-[#9DCFC3] bg-white shadow-sm" aria-labelledby="today-heading">
       <div className="bg-[#041B2D] px-6 py-5 text-white sm:px-8">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>

--- a/src/lib/premiumActivation.ts
+++ b/src/lib/premiumActivation.ts
@@ -1,0 +1,122 @@
+import "server-only";
+
+import type { User } from "@supabase/supabase-js";
+
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export type PremiumActivationProgress = {
+  blueprint: {
+    status: "connected" | "recoverable" | "missing";
+    stackId: string | null;
+    createdAt: string | null;
+  };
+  practice: {
+    status: "active" | "draft" | "missing";
+  };
+  firstActionComplete: boolean;
+};
+
+type StackSummary = {
+  id: string;
+  user_id: string | null;
+  submission_id: string | null;
+  created_at: string | null;
+  sections: unknown;
+};
+
+export async function getPremiumActivationProgress(
+  user: Pick<User, "id" | "email" | "email_confirmed_at">
+): Promise<PremiumActivationProgress> {
+  const admin = getSupabaseAdmin();
+  const [connectedResult, experimentResult, completionResult] = await Promise.all([
+    admin
+      .from("stacks")
+      .select("id,user_id,submission_id,created_at,sections")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    admin
+      .from("weekly_experiments")
+      .select("status")
+      .eq("user_id", user.id)
+      .in("status", ["draft", "active"])
+      .order("updated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    admin
+      .from("daily_practice_completions")
+      .select("id")
+      .eq("user_id", user.id)
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  if (connectedResult.error) throw connectedResult.error;
+  if (experimentResult.error) throw experimentResult.error;
+  if (completionResult.error) throw completionResult.error;
+
+  const connected = connectedResult.data as StackSummary | null;
+  const recoverable = connected ? null : await findRecoverableBlueprint(user);
+  const experimentStatus = experimentResult.data?.status;
+
+  return {
+    blueprint: connected
+      ? { status: "connected", stackId: connected.id, createdAt: connected.created_at }
+      : recoverable
+        ? { status: "recoverable", stackId: null, createdAt: recoverable.created_at }
+        : { status: "missing", stackId: null, createdAt: null },
+    practice: {
+      status: experimentStatus === "active"
+        ? "active"
+        : experimentStatus === "draft"
+          ? "draft"
+          : "missing",
+    },
+    firstActionComplete: Boolean(completionResult.data),
+  };
+}
+
+async function findRecoverableBlueprint(
+  user: Pick<User, "id" | "email" | "email_confirmed_at">
+): Promise<StackSummary | null> {
+  const email = user.email?.trim().toLowerCase();
+  if (!email || !user.email_confirmed_at) return null;
+
+  const admin = getSupabaseAdmin();
+  const { data: directMatches, error: directError } = await admin
+    .from("stacks")
+    .select("id,user_id,submission_id,created_at,sections")
+    .eq("user_email", email)
+    .order("created_at", { ascending: false })
+    .limit(10);
+  if (directError) throw directError;
+
+  const direct = ((directMatches ?? []) as StackSummary[])
+    .find((stack) => stack.user_id !== user.id && !isPremiumBlueprint(stack.sections));
+  if (direct) return direct;
+
+  const { data: submissions, error: submissionError } = await admin
+    .from("submissions")
+    .select("id")
+    .eq("user_email", email)
+    .order("created_at", { ascending: false })
+    .limit(10);
+  if (submissionError) throw submissionError;
+  const submissionIds = (submissions ?? []).map((submission) => submission.id);
+  if (!submissionIds.length) return null;
+
+  const { data: submissionStacks, error: stackError } = await admin
+    .from("stacks")
+    .select("id,user_id,submission_id,created_at,sections")
+    .in("submission_id", submissionIds)
+    .order("created_at", { ascending: false })
+    .limit(10);
+  if (stackError) throw stackError;
+  return ((submissionStacks ?? []) as StackSummary[])
+    .find((stack) => stack.user_id !== user.id && !isPremiumBlueprint(stack.sections)) ?? null;
+}
+
+function isPremiumBlueprint(sections: unknown): boolean {
+  return Boolean(sections && typeof sections === "object" && (sections as { mode?: unknown }).mode === "premium");
+}


### PR DESCRIPTION
## Outcome

New premium members see one recommended activation sequence across Today and Blueprints: connect or create a Blueprint, choose one weekly practice, then complete the first useful action.

## What changed

- adds one shared three-step activation checklist to Today and Blueprints
- derives progress from existing Blueprint, weekly-practice, and completion records
- locates an existing free Blueprint using the authenticated, verified email
- requires an explicit Connect this Blueprint action before reconciliation
- excludes premium Blueprint payloads from recovery candidates
- reuses the existing atomic reconciliation function and now reports reconciliation failures honestly
- removes the competing premium Blueprint empty state
- hides optional Today tools until the weekly practice is active
- labels daily check-ins, Routine organization, and email reminders as optional during activation
- dismisses the checklist immediately after the first practice completion

## Safety and scope

- no database migration
- no Stripe changes
- recovery requires a verified authenticated email
- recovery is limited to non-premium Blueprints
- medication and supplement guidance behavior is unchanged

## Validation

- `npm.cmd run qa:pr79`
- `npm.cmd run qa:gating`
- `npm.cmd run qa:blueprints`
- `npm.cmd run typecheck`
- `npm.cmd run build` with non-secret validation placeholders for unavailable local service variables