### PR TITLE
PR80 — Expand Journey into a Blueprint-aligned learning loop

### DIFF
--- a/app/api/journey/route.ts
+++ b/app/api/journey/route.ts
@@ -52,7 +52,7 @@ export async function GET() {
         .limit(52),
       admin
         .from("weekly_experiment_reviews")
-        .select("experiment_id, completion_count, target_count, difficulty, value_rating, decision, status, completed_at")
+        .select("experiment_id, next_experiment_id, completion_count, target_count, difficulty, value_rating, decision, status, completed_at")
         .eq("user_id", auth.user.id)
         .order("completed_at", { ascending: false })
         .limit(52),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "qa:pr77": "node --experimental-strip-types src/_tests_/pr77.assert.ts && node src/_tests_/pr77Page.assert.mjs",
     "qa:pr78": "node src/_tests_/pr78Handoff.assert.mjs",
     "qa:pr79": "node src/_tests_/pr79Activation.assert.mjs",
+    "qa:pr80": "node src/_tests_/pr80JourneyLoop.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/journey.assert.mjs
+++ b/src/_tests_/journey.assert.mjs
@@ -30,5 +30,13 @@ assert.match(dashboard, /role="img"/, "Trend charts should expose an accessible 
 assert.match(dashboard, /<table className="sr-only">/, "Trend charts should include a screen-reader data table.");
 assert.match(dashboard, /Complete the minimum version or finish a weekly review/, "Empty wins should guide the next action.");
 assert.match(helpers, /measuredMetricsForDomain/, "Trends should be selected by the user's current domain.");
+assert.match(route, /next_experiment_id/, "Journey should load the next experiment chosen in each completed review.");
+assert.match(dashboard, /Your learning loop/, "Journey should present completed reviews as a learning loop.");
+for (const label of ["Tried", "Why it mattered", "Noticed", "Chose next"]) {
+  assert.ok(dashboard.includes(label), `Journey learning loop should show ${label}.`);
+}
+assert.match(dashboard, /Progress by life area/, "Journey should summarize activity by relevant lifestyle domain.");
+assert.match(dashboard, /Based on that review and your current Blueprint/, "Next-focus copy should use both completed reviews and current Blueprint priorities.");
+assert.match(helpers, /journeyDomainSummaries/, "Domain summaries should be derived without a universal score.");
 
 console.log("Journey v1 acceptance checks passed.");

--- a/src/_tests_/pr80JourneyLoop.assert.mjs
+++ b/src/_tests_/pr80JourneyLoop.assert.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [route, dashboard, helpers, migration] = await Promise.all([
+  readFile("app/api/journey/route.ts", "utf8"),
+  readFile("src/components/journey/JourneyDashboard.tsx", "utf8"),
+  readFile("src/lib/journey.ts", "utf8"),
+  readFile("supabase/migrations/20260801233949_preserve_blueprint_journey_rollover.sql", "utf8"),
+]);
+
+assert.match(route, /next_experiment_id/, "Journey should load the member's next chosen experiment.");
+for (const label of ["Tried", "Why it mattered", "Noticed", "Chose next"]) {
+  assert.ok(dashboard.includes(label), `Journey learning loop should show ${label}.`);
+}
+assert.match(dashboard, /Progress by life area/, "Journey should summarize relevant lifestyle domains.");
+assert.match(dashboard, /not grades/, "Domain summaries should explicitly avoid grading the member.");
+assert.match(dashboard, /Based on that review and your current Blueprint/, "Next-focus suggestions should combine the latest review with current Blueprint priorities.");
+assert.match(helpers, /journeyDomainSummaries/, "Journey domain summaries should use existing experiment history.");
+assert.match(migration, /security invoker/, "The weekly review rollover should keep the existing invoker security model.");
+assert.match(migration, /p_decision in \('keep', 'shrink', 'advance'\).*current_experiment\.source_stack_id/s, "Same-practice rollover should preserve its source Blueprint.");
+assert.match(migration, /p_decision in \('keep', 'shrink', 'advance'\).*current_experiment\.source_action_id/s, "Same-practice rollover should preserve its source priority.");
+assert.match(migration, /else null end/, "Swapped practices should not inherit stale Blueprint provenance.");
+assert.match(migration, /revoke all on function[\s\S]*from public, anon, authenticated/, "The rollover function should remain unavailable to public client roles.");
+
+console.log("PR80 Journey learning-loop checks passed.");

--- a/src/components/journey/JourneyDashboard.tsx
+++ b/src/components/journey/JourneyDashboard.tsx
@@ -19,6 +19,7 @@ import {
   distinctWeeks,
   domainLabel,
   hasFourWeeksOfHistory,
+  journeyDomainSummaries,
   measuredMetricsForDomain,
   type JourneyCheckIn,
   type JourneyExperiment,
@@ -93,6 +94,8 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
     ?? data.experiments.find((item) => item.identity_direction)?.identity_direction
     ?? null;
   const metrics = measuredMetricsForDomain(currentDomain);
+  const domainSummaries = journeyDomainSummaries(data.experiments, completedReviews, data.completions);
+  const latestReview = completedReviews[0] ?? null;
 
   if (!data.experiments.length) {
     return (
@@ -133,6 +136,16 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
           href="/today"
         />
       )}
+
+      <NextFocusPrompt
+        activeExperiment={activeExperiment}
+        blueprint={data.blueprint}
+        experiments={data.experiments}
+        experimentBlueprints={data.experiment_blueprints}
+        latestReview={latestReview}
+      />
+
+      <DomainProgress summaries={domainSummaries} />
 
       <section aria-labelledby="experiment-history-title" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
         <div className="flex items-start gap-3">
@@ -189,9 +202,78 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
 
       <div className="grid gap-6 lg:grid-cols-2">
         <WinsTimeline reviews={completedReviews} completionTotal={completionTotal} />
-        <ReviewHistory reviews={completedReviews} experiments={data.experiments} />
+        <LearningLoop
+          reviews={completedReviews}
+          experiments={data.experiments}
+          experimentBlueprints={data.experiment_blueprints}
+        />
       </div>
     </div>
+  );
+}
+
+function NextFocusPrompt({ activeExperiment, blueprint, experiments, experimentBlueprints, latestReview }: {
+  activeExperiment: JourneyExperiment | null;
+  blueprint: CurrentBlueprintContext | null;
+  experiments: JourneyExperiment[];
+  experimentBlueprints: Record<string, ExperimentBlueprintContext>;
+  latestReview: JourneyReview | null;
+}) {
+  const usedCurrentPriorityIds = new Set(experiments
+    .filter((experiment) => experimentBlueprints[experiment.id]?.is_current_blueprint)
+    .map((experiment) => experiment.source_action_id)
+    .filter((id): id is string => Boolean(id)));
+  const actionable = blueprint?.priorities.filter((priority) => priority.kind === "lifestyle") ?? [];
+  const suggested = actionable.find((priority) => !usedCurrentPriorityIds.has(priority.id)) ?? actionable[0] ?? null;
+
+  if (activeExperiment) {
+    const context = experimentBlueprints[activeExperiment.id] ?? null;
+    return (
+      <section aria-labelledby="next-focus-title" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Your next choice</p>
+        <h2 id="next-focus-title" className="mt-1 text-2xl font-bold text-[#041B2D]">Learn from this week before adding more.</h2>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+          {latestReview?.decision ? `Your last review: ${DECISION_LABELS[latestReview.decision].toLowerCase()}. ` : ""}
+          Complete this week, notice usefulness and difficulty, then choose whether to keep, adjust, or replace the practice.
+        </p>
+        {context?.priority_label ? <p className="mt-4 rounded-2xl bg-[#F4FAF8] p-4 text-sm text-slate-700"><strong className="text-[#041B2D]">Current Blueprint connection:</strong> {context.priority_label}</p> : null}
+      </section>
+    );
+  }
+
+  if (!blueprint || !suggested) return null;
+  return (
+    <section aria-labelledby="next-focus-title" className="rounded-3xl border border-[#BCE3DA] bg-[#F4FAF8] p-6 sm:p-8">
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">A possible next focus</p>
+      <h2 id="next-focus-title" className="mt-1 text-2xl font-bold text-[#041B2D]">Return to a current Blueprint priority.</h2>
+      <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+        {latestReview?.decision ? `Your last review: ${DECISION_LABELS[latestReview.decision].toLowerCase()}. ` : ""}
+        Based on that review and your current Blueprint, this is one option to consider next.
+      </p>
+      <p className="mt-4 rounded-2xl bg-white p-4 font-semibold text-[#041B2D]">{suggested.label}</p>
+      <Link href={`/blueprints/${blueprint.stack_id}`} className="mt-5 inline-flex min-h-12 items-center rounded-xl bg-[#08A88A] px-5 py-3 text-sm font-bold text-white hover:bg-[#078B74]">
+        Review this priority <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+      </Link>
+    </section>
+  );
+}
+
+function DomainProgress({ summaries }: { summaries: ReturnType<typeof journeyDomainSummaries> }) {
+  return (
+    <section aria-labelledby="domain-progress-title" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Progress by life area</p>
+      <h2 id="domain-progress-title" className="mt-1 text-2xl font-bold text-[#041B2D]">Where you have been practicing</h2>
+      <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">These are activity summaries, not grades. A quieter life area is not a failure or a recommendation.</p>
+      <ul className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {summaries.map((summary) => (
+          <li key={summary.domain} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+            <h3 className="font-bold text-[#041B2D]">{domainLabel(summary.domain)}</h3>
+            <p className="mt-2 text-sm text-slate-600">{summary.weeks} {summary.weeks === 1 ? "week" : "weeks"}. {summary.repetitions} practice {summary.repetitions === 1 ? "rep" : "reps"}. {summary.reviews} {summary.reviews === 1 ? "review" : "reviews"}.</p>
+            {summary.latest_decision ? <p className="mt-2 text-xs font-semibold text-[#087F72]">Latest choice: {DECISION_LABELS[summary.latest_decision]}</p> : null}
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 
@@ -395,14 +477,23 @@ function WinsTimeline({ reviews, completionTotal }: { reviews: JourneyReview[]; 
   );
 }
 
-function ReviewHistory({ reviews, experiments }: { reviews: JourneyReview[]; experiments: JourneyExperiment[] }) {
+function LearningLoop({ reviews, experiments, experimentBlueprints }: { reviews: JourneyReview[]; experiments: JourneyExperiment[]; experimentBlueprints: Record<string, ExperimentBlueprintContext> }) {
   return (
     <section aria-labelledby="review-history-title" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div className="flex items-center gap-2"><Compass className="h-5 w-5 text-[#087F72]" aria-hidden="true" /><h2 id="review-history-title" className="text-xl font-bold text-[#041B2D]">What you learned</h2></div>
+      <div className="flex items-center gap-2"><Compass className="h-5 w-5 text-[#087F72]" aria-hidden="true" /><h2 id="review-history-title" className="text-xl font-bold text-[#041B2D]">Your learning loop</h2></div>
       {reviews.length ? (
         <ul className="mt-5 space-y-4">{reviews.map((review) => {
           const experiment = experiments.find((item) => item.id === review.experiment_id);
-          return <li key={review.experiment_id} className="rounded-2xl bg-slate-50 p-4"><p className="font-semibold text-[#041B2D]">{experiment?.action_label || "Weekly practice"}</p><p className="mt-2 text-sm leading-6 text-slate-600">Useful {review.value_rating}/5. Difficult {review.difficulty}/5. {review.decision ? DECISION_LABELS[review.decision] : "Reviewed"}.</p></li>;
+          const nextExperiment = experiments.find((item) => item.id === review.next_experiment_id) ?? null;
+          const context = experiment ? experimentBlueprints[experiment.id] ?? null : null;
+          return <li key={review.experiment_id} className="rounded-2xl bg-slate-50 p-4">
+            <dl className="space-y-3 text-sm leading-6">
+              <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Tried</dt><dd className="font-semibold text-[#041B2D]">{experiment?.action_label || "Weekly practice"}</dd></div>
+              <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Why it mattered</dt><dd className="text-slate-600">{context?.priority_label || `${domainLabel(experiment?.identity_direction ?? null)} was your chosen focus.`}</dd></div>
+              <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Noticed</dt><dd className="text-slate-600">You reported usefulness {review.value_rating}/5 and difficulty {review.difficulty}/5 after {review.completion_count} of {review.target_count} planned reps.</dd></div>
+              <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Chose next</dt><dd className="text-slate-600">{review.decision ? DECISION_LABELS[review.decision] : "Reviewed"}{nextExperiment?.action_label ? `: ${nextExperiment.action_label}` : "."}</dd></div>
+            </dl>
+          </li>;
         })}</ul>
       ) : (
         <EmptyPanel title="Your first weekly reflection will appear here." body="At the end of the week, notice usefulness and difficulty, then decide whether to keep, shrink, swap, pause, or build on the practice." />

--- a/src/lib/journey.ts
+++ b/src/lib/journey.ts
@@ -15,6 +15,7 @@ export type JourneyExperiment = {
 
 export type JourneyReview = {
   experiment_id: string;
+  next_experiment_id: string | null;
   completion_count: number;
   target_count: number;
   difficulty: number | null;
@@ -22,6 +23,14 @@ export type JourneyReview = {
   decision: "keep" | "shrink" | "swap" | "pause" | "advance" | null;
   status: "draft" | "completed";
   completed_at: string | null;
+};
+
+export type JourneyDomainSummary = {
+  domain: string;
+  weeks: number;
+  repetitions: number;
+  reviews: number;
+  latest_decision: JourneyReview["decision"];
 };
 
 export type JourneyCompletion = {
@@ -105,4 +114,36 @@ export function measuredMetricsForDomain(domain: string | null): Array<"sleep" |
   }
   if (domain === "focus" || domain === "career") return ["energy", "sleep"];
   return [];
+}
+
+export function journeyDomainSummaries(
+  experiments: JourneyExperiment[],
+  reviews: JourneyReview[],
+  completions: JourneyCompletion[],
+): JourneyDomainSummary[] {
+  const reviewsByExperiment = new Map(reviews.map((review) => [review.experiment_id, review]));
+  const completionsByExperiment = completions.reduce<Map<string, number>>((counts, completion) => {
+    counts.set(completion.experiment_id, (counts.get(completion.experiment_id) ?? 0) + 1);
+    return counts;
+  }, new Map());
+
+  const summaries = new Map<string, JourneyDomainSummary>();
+  for (const experiment of experiments) {
+    const domain = experiment.identity_direction ?? "overall_health";
+    const review = reviewsByExperiment.get(experiment.id) ?? null;
+    const existing = summaries.get(domain) ?? {
+      domain,
+      weeks: 0,
+      repetitions: 0,
+      reviews: 0,
+      latest_decision: null,
+    };
+    existing.weeks += 1;
+    existing.repetitions += completionsByExperiment.get(experiment.id) ?? 0;
+    existing.reviews += review?.status === "completed" ? 1 : 0;
+    if (!existing.latest_decision && review?.decision) existing.latest_decision = review.decision;
+    summaries.set(domain, existing);
+  }
+
+  return [...summaries.values()].sort((a, b) => b.weeks - a.weeks || a.domain.localeCompare(b.domain));
 }

--- a/supabase/migrations/20260801233949_preserve_blueprint_journey_rollover.sql
+++ b/supabase/migrations/20260801233949_preserve_blueprint_journey_rollover.sql
@@ -1,0 +1,112 @@
+create or replace function public.complete_weekly_review(
+  p_user_id uuid,
+  p_experiment_id uuid,
+  p_difficulty smallint,
+  p_value_rating smallint,
+  p_decision text,
+  p_action_label text default null,
+  p_cue text default null,
+  p_frequency_per_week smallint default null,
+  p_minimum_version text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_experiment public.weekly_experiments%rowtype;
+  next_id uuid;
+  completed_reps smallint;
+  next_week_start date;
+begin
+  if p_difficulty not between 1 and 5
+    or p_value_rating not between 1 and 5
+    or p_decision not in ('keep', 'shrink', 'swap', 'pause', 'advance') then
+    raise exception 'invalid_review';
+  end if;
+
+  select * into current_experiment
+  from public.weekly_experiments
+  where id = p_experiment_id and user_id = p_user_id and status = 'active'
+  for update;
+
+  if not found then raise exception 'active_experiment_not_found'; end if;
+  if current_date < current_experiment.week_start + 6 then raise exception 'review_not_due'; end if;
+  if exists (
+    select 1 from public.weekly_experiment_reviews
+    where experiment_id = p_experiment_id and status = 'completed'
+  ) then raise exception 'review_already_completed'; end if;
+
+  select count(distinct completion_date)::smallint into completed_reps
+  from public.daily_practice_completions
+  where user_id = p_user_id
+    and experiment_id = p_experiment_id
+    and completion_date between current_experiment.week_start and current_experiment.week_start + 6;
+
+  update public.weekly_experiments
+  set status = 'completed', completed_at = now(), updated_at = now()
+  where id = p_experiment_id;
+
+  if p_decision <> 'pause' then
+    if p_action_label is null or char_length(btrim(p_action_label)) not between 4 and 240
+      or p_cue is null or char_length(btrim(p_cue)) not between 2 and 160
+      or p_frequency_per_week not between 1 and 7
+      or p_minimum_version is null or char_length(btrim(p_minimum_version)) not between 2 and 160 then
+      raise exception 'invalid_next_experiment';
+    end if;
+
+    next_week_start := greatest(
+      current_experiment.week_start + 7,
+      date_trunc('week', current_date)::date
+    );
+
+    insert into public.weekly_experiments (
+      user_id, source_stack_id, source_action_id, identity_direction,
+      action_label, cue, frequency_per_week, minimum_version,
+      reminder_preference, reminder_timing, reminder_hour,
+      onboarding_step, status, week_start, activated_at
+    ) values (
+      p_user_id,
+      case when p_decision in ('keep', 'shrink', 'advance') then current_experiment.source_stack_id else null end,
+      case when p_decision in ('keep', 'shrink', 'advance') then current_experiment.source_action_id else null end,
+      current_experiment.identity_direction,
+      btrim(p_action_label), btrim(p_cue), p_frequency_per_week, btrim(p_minimum_version),
+      current_experiment.reminder_preference, current_experiment.reminder_timing,
+      current_experiment.reminder_hour, 6, 'active', next_week_start, now()
+    ) returning id into next_id;
+  end if;
+
+  insert into public.weekly_experiment_reviews (
+    user_id, experiment_id, completion_count, target_count, difficulty,
+    value_rating, decision, status, next_experiment_id, completed_at, updated_at
+  ) values (
+    p_user_id, p_experiment_id, completed_reps, current_experiment.frequency_per_week,
+    p_difficulty, p_value_rating, p_decision, 'completed', next_id, now(), now()
+  ) on conflict (experiment_id) do update set
+    completion_count = excluded.completion_count,
+    target_count = excluded.target_count,
+    difficulty = excluded.difficulty,
+    value_rating = excluded.value_rating,
+    decision = excluded.decision,
+    status = 'completed',
+    next_experiment_id = excluded.next_experiment_id,
+    completed_at = excluded.completed_at,
+    updated_at = excluded.updated_at;
+
+  return next_id;
+end;
+$$;
+
+revoke all on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  from public, anon, authenticated;
+grant execute on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  to service_role;
+
+comment on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text) is
+  'Completes a weekly review, records the next experiment, and preserves Blueprint provenance when a member keeps, shrinks, or advances the same practice.';
+
+-- Rollback: restore the complete_weekly_review definition from
+-- 20260801192204_pr75_practice_aware_reminders.sql. That version retains
+-- practice-aware reminder fields but does not carry Blueprint provenance into
+-- the next weekly experiment.


### PR DESCRIPTION
## Purpose

Turn Journey from a passive history page into a humane learning loop tied to the member's current Blueprint and broader lifestyle priorities.

## What changed

- Added a four-part review history showing what the member tried, why it mattered, what they noticed, and what they chose next.
- Added activity summaries by relevant lifestyle domain without a universal score or grade.
- Added a next-focus prompt that combines the latest completed review with current actionable Blueprint priorities.
- Limited weight, sleep, and energy patterns to domains where those signals are relevant, preserving the existing non-causal language.
- Loaded each review's `next_experiment_id` so Journey can show the actual practice chosen for the following week.
- Added a Supabase migration that preserves Blueprint source links when a member keeps, shrinks, or advances the same practice, while clearing stale links when they swap practices.

## Files changed

- `src/components/journey/JourneyDashboard.tsx`
- `src/lib/journey.ts`
- `app/api/journey/route.ts`
- `supabase/migrations/20260801233949_preserve_blueprint_journey_rollover.sql`
- Journey and PR80 acceptance checks

## Verified

- `npm.cmd run qa:pr80`
- `npm.cmd run qa:journey`
- `npm.cmd run typecheck`
- `npm.cmd run build` with non-secret placeholder configuration
- `git diff --check`
- No em dashes added to the changed product copy

## Not verified locally

- Authenticated visual QA with a real member's multi-week Journey history.
- Applying the migration to a live database. Supabase Preview should validate the migration before merge.
- The ordinary local launch environment check reports the expected missing secrets in this checkout. No secret or environment file was changed.

## Risks and rollback

The database change replaces the existing `complete_weekly_review` function without changing its signature. It retains `security invoker`, the empty search path, and service-role-only execution. To roll back, restore the function definition from `20260801192204_pr75_practice_aware_reminders.sql`.

## QA focus

1. Review a Blueprint-linked practice and choose Keep, Make it smaller, or Build on it. Confirm the new active week still shows the same Blueprint priority in Journey.
2. Review a practice and choose Swap. Confirm the new practice is shown as self-chosen unless deliberately started from a Blueprint.
3. Confirm a completed review shows Tried, Why it mattered, Noticed, and Chose next.
4. Confirm domain cards summarize weeks, repetitions, and reviews without displaying a grade.
5. Confirm the next-focus prompt reflects the latest review and offers a current actionable Blueprint priority.