### PR TITLE
PR83: Make health alerts actionable

### DIFF
--- a/app/(app)/blueprints/BlueprintsClient.tsx
+++ b/app/(app)/blueprints/BlueprintsClient.tsx
@@ -13,6 +13,7 @@ type StackRow = {
   tally_submission_id: string | null;
   created_at: string | null;
   safety_status: "safe" | "warning" | "error" | null;
+  safety_acknowledged_at?: string | null;
   generation_reason?: string | null;
 };
 
@@ -76,7 +77,7 @@ export default function BlueprintsClient({
                   </p>
                 )}
               </div>
-              <SafetyStatus status={latest.safety_status} />
+              <SafetyStatus stack={latest} paid={paid} />
             </div>
 
             <div className="mt-6 flex flex-col gap-3 sm:flex-row">
@@ -147,19 +148,26 @@ function generationLabel(reason: string | null | undefined): string {
   return reason === "member-refresh" ? "Updated after member changes" : "Original Blueprint";
 }
 
-function SafetyStatus({ status }: { status: StackRow["safety_status"] }) {
+function SafetyStatus({ stack, paid }: { stack: StackRow; paid: boolean }) {
+  const status = stack.safety_status;
+  const acknowledged = Boolean(stack.safety_acknowledged_at);
   const label = status === "safe"
     ? "No material concern identified"
+    : acknowledged
+      ? "Safety notes reviewed"
     : status === "warning"
       ? "Review safety notes"
       : status === "error"
         ? "Blueprint needs review"
         : "Safety status pending";
-  const tone = status === "safe"
+  const tone = status === "safe" || acknowledged
     ? "bg-emerald-50 text-emerald-800"
     : status === "warning"
       ? "bg-amber-50 text-amber-800"
       : "bg-slate-100 text-slate-700";
+  if (paid && status !== "safe" && !acknowledged) {
+    return <Link href={`/blueprints/${encodeURIComponent(stack.id)}#safety-notes`} className={`w-fit rounded-full px-3 py-1 text-sm font-semibold hover:underline ${tone}`}>{label}</Link>;
+  }
   return <span className={`w-fit rounded-full px-3 py-1 text-sm font-semibold ${tone}`}>{label}</span>;
 }
 

--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -30,6 +30,7 @@ type StackSummary = {
   createdAt: string | null;
   safetyStatus: "safe" | "warning" | "error" | null;
   generationReason: string | null;
+  safetyAcknowledgedAt: string | null;
 };
 
 type VersionSummary = {
@@ -73,6 +74,8 @@ export default function BlueprintWorkspaceClient({
   const [error, setError] = useState<string | null>(null);
   const [refreshIssue, setRefreshIssue] = useState<string | null>(null);
   const [handoffId, setHandoffId] = useState<string | null>(null);
+  const [safetyAcknowledged, setSafetyAcknowledged] = useState(Boolean(stack.safetyAcknowledgedAt));
+  const [acknowledgingSafety, setAcknowledgingSafety] = useState(false);
 
   useEffect(() => {
     trackProductEvent({ event_name: "blueprint_viewed", source: "blueprints" });
@@ -185,6 +188,25 @@ export default function BlueprintWorkspaceClient({
     }
   }
 
+  async function acknowledgeSafetyNotes() {
+    setAcknowledgingSafety(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/blueprints/${encodeURIComponent(stack.id)}/safety-acknowledgement`, {
+        method: "POST",
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data?.ok) throw new Error("safety_acknowledgement_unavailable");
+      setSafetyAcknowledged(true);
+      setMessage("Safety notes marked as reviewed. LVE360 will alert you again when a new Blueprint needs review.");
+      router.refresh();
+    } catch {
+      setError("We could not save that acknowledgement. Please try again.");
+    } finally {
+      setAcknowledgingSafety(false);
+    }
+  }
+
   const activeCount = supplements.filter((item) => item.active).length;
 
   return (
@@ -208,7 +230,7 @@ export default function BlueprintWorkspaceClient({
             </p>
           </div>
           <div className="flex flex-col items-start gap-3 sm:flex-row lg:flex-col lg:items-end">
-            <SafetyBadge status={stack.safetyStatus} stale={stale} />
+            <SafetyBadge status={stack.safetyStatus} stale={stale} acknowledged={safetyAcknowledged} />
             <a
               href={`/api/export-pdf?stack_id=${encodeURIComponent(stack.id)}`}
               target="_blank"
@@ -350,6 +372,10 @@ export default function BlueprintWorkspaceClient({
               onEditSupplements={beginEditing}
               onRefresh={refreshBlueprint}
               refreshing={refreshing}
+              safetyAcknowledged={safetyAcknowledged}
+              acknowledgingSafety={acknowledgingSafety}
+              onAcknowledgeSafety={acknowledgeSafetyNotes}
+              safetyNeedsReview={stack.safetyStatus !== "safe"}
             />
           ))}
         </main>
@@ -536,6 +562,10 @@ function ReportSection({
   onEditSupplements,
   onRefresh,
   refreshing,
+  safetyAcknowledged,
+  acknowledgingSafety,
+  onAcknowledgeSafety,
+  safetyNeedsReview,
 }: {
   name: string;
   body: string;
@@ -544,12 +574,16 @@ function ReportSection({
   onEditSupplements: () => void;
   onRefresh: () => void;
   refreshing: boolean;
+  safetyAcknowledged: boolean;
+  acknowledgingSafety: boolean;
+  onAcknowledgeSafety: () => void;
+  safetyNeedsReview: boolean;
 }) {
   const isSafety = name.includes("Contraindications");
   const isCurrent = name === "Current Stack" || name === "Dosing & Notes";
   const isRecommendations = name === "Your Blueprint Recommendations";
   return (
-    <details open={defaultOpen} className="group overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <details id={isSafety ? "safety-notes" : undefined} open={defaultOpen} className="group scroll-mt-24 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
       <summary className={`flex min-h-14 cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 font-bold marker:hidden ${isSafety ? "bg-amber-50 text-amber-950" : "bg-white text-[#041B2D]"}`}>
         {reportSectionTitle(name)}
         <ChevronDown className="h-5 w-5 shrink-0 transition group-open:rotate-180" aria-hidden="true" />
@@ -558,6 +592,22 @@ function ReportSection({
         {isSafety && stale ? (
           <p className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-950">
             These cautions are based on an earlier input snapshot. Refresh before relying on them after a change.
+          </p>
+        ) : null}
+        {isSafety && safetyNeedsReview && !stale && !safetyAcknowledged ? (
+          <button
+            type="button"
+            onClick={onAcknowledgeSafety}
+            disabled={acknowledgingSafety}
+            className="mt-5 inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-4 py-2 text-sm font-bold text-amber-900 hover:bg-amber-50 disabled:opacity-60"
+          >
+            {acknowledgingSafety ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />}
+            I have reviewed these safety notes
+          </button>
+        ) : null}
+        {isSafety && safetyNeedsReview && !stale && safetyAcknowledged ? (
+          <p className="mt-5 inline-flex min-h-11 items-center rounded-xl bg-emerald-50 px-4 py-2 text-sm font-bold text-emerald-900">
+            <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" /> Safety notes reviewed for this Blueprint
           </p>
         ) : null}
         <div className="report-prose prose prose-slate max-w-none">
@@ -590,10 +640,11 @@ function ReportSection({
   );
 }
 
-function SafetyBadge({ status, stale }: { status: StackSummary["safetyStatus"]; stale: boolean }) {
+function SafetyBadge({ status, stale, acknowledged }: { status: StackSummary["safetyStatus"]; stale: boolean; acknowledged: boolean }) {
   if (stale) return <span className="rounded-full bg-amber-100 px-3 py-1 text-sm font-bold text-amber-900">Review after changes</span>;
   if (status === "safe") return <span className="rounded-full bg-emerald-100 px-3 py-1 text-sm font-bold text-emerald-900">No material concern identified</span>;
-  if (status === "warning") return <span className="rounded-full bg-amber-100 px-3 py-1 text-sm font-bold text-amber-900">Review safety notes</span>;
+  if (acknowledged) return <a href="#safety-notes" className="rounded-full bg-emerald-100 px-3 py-1 text-sm font-bold text-emerald-900 hover:underline">Safety notes reviewed</a>;
+  if (status === "warning") return <a href="#safety-notes" className="rounded-full bg-amber-100 px-3 py-1 text-sm font-bold text-amber-900 hover:underline">Review safety notes</a>;
   return <span className="rounded-full bg-slate-100 px-3 py-1 text-sm font-bold text-slate-700">Safety status pending</span>;
 }
 

--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -86,6 +86,7 @@ export default async function BlueprintPage({ params }: PageProps) {
         createdAt: stack.created_at,
         safetyStatus: deriveBlueprintSafetyStatus(markdown),
         generationReason: stack.generation_reason,
+        safetyAcknowledgedAt: stack.safety_acknowledged_at ?? null,
       }}
       sections={Object.entries(report.sections)
         .filter(([, body]) => Boolean(body.trim()))

--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -108,6 +108,10 @@ export default function RoutineClient({
     return () => window.clearTimeout(timer);
   }, [toast]);
 
+  useEffect(() => {
+    if (window.location.hash === "#routine-ideas") setActiveView("supplements");
+  }, []);
+
   async function refreshRoutine() {
     const response = await fetch("/api/stacks/combined", { cache: "no-store" });
     const body = await response.json().catch(() => null);
@@ -290,7 +294,13 @@ export default function RoutineClient({
         })}
       </nav>
 
-      {activeView === "today" ? <TodayDoses refreshToken={doseRefreshToken} /> : null}
+      {activeView === "today" ? (
+        <TodayDoses
+          refreshToken={doseRefreshToken}
+          scheduleReviewItems={grouped.current.filter((item) => !item.schedule)}
+          onEditSchedule={setEditing}
+        />
+      ) : null}
 
       {activeView === "medications" ? (
         <div className="space-y-5">
@@ -537,7 +547,7 @@ function RoutineCard({
 
 function IdeasSection({ items, busyId, onAdopt }: { items: RoutineItem[]; busyId: string | null; onAdopt: (item: RoutineItem) => void }) {
   return (
-    <section className="rounded-2xl border border-amber-200 bg-amber-50 p-5 shadow-sm sm:p-6" aria-labelledby="routine-ideas">
+    <section className="scroll-mt-24 rounded-2xl border border-amber-200 bg-amber-50 p-5 shadow-sm sm:p-6" aria-labelledby="routine-ideas">
       <div className="flex items-start gap-3">
         <span className="rounded-xl bg-white p-2.5 text-amber-700"><ShieldAlert className="h-6 w-6" aria-hidden="true" /></span>
         <div>

--- a/app/(app)/routine/TodayDoses.tsx
+++ b/app/(app)/routine/TodayDoses.tsx
@@ -1,17 +1,27 @@
 "use client";
 
-import { Check, Clock3, History, Loader2, RotateCcw, SkipForward } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type { AsNeededRegimenItem, RegimenDoseDay, RegimenDoseOccurrence, RegimenDoseStatus } from "@/lib/regimenDose";
+import { regimenDoseDaypart, type AsNeededRegimenItem, type RegimenDoseDay, type RegimenDoseOccurrence, type RegimenDoseStatus } from "@/lib/regimenDose";
 import { localDateString } from "@/lib/regimenSchedule";
+import type { RoutineItem } from "@/lib/routine";
 
-export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
+export default function TodayDoses({
+  refreshToken,
+  scheduleReviewItems,
+  onEditSchedule,
+}: {
+  refreshToken: number;
+  scheduleReviewItems: RoutineItem[];
+  onEditSchedule: (item: RoutineItem) => void;
+}) {
   const [day, setDay] = useState<RegimenDoseDay | null>(null);
   const [loading, setLoading] = useState(true);
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const date = localDateString();
+  const dayparts = useMemo(() => groupByDaypart(day?.occurrences ?? []), [day]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -76,6 +86,32 @@ export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
     }
   }
 
+  async function recordGroup(label: string, occurrences: RegimenDoseOccurrence[]) {
+    const remaining = occurrences.filter((occurrence) => !occurrence.status);
+    if (!remaining.length) return;
+    setBusyKey(`group:${label}`);
+    setError(null);
+    try {
+      const responses = await Promise.all(remaining.map((occurrence) => fetch("/api/routine/doses", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          regimen_item_id: occurrence.regimenItemId,
+          date,
+          slot_key: occurrence.slotKey,
+          status: "taken",
+        }),
+      })));
+      if (responses.some((response) => !response.ok)) throw new Error("dose_group_record_failed");
+      await load();
+    } catch {
+      await load();
+      setError("Some items may not have been recorded. Review this section and try any remaining items again.");
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
   async function undo(eventId: string) {
     setBusyKey(eventId);
     setError(null);
@@ -113,12 +149,30 @@ export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
 
       {!loading && day ? (
         <>
-          <div className="mt-5 space-y-3">
-            {day.occurrences.map((occurrence) => {
-              const key = `${occurrence.regimenItemId}:${occurrence.slotKey}`;
-              const busy = busyKey === key || (Boolean(occurrence.eventId) && busyKey === occurrence.eventId);
+          <div className="mt-5 space-y-5">
+            {dayparts.map(({ label, occurrences }) => {
+              const remaining = occurrences.filter((occurrence) => !occurrence.status);
+              const groupBusy = busyKey === `group:${label}`;
               return (
-                <article key={key} className="rounded-2xl border border-slate-200 p-4 sm:flex sm:items-center sm:justify-between sm:gap-5">
+                <section key={label} className="overflow-hidden rounded-2xl border border-slate-200" aria-labelledby={`dose-${label.toLowerCase()}`}>
+                  <div className="flex flex-col gap-3 bg-slate-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 id={`dose-${label.toLowerCase()}`} className="text-lg font-bold text-[#041B2D]">{label}</h3>
+                      <p className="mt-1 text-xs text-slate-600">{occurrences.length} scheduled item{occurrences.length === 1 ? "" : "s"}</p>
+                    </div>
+                    {remaining.length ? (
+                      <button type="button" disabled={busyKey !== null} onClick={() => void recordGroup(label, occurrences)} className="inline-flex min-h-11 items-center justify-center rounded-xl border border-[#087F72] bg-white px-4 py-2 text-sm font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">
+                        {groupBusy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />}
+                        Mark {remaining.length === occurrences.length ? "all" : `${remaining.length} remaining`} taken
+                      </button>
+                    ) : <span className="inline-flex min-h-11 items-center text-sm font-bold text-emerald-800"><Check className="mr-2 h-4 w-4" aria-hidden="true" /> All recorded</span>}
+                  </div>
+                  <div className="divide-y divide-slate-100">
+                    {occurrences.map((occurrence) => {
+                      const key = `${occurrence.regimenItemId}:${occurrence.slotKey}`;
+                      const busy = busyKey === key || (Boolean(occurrence.eventId) && busyKey === occurrence.eventId);
+                      return (
+                        <article key={key} className="p-4 sm:flex sm:items-center sm:justify-between sm:gap-5">
                   <div>
                     <p className="flex items-center text-sm font-bold text-[#087F72]"><Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> {occurrence.timeLabel}</p>
                     <h3 className="mt-1 text-lg font-bold text-[#041B2D]">{occurrence.itemName}</h3>
@@ -144,7 +198,11 @@ export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
                       </button>
                     </div>
                   )}
-                </article>
+                        </article>
+                      );
+                    })}
+                  </div>
+                </section>
               );
             })}
             {!day.occurrences.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No scheduled doses are due today.</p> : null}
@@ -163,7 +221,19 @@ export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
             </div>
           ) : null}
 
-          {day.scheduleReview ? <p className="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm font-semibold text-amber-950">{day.scheduleReview} current item{day.scheduleReview === 1 ? " needs" : "s need"} a structured schedule before it can appear in this checklist. Use Edit schedule below.</p> : null}
+          {scheduleReviewItems.length ? (
+            <section id="schedule-review" className="mt-5 scroll-mt-24 rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-950" aria-labelledby="schedule-review-heading">
+              <h3 id="schedule-review-heading" className="font-bold">Complete {scheduleReviewItems.length} schedule{scheduleReviewItems.length === 1 ? "" : "s"}</h3>
+              <p className="mt-1 text-sm leading-6">These items need a structured time or cadence before they can appear in the checklist.</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {scheduleReviewItems.map((item) => (
+                  <button key={item.id} type="button" onClick={() => onEditSchedule(item)} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
+                    <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> Edit {item.name}
+                  </button>
+                ))}
+              </div>
+            </section>
+          ) : null}
 
           <details className="mt-6 border-t border-slate-200 pt-5">
             <summary className="flex min-h-12 cursor-pointer items-center font-bold text-[#041B2D]"><History className="mr-2 h-5 w-5" aria-hidden="true" /> Recent dose history</summary>
@@ -176,6 +246,21 @@ export default function TodayDoses({ refreshToken }: { refreshToken: number }) {
       ) : null}
     </section>
   );
+}
+
+function groupByDaypart(occurrences: RegimenDoseOccurrence[]): Array<{ label: "Morning" | "Afternoon" | "Evening"; occurrences: RegimenDoseOccurrence[] }> {
+  const groups = {
+    Morning: [] as RegimenDoseOccurrence[],
+    Afternoon: [] as RegimenDoseOccurrence[],
+    Evening: [] as RegimenDoseOccurrence[],
+  };
+  for (const occurrence of occurrences) {
+    const label = regimenDoseDaypart(occurrence.time);
+    groups[label].push(occurrence);
+  }
+  return (["Morning", "Afternoon", "Evening"] as const)
+    .map((label) => ({ label, occurrences: groups[label] }))
+    .filter((group) => group.occurrences.length > 0);
 }
 
 function formatDay(value: string): string {

--- a/app/api/blueprints/[stackId]/safety-acknowledgement/route.ts
+++ b/app/api/blueprints/[stackId]/safety-acknowledgement/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { requirePaidApi } from "@/lib/serverEntitlements";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+type RouteContext = { params: Promise<{ stackId: string }> };
+
+export async function POST(_req: Request, { params }: RouteContext) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  const { stackId } = await params;
+  const acknowledgedAt = new Date().toISOString();
+  const { data, error } = await getSupabaseAdmin()
+    .from("stacks")
+    .update({ safety_acknowledged_at: acknowledgedAt })
+    .eq("id", stackId)
+    .eq("user_id", entitlement.user.id)
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    console.error("[blueprints/safety-acknowledgement] save failed", error);
+    return NextResponse.json({ ok: false, error: "safety_acknowledgement_unavailable" }, { status: 500 });
+  }
+  if (!data) return NextResponse.json({ ok: false, error: "blueprint_not_found" }, { status: 404 });
+
+  return NextResponse.json({ ok: true, acknowledged_at: acknowledgedAt });
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "qa:pr79": "node src/_tests_/pr79Activation.assert.mjs",
     "qa:pr80": "node src/_tests_/pr80JourneyLoop.assert.mjs",
     "qa:pr80-refresh": "node --experimental-strip-types src/_tests_/blueprintRefreshRecovery.assert.ts",
+    "qa:pr83": "node --experimental-strip-types src/_tests_/pr83.assert.ts && node src/_tests_/pr83Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr74.assert.ts
+++ b/src/_tests_/pr74.assert.ts
@@ -28,6 +28,7 @@ const context: CurrentBlueprintContext = {
   stack_id: "stack",
   created_at: "2026-08-01T12:00:00.000Z",
   safety_status: "safe",
+  safety_acknowledged: false,
   needs_refresh: true,
   priorities: [],
 };

--- a/src/_tests_/pr83.assert.ts
+++ b/src/_tests_/pr83.assert.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+
+import { blueprintSafetyLabel, type CurrentBlueprintContext } from "../lib/blueprintContext.ts";
+import { regimenDoseDaypart } from "../lib/regimenDose.ts";
+
+const warning: CurrentBlueprintContext = {
+  stack_id: "stack-83",
+  created_at: "2026-08-08T12:00:00.000Z",
+  safety_status: "warning",
+  safety_acknowledged: false,
+  needs_refresh: false,
+  priorities: [],
+};
+
+assert.equal(blueprintSafetyLabel(warning), "Safety notes need your attention");
+assert.equal(blueprintSafetyLabel({ ...warning, safety_acknowledged: true }), "Safety notes reviewed");
+assert.equal(
+  blueprintSafetyLabel({ ...warning, safety_acknowledged: true, needs_refresh: true }),
+  "Review after your recent changes",
+  "A new input change must take priority over an older acknowledgement",
+);
+
+assert.equal(regimenDoseDaypart("06:30"), "Morning");
+assert.equal(regimenDoseDaypart("12:00"), "Afternoon");
+assert.equal(regimenDoseDaypart("16:59"), "Afternoon");
+assert.equal(regimenDoseDaypart("17:00"), "Evening");
+
+console.log("PR83 behavior assertions passed.");

--- a/src/_tests_/pr83Page.assert.mjs
+++ b/src/_tests_/pr83Page.assert.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+const today = read("app/(app)/routine/TodayDoses.tsx");
+const summary = read("src/components/dashboard/TodaysPlan.tsx");
+const workspace = read("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx");
+const context = read("src/components/dashboard/TodayExperience.tsx");
+const migration = read("supabase/migrations/20260808212539_pr83_safety_acknowledgement.sql");
+
+assert.match(today, /groupByDaypart/);
+assert.match(today, /Mark .*remaining.* taken|Mark \{remaining\.length === occurrences\.length/);
+assert.match(today, /onEditSchedule\(item\)/);
+assert.match(summary, /href="\/routine#routine-ideas"/);
+assert.match(summary, /href="\/routine#schedule-review"/);
+assert.match(workspace, /I have reviewed these safety notes/);
+assert.match(workspace, /id=\{isSafety \? "safety-notes"/);
+assert.match(context, /!blueprint\.safety_acknowledged/);
+assert.match(migration, /safety_acknowledged_at timestamptz/);
+
+console.log("PR83 page assertions passed.");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -166,8 +166,8 @@ export default function TodayExperience({
         </div>
       </div>
 
-      {blueprint && (blueprint.needs_refresh || blueprint.safety_status !== "safe") ? (
-        <a href={`/blueprints/${blueprint.stack_id}`} className="flex items-start gap-3 border-b border-amber-200 bg-amber-50 px-6 py-4 text-amber-950 hover:bg-amber-100 sm:px-8">
+      {blueprint && (blueprint.needs_refresh || (blueprint.safety_status !== "safe" && !blueprint.safety_acknowledged)) ? (
+        <a href={`/blueprints/${blueprint.stack_id}#safety-notes`} className="flex items-start gap-3 border-b border-amber-200 bg-amber-50 px-6 py-4 text-amber-950 hover:bg-amber-100 sm:px-8">
           <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" />
           <span className="text-sm leading-6">
             <strong>{blueprintSafetyLabel(blueprint)}.</strong>{" "}
@@ -306,7 +306,7 @@ function CurrentBlueprintPanel({
         <div>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">Current Blueprint</p>
           <p className="mt-1 text-sm font-semibold text-[#041B2D]">Refreshed {formatBlueprintDate(blueprint.created_at)}</p>
-          <p className={`mt-1 text-sm ${blueprint.needs_refresh || blueprint.safety_status !== "safe" ? "font-semibold text-amber-800" : "text-slate-600"}`}>
+          <p className={`mt-1 text-sm ${blueprint.needs_refresh || (blueprint.safety_status !== "safe" && !blueprint.safety_acknowledged) ? "font-semibold text-amber-800" : "text-slate-600"}`}>
             {blueprintSafetyLabel(blueprint)}
           </p>
         </div>

--- a/src/components/dashboard/TodaysPlan.tsx
+++ b/src/components/dashboard/TodaysPlan.tsx
@@ -50,11 +50,11 @@ export default function TodaysPlan() {
           <AlertTriangle className="mr-2 mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" /> Routine details are temporarily unavailable. Open Routine to try again.
         </div>
       ) : (
-        <dl className="mt-5 grid gap-3 sm:grid-cols-3">
-          <SummaryStat icon={CalendarCheck2} value={summary.dueToday} label="Due today" detail="Based on your recorded schedule" />
-          <SummaryStat icon={ClipboardList} value={summary.scheduleReview} label="Need a schedule" detail="Schedule not recorded" warning={summary.scheduleReview > 0} />
-          <SummaryStat icon={AlertTriangle} value={summary.ideasToConsider} label="Ideas to consider" detail="Not in your current routine" warning={summary.ideasToConsider > 0} />
-        </dl>
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <SummaryStat icon={CalendarCheck2} value={summary.dueToday} label="Due today" detail="Based on your recorded schedule" href="/routine" />
+          <SummaryStat icon={ClipboardList} value={summary.scheduleReview} label="Need a schedule" detail="Open the item that needs attention" warning={summary.scheduleReview > 0} href="/routine#schedule-review" />
+          <SummaryStat icon={AlertTriangle} value={summary.ideasToConsider} label="Ideas to consider" detail="Review before adding anything" warning={summary.ideasToConsider > 0} href="/routine#routine-ideas" />
+        </div>
       )}
     </section>
   );
@@ -66,18 +66,20 @@ function SummaryStat({
   label,
   detail,
   warning = false,
+  href,
 }: {
   icon: typeof CalendarCheck2;
   value: number;
   label: string;
   detail: string;
   warning?: boolean;
+  href: string;
 }) {
   return (
-    <div className={`rounded-xl border p-4 ${warning ? "border-amber-200 bg-amber-50" : "border-slate-200 bg-slate-50"}`}>
-      <dt className="flex items-center text-sm font-bold text-[#041B2D]"><Icon className={`mr-2 h-5 w-5 ${warning ? "text-amber-700" : "text-[#087F72]"}`} aria-hidden="true" /> {label}</dt>
-      <dd className="mt-2 text-3xl font-extrabold text-[#041B2D]">{value}</dd>
-      <p className="mt-1 text-xs leading-5 text-slate-600">{detail}</p>
-    </div>
+    <Link href={href} className={`group rounded-xl border p-4 transition hover:-translate-y-0.5 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] ${warning ? "border-amber-200 bg-amber-50" : "border-slate-200 bg-slate-50"}`}>
+      <p className="flex items-center text-sm font-bold text-[#041B2D]"><Icon className={`mr-2 h-5 w-5 ${warning ? "text-amber-700" : "text-[#087F72]"}`} aria-hidden="true" /> {label}</p>
+      <p className="mt-2 text-3xl font-extrabold text-[#041B2D]">{value}</p>
+      <p className="mt-1 flex items-center text-xs leading-5 text-slate-600">{detail}<ArrowRight className="ml-1 h-3.5 w-3.5 transition group-hover:translate-x-0.5" aria-hidden="true" /></p>
+    </Link>
   );
 }

--- a/src/lib/blueprintContext.ts
+++ b/src/lib/blueprintContext.ts
@@ -12,6 +12,7 @@ export type CurrentBlueprintContext = {
   stack_id: string;
   created_at: string;
   safety_status: BlueprintSafetyStatus;
+  safety_acknowledged: boolean;
   needs_refresh: boolean;
   priorities: BlueprintPriorityContext[];
 };
@@ -30,6 +31,7 @@ export type ExperimentBlueprintContext = {
 export function blueprintSafetyLabel(context: CurrentBlueprintContext): string {
   if (context.needs_refresh) return "Review after your recent changes";
   if (context.safety_status === "safe") return "No material safety flags identified";
+  if (context.safety_acknowledged) return "Safety notes reviewed";
   if (context.safety_status === "warning") return "Safety notes need your attention";
   return "Safety section needs review";
 }

--- a/src/lib/currentBlueprintContext.ts
+++ b/src/lib/currentBlueprintContext.ts
@@ -23,6 +23,7 @@ type StackSource = {
   summary: string | null;
   created_at: string;
   input_snapshot_hash: string | null;
+  safety_acknowledged_at: string | null;
 };
 
 function stackActions(stack: Pick<StackSource, "sections" | "summary">) {
@@ -34,7 +35,7 @@ export async function getCurrentBlueprintContext(userId: string): Promise<Curren
   const admin = getSupabaseAdmin();
   const { data: latest, error } = await admin
     .from("stacks")
-    .select("id,submission_id,sections,summary,created_at,input_snapshot_hash")
+    .select("id,submission_id,sections,summary,created_at,input_snapshot_hash,safety_acknowledged_at")
     .eq("user_id", userId)
     .order("created_at", { ascending: false })
     .limit(1)
@@ -64,6 +65,7 @@ export async function getCurrentBlueprintContext(userId: string): Promise<Curren
     stack_id: stack.id,
     created_at: stack.created_at,
     safety_status: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(stack)),
+    safety_acknowledged: Boolean(stack.safety_acknowledged_at),
     needs_refresh: needsRefresh,
     priorities: stackActions(stack).map(({ id, label, category, kind }) => ({ id, label, category, kind })),
   };
@@ -79,7 +81,7 @@ export async function getExperimentBlueprintContexts(
   if (sourceIds.length) {
     const { data, error } = await getSupabaseAdmin()
       .from("stacks")
-      .select("id,submission_id,sections,summary,created_at,input_snapshot_hash")
+      .select("id,submission_id,sections,summary,created_at,input_snapshot_hash,safety_acknowledged_at")
       .eq("user_id", userId)
       .in("id", sourceIds);
     if (error) throw error;

--- a/src/lib/regimenDose.ts
+++ b/src/lib/regimenDose.ts
@@ -1,6 +1,7 @@
 import type { RoutineItemKind } from "@/lib/routine";
 
 export type RegimenDoseStatus = "taken" | "skipped";
+export type RegimenDoseDaypart = "Morning" | "Afternoon" | "Evening";
 
 export type RegimenDoseOccurrence = {
   eventId: string | null;
@@ -41,3 +42,10 @@ export type RegimenDoseDay = {
   history: RegimenDoseHistoryItem[];
   scheduleReview: number;
 };
+
+export function regimenDoseDaypart(time: string): RegimenDoseDaypart {
+  const hour = Number(time.slice(0, 2));
+  if (hour < 12) return "Morning";
+  if (hour < 17) return "Afternoon";
+  return "Evening";
+}

--- a/supabase/migrations/20260808212539_pr83_safety_acknowledgement.sql
+++ b/supabase/migrations/20260808212539_pr83_safety_acknowledgement.sql
@@ -1,0 +1,5 @@
+alter table public.stacks
+  add column if not exists safety_acknowledged_at timestamptz;
+
+comment on column public.stacks.safety_acknowledged_at is
+  'When the owning member acknowledged the safety notes for this exact Blueprint version.';


### PR DESCRIPTION
## What changed

- Adds a per-Blueprint safety-note acknowledgement so a member can confirm they reviewed a warning without hiding the underlying caution.
- Resets that acknowledgement naturally for every newly generated Blueprint version.
- Links safety badges directly to the safety section and quiets the repeated Today warning after acknowledgement.
- Makes Today routine summary cards navigable to the exact Routine actions.
- Groups scheduled doses into Morning, Afternoon, and Evening.
- Adds a bulk action to mark only unrecorded items in a daypart as taken.
- Replaces the static missing-schedule warning with named buttons that open each item’s schedule editor.
- Adds and applies the Supabase migration for `stacks.safety_acknowledged_at`.

## Why

The current product raises appropriate warnings but does not reliably let members resolve, acknowledge, or act on them. This made safety prompting feel aggressive and left several flagged counts as dead ends. The Routine checklist also required unnecessary one-by-one work.

## Safety behavior

Acknowledgement means “I reviewed these notes,” not “this is safe.” The caution remains visible in the Blueprint. Any newly generated Blueprint starts unacknowledged and can prompt the member again.

Bulk completion affects only occurrences that have no recorded status. It does not overwrite skipped or already recorded doses.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run qa:pr83`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr74`
- `npm.cmd run qa:blueprints`
- `npm.cmd run qa:pr80`
- `git diff --check`
- Supabase migration applied and column verified

The local production build compiled successfully and reached page-data collection. It then stopped because this checkout does not contain `OPENAI_API_KEY`; Vercel supplies the real environment for the preview build.