### PR TITLE
PR80.1 — Recover Blueprint refresh generation

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -71,6 +71,7 @@ export default function BlueprintWorkspaceClient({
   const [refreshing, setRefreshing] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [refreshIssue, setRefreshIssue] = useState<string | null>(null);
   const [handoffId, setHandoffId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -145,17 +146,20 @@ export default function BlueprintWorkspaceClient({
     setRefreshing(true);
     setError(null);
     setMessage(null);
+    setRefreshIssue(null);
     try {
       const response = await fetch(`/api/blueprints/${encodeURIComponent(stack.id)}/refresh`, {
         method: "POST",
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data?.ok || !data?.stack_id) {
-        throw new Error("We could not refresh your Blueprint. Your existing version is unchanged.");
+        throw new Error("refresh_unavailable");
       }
       window.location.assign(`/blueprints/${encodeURIComponent(data.stack_id)}?refreshed=1`);
-    } catch (refreshError) {
-      setError(refreshError instanceof Error ? refreshError.message : "We could not refresh your Blueprint.");
+    } catch {
+      setRefreshIssue(
+        "We could not create an updated version right now. Your saved changes and current Blueprint are still available. This is a service issue, so there is nothing you need to correct. Please try again in a few minutes."
+      );
       setRefreshing(false);
     }
   }
@@ -234,11 +238,10 @@ export default function BlueprintWorkspaceClient({
             <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" aria-hidden="true" />
             <div className="flex-1">
               <h2 className="font-bold text-amber-950">
-                {stack.generationReason ? "Your Blueprint may be out of date" : "Refresh recommended"}
+                {refreshIssue ? "Your current Blueprint is still available" : "Your saved changes are ready for review"}
               </h2>
               <p className="mt-1 text-sm leading-6 text-amber-900">
-                Your current inputs differ from this report, or this version predates change tracking. The existing report
-                stays available until you choose to create a refreshed version.
+                {refreshIssue ?? "Your current health information differs from this dated report. Create an updated Blueprint when you are ready to review those changes and rerun the safety check."}
               </p>
               <button
                 type="button"
@@ -247,7 +250,7 @@ export default function BlueprintWorkspaceClient({
                 className="mt-4 inline-flex min-h-11 items-center rounded-xl bg-amber-800 px-5 py-3 text-sm font-bold text-white hover:bg-amber-900 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {refreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />}
-                {refreshing ? "Refreshing Blueprint..." : "Refresh Blueprint and safety review"}
+                {refreshing ? "Refreshing Blueprint..." : refreshIssue ? "Try Blueprint refresh again" : "Refresh Blueprint and safety review"}
               </button>
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "qa:pr78": "node src/_tests_/pr78Handoff.assert.mjs",
     "qa:pr79": "node src/_tests_/pr79Activation.assert.mjs",
     "qa:pr80": "node src/_tests_/pr80JourneyLoop.assert.mjs",
+    "qa:pr80-refresh": "node --experimental-strip-types src/_tests_/blueprintRefreshRecovery.assert.ts",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/blueprintRefreshRecovery.assert.ts
+++ b/src/_tests_/blueprintRefreshRecovery.assert.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+
+import {
+  BLUEPRINT_MIN_RECOMMENDATIONS,
+  BLUEPRINT_TARGET_RECOMMENDATIONS,
+  validateBlueprintRecommendationMix,
+} from "../lib/blueprintRecommendationMix.ts";
+
+assert.equal(BLUEPRINT_MIN_RECOMMENDATIONS, 8);
+assert.equal(BLUEPRINT_TARGET_RECOMMENDATIONS, 10);
+
+assert.equal(validateBlueprintRecommendationMix([
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "New - consider",
+  "Clinician review",
+  "Clinician review",
+]).valid, true, "A useful eight-item report must not fail merely because safe filler is unavailable.");
+
+assert.equal(validateBlueprintRecommendationMix([
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "New - consider",
+  "New - consider",
+]).valid, false, "The five-current-item cap must remain enforced.");
+
+assert.equal(validateBlueprintRecommendationMix([
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "New - consider",
+  "New - consider",
+]).valid, false, "Reports with fewer than eight recommendations must still fail closed.");
+
+assert.equal(validateBlueprintRecommendationMix([
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "New - consider",
+  "New - consider",
+  "New - consider",
+  "New - consider",
+  "New - consider",
+  "New - consider",
+]).valid, false, "Reports with more than ten recommendations must still be rejected.");
+
+console.log("Blueprint refresh recovery assertions passed.");

--- a/src/lib/blueprintRecommendationMix.ts
+++ b/src/lib/blueprintRecommendationMix.ts
@@ -1,0 +1,25 @@
+export const BLUEPRINT_MIN_RECOMMENDATIONS = 8;
+export const BLUEPRINT_TARGET_RECOMMENDATIONS = 10;
+
+const ALLOWED_STATUSES = new Set([
+  "Current - optimize",
+  "New - consider",
+  "Clinician review",
+]);
+
+export function validateBlueprintRecommendationMix(statuses: string[]) {
+  const counts = {
+    total: statuses.length,
+    current: statuses.filter((status) => status === "Current - optimize").length,
+    new: statuses.filter((status) => status === "New - consider").length,
+    clinicianReview: statuses.filter((status) => status === "Clinician review").length,
+  };
+  return {
+    valid: counts.total >= BLUEPRINT_MIN_RECOMMENDATIONS &&
+      counts.total <= BLUEPRINT_TARGET_RECOMMENDATIONS &&
+      counts.current <= 5 &&
+      (counts.new + counts.clinicianReview) >= 3 &&
+      statuses.every((status) => ALLOWED_STATUSES.has(status)),
+    counts,
+  };
+}

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -36,6 +36,11 @@ import {
 } from "@/lib/supplementEligibility";
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
 import { ensureCurrentRegimen } from "@/lib/currentRegimen";
+import {
+  BLUEPRINT_MIN_RECOMMENDATIONS,
+  BLUEPRINT_TARGET_RECOMMENDATIONS,
+  validateBlueprintRecommendationMix,
+} from "@/lib/blueprintRecommendationMix";
 
 // Curated evidence index (JSON)
 // If this path differs in your repo, update the import below.
@@ -175,7 +180,7 @@ async function callChatWithRetry(
 // ----------------------------------------------------------------------------
 const TODAY = new Date().toISOString().slice(0, 10); // e.g., 2025-11-03
 const MIN_ANALYSIS_SENTENCES = 3;
-const BLUEPRINT_MIN_ROWS = 10; // business rule: always show ≥10 rows
+const BLUEPRINT_MIN_ROWS = BLUEPRINT_MIN_RECOMMENDATIONS;
 
 const MODEL_CITE_RE = /\bhttps?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/?|doi\.org\/\S+)\b/;
 const CURATED_CITE_RE = /\bhttps?:\/\/(?:pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/?|pmc\.ncbi\.nlm\.nih\.gov\/articles\/\S+|doi\.org\/\S+|jamanetwork\.com\/\S+|(?:[a-z0-9-]+\.)?biomedcentral\.com\/\S+|journals\.plos\.org\/\S+|nature\.com\/\S+|sciencedirect\.com\/\S+|amjmed\.com\/\S+|koreascience\.kr\/\S+|researchmgt\.monash\.edu\/\S+)\b/i;
@@ -708,17 +713,7 @@ function validateBlueprintMix(md: string) {
     .filter((line) => /^\s*\|\s*\d+\s*\|/.test(line))
     .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()));
   const statuses = rows.map((cells) => cells[2]);
-  const counts = {
-    total: rows.length,
-    current: statuses.filter((status) => status === "Current - optimize").length,
-    new: statuses.filter((status) => status === "New - consider").length,
-    clinicianReview: statuses.filter((status) => status === "Clinician review").length,
-  };
-  return {
-    valid: counts.total === 10 && counts.current <= 5 && (counts.new + counts.clinicianReview) >= 4 &&
-      statuses.every((status) => ["Current - optimize", "New - consider", "Clinician review"].includes(status)),
-    counts,
-  };
+  return validateBlueprintRecommendationMix(statuses);
 }
 
 function malformedCurrentStackRows(md: string): string[] {
@@ -1486,8 +1481,8 @@ ${JSON.stringify(recommendableSupplementLedger, null, 2)}
 Output ONLY the section "## Your Blueprint Recommendations" as a Markdown table with the exact header:
 | Rank | Supplement | Status | Why it Matters |
 
-- Provide exactly **10** data rows (Rank 1..10).
-- Include at least 4 "New - consider" rows, no more than 5 "Current - optimize" rows, and no more than 1 "Clinician review" row.
+- Provide 8 to 10 justified data rows. Do not add filler simply to reach 10.
+- Include at least 3 combined "New - consider" or "Clinician review" rows and no more than 5 "Current - optimize" rows.
 - Recommend goal-aligned supplement options only. Never recommend medications, prescription drugs, or hormones.
 - Never recommend endocrine-active supplements such as DHEA or Pregnenolone by default.
 - Select from the recommendable supplement ledger. Do not simply copy the Current Stack unless a legitimate current supplement has a clear optimization reason.
@@ -1891,8 +1886,8 @@ if (!tableMd) {
 Convert the text below into a single Markdown table ONLY with header exactly:
 | Rank | Supplement | Status | Why it Matters |
 
-- Provide exactly 10 data rows (Rank 1..10).
-- Include at least 4 "New - consider" rows, no more than 5 "Current - optimize" rows, and no more than 1 "Clinician review" row.
+- Provide 8 to 10 justified data rows. Do not add filler simply to reach 10.
+- Include at least 3 combined "New - consider" or "Clinician review" rows and no more than 5 "Current - optimize" rows.
 - Short, plain-English "Why it Matters".
 - If dose/timing is relevant, write "See Dosing & Notes".
 - No other text. No code fences.
@@ -1917,7 +1912,7 @@ if (!tableMd) {
 }
 tableMd = sanitizeBlueprintTable(
   tableMd,
-  BLUEPRINT_MIN_ROWS,
+  BLUEPRINT_TARGET_RECOMMENDATIONS,
   recommendableSupplementLedger.map((item) => item.name),
   currentStackLedger,
   berberineRequiresReview
@@ -2287,7 +2282,7 @@ md = replaceOrAppendSection(md, buildPracticalFollowUpSection());
   md = forceHeadings(md);
   md = hardenBlueprintSection(
     md,
-    computeValidationTargets(mode, cap).minRows,
+    BLUEPRINT_TARGET_RECOMMENDATIONS,
     recommendableSupplementLedger.map((item) => item.name),
     currentStackLedger,
     berberineRequiresReview


### PR DESCRIPTION
## What changed

- Accept 8 to 10 justified Blueprint recommendations instead of requiring exactly 10.
- Keep the existing maximum of five current-item recommendations and require at least three new or clinician-review items.
- Continue targeting 10 recommendations when enough eligible options exist.
- Replace the repetitive stale warning plus generic red error with one clear recovery state.
- Add focused regression coverage for the production recommendation mix.

## Root cause

Production refreshes were reaching the safety-complete stage, then being rejected because the final recommendation mix contained 8 or 9 eligible items rather than exactly 10. This happens when a member already takes many supplements from the approved recommendation pool. The generator correctly limits current-item recommendations, but it should not invent filler solely to reach 10.

## User impact

Members can refresh a dated Blueprint after changing their routine without a useful, safety-reviewed report being discarded for an arbitrary row count. If generation is temporarily unavailable, the page now explains that saved changes and the existing Blueprint remain available and that the user does not need to correct anything.

## Validation

- `npm.cmd run qa:pr80-refresh`
- `npm.cmd run qa:blueprints`
- `npm.cmd run qa:blueprint-safety`
- `npm.cmd run typecheck`
- `npm.cmd run build` with temporary build-only placeholders for required environment variables

The PR80 production migration was applied and verified separately before this follow-up.