### PR TITLE
PR80.2 — Allow focused Blueprint reviews

### DIFF
--- a/src/_tests_/blueprintRefreshRecovery.assert.ts
+++ b/src/_tests_/blueprintRefreshRecovery.assert.ts
@@ -6,7 +6,7 @@ import {
   validateBlueprintRecommendationMix,
 } from "../lib/blueprintRecommendationMix.ts";
 
-assert.equal(BLUEPRINT_MIN_RECOMMENDATIONS, 8);
+assert.equal(BLUEPRINT_MIN_RECOMMENDATIONS, 5);
 assert.equal(BLUEPRINT_TARGET_RECOMMENDATIONS, 10);
 
 assert.equal(validateBlueprintRecommendationMix([
@@ -18,7 +18,25 @@ assert.equal(validateBlueprintRecommendationMix([
   "New - consider",
   "Clinician review",
   "Clinician review",
-]).valid, true, "A useful eight-item report must not fail merely because safe filler is unavailable.");
+]).valid, true, "A useful report must not fail merely because safe filler is unavailable.");
+
+assert.equal(validateBlueprintRecommendationMix([
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "New - consider",
+  "Clinician review",
+]).valid, true, "The seven-item production mix must remain valid.");
+
+assert.equal(validateBlueprintRecommendationMix([
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+  "Current - optimize",
+]).valid, true, "A current-stack review must not be forced to recommend another purchase.");
 
 assert.equal(validateBlueprintRecommendationMix([
   "Current - optimize",
@@ -36,10 +54,7 @@ assert.equal(validateBlueprintRecommendationMix([
   "Current - optimize",
   "Current - optimize",
   "Current - optimize",
-  "Current - optimize",
-  "New - consider",
-  "New - consider",
-]).valid, false, "Reports with fewer than eight recommendations must still fail closed.");
+]).valid, false, "Reports with fewer than five recommendations must still fail closed.");
 
 assert.equal(validateBlueprintRecommendationMix([
   "Current - optimize",

--- a/src/lib/blueprintRecommendationMix.ts
+++ b/src/lib/blueprintRecommendationMix.ts
@@ -1,4 +1,4 @@
-export const BLUEPRINT_MIN_RECOMMENDATIONS = 8;
+export const BLUEPRINT_MIN_RECOMMENDATIONS = 5;
 export const BLUEPRINT_TARGET_RECOMMENDATIONS = 10;
 
 const ALLOWED_STATUSES = new Set([
@@ -18,7 +18,6 @@ export function validateBlueprintRecommendationMix(statuses: string[]) {
     valid: counts.total >= BLUEPRINT_MIN_RECOMMENDATIONS &&
       counts.total <= BLUEPRINT_TARGET_RECOMMENDATIONS &&
       counts.current <= 5 &&
-      (counts.new + counts.clinicianReview) >= 3 &&
       statuses.every((status) => ALLOWED_STATUSES.has(status)),
     counts,
   };

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -1481,8 +1481,8 @@ ${JSON.stringify(recommendableSupplementLedger, null, 2)}
 Output ONLY the section "## Your Blueprint Recommendations" as a Markdown table with the exact header:
 | Rank | Supplement | Status | Why it Matters |
 
-- Provide 8 to 10 justified data rows. Do not add filler simply to reach 10.
-- Include at least 3 combined "New - consider" or "Clinician review" rows and no more than 5 "Current - optimize" rows.
+- Provide 5 to 10 justified data rows. Do not add filler simply to reach 10.
+- Include no more than 5 "Current - optimize" rows. Add "New - consider" or "Clinician review" rows only when they are justified by the member's context.
 - Recommend goal-aligned supplement options only. Never recommend medications, prescription drugs, or hormones.
 - Never recommend endocrine-active supplements such as DHEA or Pregnenolone by default.
 - Select from the recommendable supplement ledger. Do not simply copy the Current Stack unless a legitimate current supplement has a clear optimization reason.
@@ -1886,8 +1886,8 @@ if (!tableMd) {
 Convert the text below into a single Markdown table ONLY with header exactly:
 | Rank | Supplement | Status | Why it Matters |
 
-- Provide 8 to 10 justified data rows. Do not add filler simply to reach 10.
-- Include at least 3 combined "New - consider" or "Clinician review" rows and no more than 5 "Current - optimize" rows.
+- Provide 5 to 10 justified data rows. Do not add filler simply to reach 10.
+- Include no more than 5 "Current - optimize" rows. Add "New - consider" or "Clinician review" rows only when they are justified by the member's context.
 - Short, plain-English "Why it Matters".
 - If dose/timing is relevant, write "See Dosing & Notes".
 - No other text. No code fences.


### PR DESCRIPTION
## What changed

- Accept 5 to 10 justified Blueprint priorities instead of requiring at least 8.
- Preserve the hard maximum of five `Current - optimize` rows.
- Remove the requirement to propose a minimum number of new supplements.
- Update generation and repair prompts so new or clinician-review items appear only when justified.
- Add regression coverage for the seven-item production failure and for a five-item current-stack-only review.

## Root cause

PR80.1 resolved the common 8–9 item failure, but production observability showed a supplement-heavy member could still finish with seven eligible recommendations: five current items, one new consideration, and one clinician-review item. The report was useful and passed safety evaluation, but the arbitrary minimum of eight caused the entire refresh to be discarded.

## Product rationale

LVE360 should not invent recommendations or pressure a member to add products solely to fill a table. A focused review of what to keep, change, stop, or discuss can be more valuable than a longer shopping list.

## Validation

- `npm.cmd run qa:pr80-refresh`
- `npm.cmd run qa:blueprints`
- `npm.cmd run qa:blueprint-safety`
- `npm.cmd run typecheck`
- `npm.cmd run build` with temporary build-only placeholders for required environment variables
- Production evidence: post-PR80.1 refresh failure with `{"total":7,"current":5,"new":1,"clinicianReview":1}`