### PR TITLE
PR84 — Canonicalize health-record integrity

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -21,6 +21,7 @@ import remarkGfm from "remark-gfm";
 
 import type { BlueprintActionCandidate } from "@/lib/blueprintActions";
 import type { MemberSupplement } from "@/lib/blueprintWorkspace";
+import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
 import { reportSectionTitle } from "@/lib/reportPresentation";
 
@@ -442,14 +443,16 @@ function SupplementEditor({
   onCancel: () => void;
   onSave: () => void;
 }) {
+  const hasDoseIssues = supplements.some((item) => Boolean(doseIntegrityIssue(item.name, item.dose)));
   return (
     <div className="mt-6">
       <p className="rounded-xl bg-blue-50 px-4 py-3 text-sm leading-6 text-blue-950">
         Mark an item stopped to preserve the history. Saving changes does not modify this older report.
       </p>
       <div className="mt-4 space-y-4">
-        {supplements.map((item, index) => (
-          <fieldset key={item.id} className="rounded-xl border border-slate-200 p-4">
+        {supplements.map((item, index) => {
+          const doseIssue = doseIntegrityIssue(item.name, item.dose);
+          return <fieldset key={item.id} className="rounded-xl border border-slate-200 p-4">
             <legend className="px-1 text-sm font-bold text-[#041B2D]">Supplement {index + 1}</legend>
             <div className="grid gap-4 sm:grid-cols-2">
               <Field label="Name" required>
@@ -478,16 +481,13 @@ function SupplementEditor({
                   className={inputClass}
                 />
               </Field>
-              <Field label="Timing">
-                <input
-                  value={item.timing ?? ""}
-                  onChange={(event) => onChange(item.id, { timing: event.target.value || null })}
-                  maxLength={160}
-                  placeholder="Example: Evening with food"
-                  className={inputClass}
-                />
-              </Field>
+              <div className="text-sm font-semibold text-slate-700">
+                <p>Timing</p>
+                <p className="mt-1 min-h-11 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-normal text-slate-700">{item.timing || "Schedule not recorded"}</p>
+              </div>
             </div>
+            <p className="mt-3 text-sm leading-6 text-slate-600">Manage checklist timing and cadence in <Link href="/routine" className="font-bold text-[#087F72] hover:underline">Routine</Link> so every page uses the same schedule.</p>
+            {doseIssue ? <p className="mt-3 flex items-start rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm font-semibold leading-6 text-amber-950"><AlertTriangle className="mr-2 mt-1 h-4 w-4 shrink-0" aria-hidden="true" />{doseIssue.message} Correct it before saving.</p> : null}
             <label className="mt-4 flex min-h-11 cursor-pointer items-center gap-3 text-sm font-semibold text-slate-700">
               <input
                 type="checkbox"
@@ -497,8 +497,8 @@ function SupplementEditor({
               />
               I currently take this supplement
             </label>
-          </fieldset>
-        ))}
+          </fieldset>;
+        })}
       </div>
       <button
         type="button"
@@ -512,7 +512,7 @@ function SupplementEditor({
         <button
           type="button"
           onClick={onSave}
-          disabled={saving}
+          disabled={saving || hasDoseIssues}
           className="inline-flex min-h-11 items-center justify-center rounded-xl bg-[#087F72] px-5 py-3 text-sm font-bold text-white hover:bg-[#06695F] disabled:opacity-60"
         >
           {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
@@ -537,19 +537,21 @@ function SupplementList({ supplements }: { supplements: MemberSupplement[] }) {
   }
   return (
     <ul className="mt-5 divide-y divide-slate-100">
-      {supplements.map((item) => (
-        <li key={item.id} className="flex flex-col gap-1 py-3 sm:flex-row sm:items-start sm:justify-between">
+      {supplements.map((item) => {
+        const doseIssue = doseIntegrityIssue(item.name, item.dose);
+        return <li key={item.id} className="flex flex-col gap-1 py-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <p className={`font-semibold ${item.active ? "text-[#041B2D]" : "text-slate-500 line-through"}`}>{item.name}</p>
             <p className="text-sm text-slate-500">
               {[item.brand, item.dose, item.timing].filter(Boolean).join(" · ") || "Details not provided"}
             </p>
+            {doseIssue ? <p className="mt-1 text-sm font-semibold text-amber-800">Check amount and unit in Routine.</p> : null}
           </div>
           <span className={`w-fit rounded-full px-2 py-1 text-xs font-bold ${item.active ? "bg-emerald-50 text-emerald-800" : "bg-slate-100 text-slate-600"}`}>
             {item.active ? "Current" : "Stopped"}
           </span>
-        </li>
-      ))}
+        </li>;
+      })}
     </ul>
   );
 }
@@ -674,6 +676,7 @@ function messageForSupplementError(value: unknown): string {
   if (value === "duplicate_supplement") return "Each supplement should appear only once.";
   if (value === "invalid_supplement_name") return "Enter a valid supplement name. Medications and hormones belong in the broader health-context update.";
   if (value === "too_many_supplements") return "You can save up to 30 supplements.";
+  if (value === "invalid_supplement_dose") return "Check the highlighted supplement amount and unit before saving.";
   return "We could not save those changes. Check the fields and try again.";
 }
 

--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/blueprintWorkspace";
 import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
 import { regimenToLedger } from "@/lib/currentRegimenModel";
+import { canonicalRegimenTiming } from "@/lib/regimenSchedule";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 import BlueprintWorkspaceClient from "./BlueprintWorkspaceClient";
@@ -65,9 +66,9 @@ export default async function BlueprintPage({ params }: PageProps) {
   const supplements = supplementRegimen.map((item) => ({
     id: item.id,
     name: item.name,
-    brand: null,
+    brand: item.brand,
     dose: item.dose,
-    timing: item.timing,
+    timing: canonicalRegimenTiming(item),
     active: item.active,
   }));
   const hasOverride = supplementRegimen.some((item) => item.instruction_source !== "intake");

--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -42,6 +42,7 @@ import {
   type MedicationInstructionAuthority,
   type RegimenInstructionAuthority,
 } from "@/lib/medicationRecord";
+import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 import ScheduleEditor, {
   scheduleDraft,
   scheduleDraftIsReady,
@@ -55,6 +56,7 @@ type ToastState = { message: string; undo?: () => Promise<void> } | null;
 type RoutineView = "today" | "medications" | "hormones" | "supplements";
 type RoutineEditPatch = {
   dose?: string | null;
+  doseConfirmed?: boolean;
   schedule?: RoutineItem["schedule"];
   instructionAuthority?: RegimenInstructionAuthority;
   brand?: string | null;
@@ -134,6 +136,7 @@ export default function RoutineClient({
     setBusyId(item.id);
     const previous = {
       dose: item.dose,
+      doseConfirmed: Boolean(doseIntegrityIssue(item.name, item.dose)),
       schedule: item.schedule ?? null,
       instructionAuthority: item.instruction_authority ?? undefined,
       brand: item.brand,
@@ -468,6 +471,7 @@ function RoutineCard({
   const supplementItem = !prescribedItem;
   const hormoneActive = item.item_kind === "endocrine_active_supplement";
   const authorityLabel = routineInstructionAuthorityLabel(item.instruction_authority);
+  const doseIssue = doseIntegrityIssue(item.name, item.dose);
   return (
     <li className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
       <div className="flex items-start gap-4">
@@ -498,7 +502,7 @@ function RoutineCard({
       </div>
       <dl className="mt-4 space-y-3 text-sm">
         <div>
-          <dt className="font-bold text-[#041B2D]">{prescribedItem ? "Reported dose" : "Recorded amount"}</dt>
+          <dt className="font-bold text-[#041B2D]">{prescribedItem ? "Reported dose at each scheduled time" : "Recorded amount at each scheduled time"}</dt>
           <dd className="mt-0.5 text-slate-700">{item.dose?.trim() || "Dose not recorded"}</dd>
         </div>
         <div>
@@ -510,6 +514,12 @@ function RoutineCard({
         {item.purpose ? <div><dt className="font-bold text-[#041B2D]">Purpose you reported</dt><dd className="mt-0.5 text-slate-700">{item.purpose}</dd></div> : null}
         {authorityLabel ? <div><dt className="font-bold text-[#041B2D]">Instruction source</dt><dd className="mt-0.5 text-slate-700">{authorityLabel}</dd></div> : null}
       </dl>
+      {doseIssue ? (
+        <p className="mt-4 flex items-start rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm font-semibold leading-6 text-amber-950">
+          <AlertTriangle className="mr-2 mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+          {doseIssue.message}
+        </p>
+      ) : null}
       {prescribedItem ? (
         <p className="mt-4 rounded-xl bg-white p-3 text-xs leading-5 text-slate-600">
           LVE360 records what you report. It does not select or recommend prescription doses. Follow your prescription label and clinician instructions.
@@ -595,6 +605,7 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
   const [instructionAuthority, setInstructionAuthority] = useState<RegimenInstructionAuthority | "">(
     item.instruction_authority ?? ""
   );
+  const [doseConfirmed, setDoseConfirmed] = useState(false);
   const authorities = prescribedItem
     ? MEDICATION_INSTRUCTION_AUTHORITIES
     : REGIMEN_INSTRUCTION_AUTHORITIES.filter((authority) => authority !== "medication_label");
@@ -602,6 +613,7 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
   const scheduleReady = !hasStructuredSchedule || scheduleDraftIsReady(schedule);
   const sourceRequired = prescribedItem || hasStructuredSchedule;
   const reorderUrlReady = !reorderUrl.trim() || isValidHttpsUrl(reorderUrl);
+  const doseIssue = doseIntegrityIssue(item.name, dose);
   return (
     <DialogShell title={prescribedItem ? `Record a prescribed change for ${item.name}` : `Update ${item.name}`} onClose={onClose}>
       <p className="text-sm leading-6 text-slate-600">
@@ -609,7 +621,17 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
           ? "Use this only to record a change you received from your clinician, pharmacist, or current prescription label. LVE360 is not changing or recommending your prescription."
           : "Record what you currently do. This does not create a medical instruction or replace a product label."}
       </p>
-      <label className="mt-5 block text-sm font-bold text-[#041B2D]">{prescribedItem ? "Prescribed dose" : "Amount you take"}<input autoFocus value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={item.item_kind === "hormone" ? "For example, 80 mg" : "For example, 2 capsules"} /></label>
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">{prescribedItem ? "Prescribed dose at each scheduled time" : "Amount at each scheduled time"}<input autoFocus value={dose} onChange={(event) => { setDose(event.target.value); setDoseConfirmed(false); }} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={item.item_kind === "hormone" ? "For example, 80 mg" : "For example, 2 capsules"} /></label>
+      {item.schedule && item.schedule.times.length > 1 ? <p className="mt-2 text-sm leading-6 text-slate-600">This amount is shown for every scheduled time. If the amount is a full-day total, enter the amount you take at one scheduled time instead.</p> : null}
+      {doseIssue ? (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-950">
+          <p className="font-semibold">{doseIssue.message}</p>
+          <label className="mt-3 flex min-h-11 cursor-pointer items-start gap-3 font-semibold">
+            <input type="checkbox" checked={doseConfirmed} onChange={(event) => setDoseConfirmed(event.target.checked)} className="mt-1 h-4 w-4 rounded border-amber-400 text-[#087F72] focus:ring-[#087F72]" />
+            I checked the amount and unit against the current label or instruction.
+          </label>
+        </div>
+      ) : null}
       {!prescribedItem ? (
         <div className="mt-5 grid gap-4 sm:grid-cols-2">
           <label className="block text-sm font-bold text-[#041B2D]">Brand <span className="font-normal text-slate-500">(optional)</span><input value={brand} onChange={(event) => setBrand(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, Thorne" /></label>
@@ -630,8 +652,9 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
       ) : null}
       <div className="mt-6 grid gap-2 sm:grid-cols-2">
         <button type="button" onClick={onClose} disabled={saving} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
-        <button type="button" disabled={saving || !scheduleReady || !reorderUrlReady || (sourceRequired && !instructionAuthority)} onClick={() => onSave(item, {
+        <button type="button" disabled={saving || !scheduleReady || !reorderUrlReady || Boolean(doseIssue && !doseConfirmed) || (sourceRequired && !instructionAuthority)} onClick={() => onSave(item, {
           dose: dose.trim() || null,
+          ...(doseIssue ? { doseConfirmed } : {}),
           ...(!prescribedItem ? { brand: brand.trim() || null, reorderUrl: reorderUrl.trim() || null } : {}),
           ...(hasStructuredSchedule ? { schedule: scheduleDraftPayload(schedule) } : {}),
           ...(instructionAuthority ? { instructionAuthority } : {}),

--- a/app/(app)/routine/TodayDoses.tsx
+++ b/app/(app)/routine/TodayDoses.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
+import { AlertTriangle, Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { regimenDoseDaypart, type AsNeededRegimenItem, type RegimenDoseDay, type RegimenDoseOccurrence, type RegimenDoseStatus } from "@/lib/regimenDose";
 import { localDateString } from "@/lib/regimenSchedule";
 import type { RoutineItem } from "@/lib/routine";
+import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 
 export default function TodayDoses({
   refreshToken,
@@ -171,12 +172,14 @@ export default function TodayDoses({
                     {occurrences.map((occurrence) => {
                       const key = `${occurrence.regimenItemId}:${occurrence.slotKey}`;
                       const busy = busyKey === key || (Boolean(occurrence.eventId) && busyKey === occurrence.eventId);
+                      const doseIssue = doseIntegrityIssue(occurrence.itemName, occurrence.dose);
                       return (
                         <article key={key} className="p-4 sm:flex sm:items-center sm:justify-between sm:gap-5">
                   <div>
                     <p className="flex items-center text-sm font-bold text-[#087F72]"><Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> {occurrence.timeLabel}</p>
                     <h3 className="mt-1 text-lg font-bold text-[#041B2D]">{occurrence.itemName}</h3>
                     <p className="mt-1 text-sm text-slate-600">{occurrence.dose || "Dose not recorded"}</p>
+                    {doseIssue ? <p className="mt-1 flex items-start text-xs font-semibold text-amber-800"><AlertTriangle className="mr-1.5 mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />Confirm amount and unit in Routine.</p> : null}
                   </div>
                   {occurrence.status ? (
                     <div className="mt-3 flex flex-col gap-2 sm:mt-0 sm:items-end">
@@ -215,7 +218,8 @@ export default function TodayDoses({
               <div className="mt-3 grid gap-3 sm:grid-cols-2">
                 {day.asNeeded.map((item) => {
                   const busy = busyKey === `as-needed:${item.regimenItemId}`;
-                  return <div key={item.regimenItemId} className="rounded-xl border border-slate-200 p-4"><h4 className="font-bold text-[#041B2D]">{item.itemName}</h4><p className="mt-1 text-sm text-slate-600">{item.dose || "Dose not recorded"}</p><button type="button" disabled={busy} onClick={() => void recordAsNeeded(item)} className="mt-3 inline-flex min-h-12 w-full items-center justify-center rounded-xl border border-[#087F72] px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">{busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Record taken</button></div>;
+                  const doseIssue = doseIntegrityIssue(item.itemName, item.dose);
+                  return <div key={item.regimenItemId} className="rounded-xl border border-slate-200 p-4"><h4 className="font-bold text-[#041B2D]">{item.itemName}</h4><p className="mt-1 text-sm text-slate-600">{item.dose || "Dose not recorded"}</p>{doseIssue ? <p className="mt-1 text-xs font-semibold text-amber-800">Confirm amount and unit in Routine.</p> : null}<button type="button" disabled={busy} onClick={() => void recordAsNeeded(item)} className="mt-3 inline-flex min-h-12 w-full items-center justify-center rounded-xl border border-[#087F72] px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">{busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Record taken</button></div>;
                 })}
               </div>
             </div>

--- a/app/(app)/routine/print/page.tsx
+++ b/app/(app)/routine/print/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { requireTier } from "@/app/_auth/requireTier";
 import { groupRoutineItems, ROUTINE_SECTION_LABELS, ROUTINE_SECTION_ORDER, routineInstructionAuthorityLabel, routineScheduleLabel } from "@/lib/routine";
 import { getRoutineData } from "@/lib/routineData";
+import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 
 import PrintButton from "./PrintButton";
 
@@ -44,17 +45,19 @@ export default async function RoutinePrintPage() {
               <div className="mt-3 space-y-3">
                 {items.map((item) => {
                   const authority = routineInstructionAuthorityLabel(item.instruction_authority);
+                  const doseIssue = doseIntegrityIssue(item.name, item.dose);
                   return (
                     <div key={item.id} className="break-inside-avoid rounded-xl border border-slate-300 p-4 print:rounded-none">
                       <h3 className="text-lg font-bold text-[#041B2D]">{item.name}</h3>
                       {item.brand ? <p className="mt-1 text-sm text-slate-700">Brand: {item.brand}</p> : null}
                       <dl className="mt-2 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
-                        <div><dt className="font-bold">Recorded dose or amount</dt><dd>{item.dose?.trim() || "Not recorded"}</dd></div>
+                        <div><dt className="font-bold">Recorded amount at each scheduled time</dt><dd>{item.dose?.trim() || "Not recorded"}</dd></div>
                         <div><dt className="font-bold">Recorded schedule</dt><dd>{routineScheduleLabel(item)}</dd></div>
                         <div><dt className="font-bold">Instruction source</dt><dd>{authority || "Not recorded"}</dd></div>
                         <div><dt className="font-bold">Last updated</dt><dd>{item.updated_at ? formatDate(item.updated_at) : "Not available"}</dd></div>
                         {item.purpose ? <div className="sm:col-span-2"><dt className="font-bold">Purpose reported by member</dt><dd>{item.purpose}</dd></div> : null}
                       </dl>
+                      {doseIssue ? <p className="mt-3 border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-950">Member confirmation needed: {doseIssue.message}</p> : null}
                     </div>
                   );
                 })}

--- a/app/api/blueprints/[stackId]/supplements/route.ts
+++ b/app/api/blueprints/[stackId]/supplements/route.ts
@@ -10,6 +10,7 @@ import { replaceCurrentSupplements } from "@/lib/currentRegimen";
 import { regimenToLedger } from "@/lib/currentRegimenModel";
 import { requirePaidApi } from "@/lib/serverEntitlements";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -24,6 +25,9 @@ export async function PUT(req: Request, { params }: RouteContext) {
     const { stackId } = await params;
     const body = await req.json().catch(() => null) as { supplements?: unknown } | null;
     const supplements = normalizeMemberSupplements(body?.supplements);
+    if (supplements.some((item) => doseIntegrityIssue(item.name, item.dose))) {
+      return NextResponse.json({ ok: false, error: "invalid_supplement_dose" }, { status: 400 });
+    }
     const admin = getSupabaseAdmin();
 
     const { data: stack, error: stackError } = await admin
@@ -86,6 +90,7 @@ export async function PUT(req: Request, { params }: RouteContext) {
       "invalid_supplement",
       "invalid_supplement_name",
       "duplicate_supplement",
+      "invalid_supplement_dose",
     ].includes(message) ? 400 : 500;
     if (status === 500) console.error("[blueprints/supplements] failed", error);
     return NextResponse.json({ ok: false, error: message }, { status });

--- a/app/api/stacks/update/route.ts
+++ b/app/api/stacks/update/route.ts
@@ -4,6 +4,7 @@ import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { isMedicationInstructionAuthority, isRegimenInstructionAuthority } from "@/lib/medicationRecord";
 import { normalizeRegimenSchedule, regimenScheduleLabel } from "@/lib/regimenSchedule";
 import { normalizeHttpsUrl } from "@/lib/supplementProduct";
+import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -13,13 +14,13 @@ export async function POST(req: Request) {
     const entitlement = await requirePaidApi();
     if (!entitlement.ok) return entitlement.response;
 
-    const { id, purpose, dose, timing, schedule, active, instructionAuthority, brand, reorderUrl } = await req.json();
+    const { id, purpose, dose, timing, schedule, active, instructionAuthority, brand, reorderUrl, doseConfirmed } = await req.json();
     if (!id) return NextResponse.json({ ok: false, error: "missing_id" }, { status: 400 });
 
     const admin = getSupabaseAdmin();
     const { data: existing, error: existingError } = await admin
       .from("current_regimen_items")
-      .select("id,item_kind,instruction_authority")
+      .select("id,item_kind,name,instruction_authority")
       .eq("id", id)
       .eq("user_id", entitlement.user.id)
       .maybeSingle();
@@ -51,6 +52,12 @@ export async function POST(req: Request) {
     if (typeof instructionAuthority !== "undefined"
       && !isRegimenInstructionAuthority(instructionAuthority)) {
       return NextResponse.json({ ok: false, error: "invalid_instruction_source" }, { status: 400 });
+    }
+    if (typeof dose !== "undefined") {
+      const normalizedDose = String(dose ?? "").trim() || null;
+      if (doseIntegrityIssue(existing.name, normalizedDose) && doseConfirmed !== true) {
+        return NextResponse.json({ ok: false, error: "dose_confirmation_required" }, { status: 400 });
+      }
     }
 
     const patch: Record<string, unknown> = Object.fromEntries(

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "qa:pr80": "node src/_tests_/pr80JourneyLoop.assert.mjs",
     "qa:pr80-refresh": "node --experimental-strip-types src/_tests_/blueprintRefreshRecovery.assert.ts",
     "qa:pr83": "node --experimental-strip-types src/_tests_/pr83.assert.ts && node src/_tests_/pr83Page.assert.mjs",
+    "qa:pr84": "node --experimental-strip-types src/_tests_/pr84.assert.ts && node src/_tests_/pr84Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr84.assert.ts
+++ b/src/_tests_/pr84.assert.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+
+import { doseIntegrityIssue } from "../lib/doseIntegrity.ts";
+import { getRoutineTodaySummary, type RoutineItem } from "../lib/routine.ts";
+import { canonicalRegimenTiming } from "../lib/regimenSchedule.ts";
+
+const daily = { cadence: "daily" as const, times: ["10:30"], weekdays: [], interval_days: null, anchor_date: null };
+
+assert.equal(
+  canonicalRegimenTiming({ timing: "Daily at 6:00 AM", schedule: daily }),
+  "Daily at 10:30 AM",
+  "A structured schedule must win over stale written timing",
+);
+assert.equal(canonicalRegimenTiming({ timing: " PM ", schedule: null }), "PM");
+assert.equal(doseIntegrityIssue("Vitamin D", "5000mg")?.code, "possible_unit_mismatch");
+assert.equal(doseIntegrityIssue("Vitamin D3", "5000 IU"), null);
+assert.equal(doseIntegrityIssue("Magnesium Glycinate", "400 mg"), null);
+
+const base = {
+  stack_id: null,
+  brand: null,
+  reorder_url: null,
+  image_url: null,
+  product_source: null,
+  product_sku: null,
+  purpose: null,
+  notes: null,
+  item_kind: "supplement" as const,
+  instruction_source: "member_update" as const,
+  instruction_authority: "product_label" as const,
+  active: true,
+  is_current: true,
+  source_type: "regimen" as const,
+  link_amazon: null,
+  link_fullscript: null,
+  refill_days_left: null,
+  last_refilled_at: null,
+};
+const items: RoutineItem[] = [
+  { ...base, id: "scheduled", name: "Vitamin D", dose: "5000 IU", timing: "6 AM", timing_text: "6 AM", schedule: daily },
+  { ...base, id: "legacy", name: "Magnesium Glycinate", dose: "400 mg", timing: "PM", timing_text: "PM", schedule: null },
+];
+assert.deepEqual(getRoutineTodaySummary(items, new Date(2026, 7, 8)), {
+  dueToday: 1,
+  scheduleReview: 1,
+  ideasToConsider: 0,
+});
+
+console.log("PR84 behavior assertions passed.");

--- a/src/_tests_/pr84Page.assert.mjs
+++ b/src/_tests_/pr84Page.assert.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+const regimenModel = read("src/lib/currentRegimenModel.ts");
+const routine = read("src/lib/routine.ts");
+const blueprintPage = read("app/(app)/blueprints/[stackId]/page.tsx");
+const blueprintClient = read("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx");
+const updateRoute = read("app/api/stacks/update/route.ts");
+const supplementRoute = read("app/api/blueprints/[stackId]/supplements/route.ts");
+const routineClient = read("app/(app)/routine/RoutineClient.tsx");
+const printPage = read("app/(app)/routine/print/page.tsx");
+
+assert.match(regimenModel, /canonicalRegimenTiming\(item\)/, "Blueprint refresh inputs must use canonical timing.");
+assert.match(blueprintPage, /timing: canonicalRegimenTiming\(item\)/, "Current Blueprint supplements must use canonical timing.");
+assert.match(routine, /scheduleReview: current\.filter\(\(item\) => !item\.schedule\)/, "Today and Routine must share the structured-schedule rule.");
+assert.match(updateRoute, /dose_confirmation_required/, "Suspicious dose edits need explicit confirmation.");
+assert.match(supplementRoute, /invalid_supplement_dose/, "Blueprint supplement edits must reject suspicious units.");
+assert.match(routineClient, /I checked the amount and unit/, "Routine must expose a member confirmation step.");
+assert.match(blueprintClient, /Manage checklist timing and cadence in/, "Blueprint timing edits must hand off to the canonical Routine schedule.");
+assert.match(printPage, /Member confirmation needed/, "Clinician export must not silently present a suspicious dose.");
+
+console.log("PR84 page assertions passed.");

--- a/src/_tests_/routine.assert.ts
+++ b/src/_tests_/routine.assert.ts
@@ -33,10 +33,10 @@ function item(overrides: Partial<RoutineItem>): RoutineItem {
 }
 
 const regimen = [
-  item({ id: "med", name: "Metformin", item_kind: "medication", timing: "Morning with breakfast" }),
-  item({ id: "hormone", name: "Testosterone", item_kind: "hormone", timing: "Monday and Thursday evenings" }),
+  item({ id: "med", name: "Metformin", item_kind: "medication", timing: "Morning with breakfast", schedule: { cadence: "daily", times: ["08:00"], weekdays: [], interval_days: null, anchor_date: null } }),
+  item({ id: "hormone", name: "Testosterone", item_kind: "hormone", timing: "Monday and Thursday evenings", schedule: { cadence: "weekdays", times: ["20:00"], weekdays: [1, 4], interval_days: null, anchor_date: null } }),
   item({ id: "supplement", name: "Magnesium Threonate", item_kind: "supplement", timing: "Before bed" }),
-  item({ id: "active", name: "DHEA", item_kind: "endocrine_active_supplement", timing: null }),
+  item({ id: "active", name: "DHEA", item_kind: "endocrine_active_supplement", timing: null, schedule: { cadence: "as_needed", times: [], weekdays: [], interval_days: null, anchor_date: null } }),
   item({ id: "idea", name: "Berberine", source_type: "blueprint_proposal", is_current: true, active: false, notes: "Clinician review" }),
 ];
 
@@ -48,7 +48,9 @@ assert.deepEqual(grouped.byKind.endocrine_active_supplement.map(({ id }) => id),
 assert.equal(grouped.current.some(({ id }) => id === "idea"), false, "A proposal must never appear current even if a historical flag says otherwise");
 assert.deepEqual(grouped.proposals.map(({ id }) => id), ["idea"]);
 
-assert.equal(routineScheduleLabel(regimen[3]), "Schedule not recorded");
+assert.equal(routineScheduleLabel(regimen[2]), "Before bed", "Legacy text remains visible until a structured schedule is recorded");
+assert.equal(routineScheduleLabel(item({ timing: null })), "Schedule not recorded");
+assert.equal(routineScheduleLabel(regimen[0]), "Daily at 8:00 AM", "Structured timing must override legacy text");
 assert.equal(isRoutineItemDueToday(regimen[0], new Date(2026, 7, 3)), true);
 assert.equal(isRoutineItemDueToday(regimen[1], new Date(2026, 7, 3)), true, "Monday hormone schedule should be due Monday");
 assert.equal(isRoutineItemDueToday(regimen[1], new Date(2026, 7, 4)), false, "Monday/Thursday hormone schedule should not be due Tuesday");
@@ -56,7 +58,7 @@ assert.equal(isRoutineItemDueToday(item({ timing: "As needed" }), new Date(2026,
 assert.equal(isClinicianReviewProposal(regimen[4]), true);
 
 assert.deepEqual(getRoutineTodaySummary(regimen, new Date(2026, 7, 3)), {
-  dueToday: 3,
+  dueToday: 2,
   scheduleReview: 1,
   ideasToConsider: 1,
 });

--- a/src/lib/currentRegimenModel.ts
+++ b/src/lib/currentRegimenModel.ts
@@ -2,6 +2,7 @@ import type { NormalizedCurrentStackLedgerItem } from "@/lib/normalizedCurrentSt
 import { isEndocrineActiveSupplementName } from "@/lib/supplementEligibility";
 import type { RegimenInstructionAuthority } from "@/lib/medicationRecord";
 import type { RegimenSchedule } from "@/lib/regimenSchedule";
+import { canonicalRegimenTiming } from "@/lib/regimenSchedule";
 import type { SupplementProductSource } from "@/lib/supplementProduct";
 
 export type CurrentRegimenKind = NormalizedCurrentStackLedgerItem["kind"];
@@ -67,13 +68,16 @@ export function regimenToLedger(items: CurrentRegimenItem[]): NormalizedCurrentS
       left.item_kind.localeCompare(right.item_kind) ||
       left.normalized_name.localeCompare(right.normalized_name)
     )
-    .map((item) => ({
-    name: item.name,
-    kind: item.item_kind,
-    ...(item.purpose ? { purpose: item.purpose } : {}),
-    ...(item.dose ? { dose: item.dose } : {}),
-    ...(item.timing ? { timing: item.timing } : {}),
-    source_paths: [`current_regimen_items.${item.id}`, `instruction_source.${item.instruction_source}`],
-    raw_labels: [item.instruction_source, item.instruction_authority].filter(Boolean) as string[],
-  }));
+    .map((item) => {
+      const timing = canonicalRegimenTiming(item);
+      return {
+        name: item.name,
+        kind: item.item_kind,
+        ...(item.purpose ? { purpose: item.purpose } : {}),
+        ...(item.dose ? { dose: item.dose } : {}),
+        ...(timing ? { timing } : {}),
+        source_paths: [`current_regimen_items.${item.id}`, `instruction_source.${item.instruction_source}`],
+        raw_labels: [item.instruction_source, item.instruction_authority].filter(Boolean) as string[],
+      };
+    });
 }

--- a/src/lib/doseIntegrity.ts
+++ b/src/lib/doseIntegrity.ts
@@ -1,0 +1,19 @@
+export type DoseIntegrityIssue = {
+  code: "possible_unit_mismatch";
+  message: string;
+};
+
+const VITAMIN_D_NAME_RE = /\b(?:vitamin\s*d(?:3)?|cholecalciferol)\b/i;
+const MILLIGRAM_OR_GRAM_RE = /(?:^|\s)\d+(?:\.\d+)?\s*(?:mg|milligrams?|g|grams?)\b/i;
+
+export function doseIntegrityIssue(name: string, dose: string | null | undefined): DoseIntegrityIssue | null {
+  const recordedDose = dose?.trim();
+  if (!recordedDose) return null;
+  if (VITAMIN_D_NAME_RE.test(name) && MILLIGRAM_OR_GRAM_RE.test(recordedDose)) {
+    return {
+      code: "possible_unit_mismatch",
+      message: "Check this amount and unit against the product label. Vitamin D labels commonly use IU or mcg, so an entry in mg or g may be a recording error.",
+    };
+  }
+  return null;
+}

--- a/src/lib/regimenSchedule.ts
+++ b/src/lib/regimenSchedule.ts
@@ -88,6 +88,14 @@ export function regimenScheduleLabel(schedule: RegimenSchedule): string {
   return `Every ${schedule.interval_days} days from ${formatDate(schedule.anchor_date!)} at ${times}`;
 }
 
+export function canonicalRegimenTiming(item: {
+  schedule?: RegimenSchedule | null;
+  timing?: string | null;
+}): string | null {
+  if (item.schedule) return regimenScheduleLabel(item.schedule);
+  return item.timing?.trim() || null;
+}
+
 export function isRegimenScheduleDue(schedule: RegimenSchedule, date: string): boolean {
   if (!validDate(date) || schedule.cadence === "as_needed") return false;
   const day = dateDay(date);

--- a/src/lib/routine.ts
+++ b/src/lib/routine.ts
@@ -98,11 +98,11 @@ export function getRoutineTodaySummary(items: RoutineItem[], today = new Date())
   const { current, proposals } = groupRoutineItems(items);
   const date = localDateString(today);
   return {
-    dueToday: current.reduce((total, item) => {
-      if (item.schedule) return total + regimenDoseSlots(item.schedule, date).length;
-      return total + (isRoutineItemDueToday(item, today) ? 1 : 0);
-    }, 0),
-    scheduleReview: current.filter((item) => routineScheduleLabel(item) === "Schedule not recorded").length,
+    dueToday: current.reduce(
+      (total, item) => total + (item.schedule ? regimenDoseSlots(item.schedule, date).length : 0),
+      0,
+    ),
+    scheduleReview: current.filter((item) => !item.schedule).length,
     ideasToConsider: proposals.length,
   };
 }


### PR DESCRIPTION
## What changed

- makes structured regimen schedules the canonical timing source across Blueprint, refreshed reports, Today, Routine, and clinician print
- aligns Today and Routine due and schedule-review counts
- clarifies that dose amounts apply at each scheduled occurrence
- flags suspicious Vitamin D values recorded in mg or g and requires confirmation or correction before saving
- routes Blueprint timing changes to the canonical Routine editor
- adds focused PR84 regression coverage

## Why

Authenticated dashboard QA found contradictory legacy timing and structured schedules, inconsistent Today/Routine counts, and a likely unsafe Vitamin D unit entry. These issues weakened trust in the member health record and could present confusing instructions.

## Member impact

Members now see a consistent regimen schedule across paid surfaces and receive an explicit safeguard when a Vitamin D amount may use the wrong unit.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr83`
- `npm.cmd run qa:pr84`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:blueprints`
- `git diff --check`
- full Next.js production build with inert build-only environment placeholders
- GitHub CI passed
- Vercel deployment passed with no runtime-error clusters after deployment

## Preview QA note

The public Preview and login page load correctly. Authenticated Preview QA is blocked by the existing Preview auth configuration: `NEXT_PUBLIC_APP_URL` sends the OAuth callback to `app.lve360.com`, where the Preview PKCE verifier is unavailable. This is not introduced by PR84. Keep this PR in draft until authenticated verification is completed after merge or the Preview callback configuration is corrected.

## Deployment notes

No Supabase migration is required.