### PR TITLE
PR85: Make recommendations traceable and actionable

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -8,13 +8,16 @@ import {
   ArrowLeft,
   CheckCircle2,
   ChevronDown,
+  Clock3,
   FileDown,
+  HeartPulse,
   History,
   Loader2,
   Pencil,
   Plus,
   RefreshCw,
   RotateCcw,
+  X,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -24,6 +27,10 @@ import type { MemberSupplement } from "@/lib/blueprintWorkspace";
 import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
 import { reportSectionTitle } from "@/lib/reportPresentation";
+import type {
+  MemberRecommendationDecision,
+  RecommendationDecisionRecord,
+} from "@/lib/recommendationDecision";
 
 type StackSummary = {
   id: string;
@@ -41,10 +48,24 @@ type VersionSummary = {
   generationReason: string | null;
 };
 
+type RecommendationSummary = {
+  proposal: {
+    id: string;
+    name: string;
+    dose: string | null;
+    timing: string | null;
+    timing_text: string | null;
+    link_amazon: string | null;
+    link_fullscript: string | null;
+  };
+  decision: RecommendationDecisionRecord;
+};
+
 type Props = {
   stack: StackSummary;
   sections: Array<{ name: string; body: string }>;
   actions: BlueprintActionCandidate[];
+  recommendations: RecommendationSummary[];
   initialSupplements: MemberSupplement[];
   hasMemberOverride: boolean;
   initialStale: boolean;
@@ -57,6 +78,7 @@ export default function BlueprintWorkspaceClient({
   stack,
   sections,
   actions,
+  recommendations,
   initialSupplements,
   hasMemberOverride,
   initialStale,
@@ -77,10 +99,16 @@ export default function BlueprintWorkspaceClient({
   const [handoffId, setHandoffId] = useState<string | null>(null);
   const [safetyAcknowledged, setSafetyAcknowledged] = useState(Boolean(stack.safetyAcknowledgedAt));
   const [acknowledgingSafety, setAcknowledgingSafety] = useState(false);
+  const [recommendationItems, setRecommendationItems] = useState(recommendations);
+  const [recommendationBusyId, setRecommendationBusyId] = useState<string | null>(null);
 
   useEffect(() => {
     trackProductEvent({ event_name: "blueprint_viewed", source: "blueprints" });
   }, []);
+
+  useEffect(() => {
+    setRecommendationItems(recommendations);
+  }, [recommendations]);
 
   function beginEditing() {
     if (!versioningReady) {
@@ -205,6 +233,67 @@ export default function BlueprintWorkspaceClient({
       setError("We could not save that acknowledgement. Please try again.");
     } finally {
       setAcknowledgingSafety(false);
+    }
+  }
+
+  async function updateRecommendationStatus(itemId: string, decision: MemberRecommendationDecision) {
+    setRecommendationBusyId(itemId);
+    setError(null);
+    try {
+      const response = await fetch("/api/recommendations/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ item_id: itemId, decision }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data?.ok || !data?.decision) throw new Error(data?.error ?? "recommendation_decision_failed");
+      setRecommendationItems((current) => current.map((item) =>
+        item.proposal.id === itemId ? { ...item, decision: data.decision } : item
+      ));
+      const statusMessage = decision === "clinician_review"
+        ? "Marked for a clinician or pharmacist conversation."
+        : decision === "deferred"
+          ? "Moved out of your active ideas for now."
+          : decision === "dismissed"
+            ? "Dismissed for this health context."
+            : "Returned to active review.";
+      setMessage(statusMessage);
+      router.refresh();
+    } catch {
+      setError("We could not save that recommendation decision. Nothing changed.");
+    } finally {
+      setRecommendationBusyId(null);
+    }
+  }
+
+  async function adoptRecommendation(item: RecommendationSummary) {
+    if (item.decision.overlap_snapshot.length || item.decision.status === "clinician_review") {
+      const confirmed = window.confirm(
+        "This recommendation has an overlap or clinician-review note. Only add it after you have checked that it belongs in your routine."
+      );
+      if (!confirmed) return;
+    }
+    setRecommendationBusyId(item.proposal.id);
+    setError(null);
+    try {
+      const response = await fetch("/api/stack-items/activate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ item_id: item.proposal.id }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data?.ok) throw new Error("recommendation_adoption_failed");
+      setRecommendationItems((current) => current.map((candidate) =>
+        candidate.proposal.id === item.proposal.id
+          ? { ...candidate, decision: { ...candidate.decision, status: "adopted" } }
+          : candidate
+      ));
+      setMessage(`${item.proposal.name} was added to your current routine. Record its schedule in Routine.`);
+      router.refresh();
+    } catch {
+      setError("We could not add that recommendation. Your routine is unchanged.");
+    } finally {
+      setRecommendationBusyId(null);
     }
   }
 
@@ -353,15 +442,22 @@ export default function BlueprintWorkspaceClient({
                         {handoffId === action.id ? "Saving..." : "Start this weekly practice"}
                       </button>
                     ) : (
-                      <p className="mt-auto pt-4 text-xs font-bold uppercase tracking-wide text-amber-700">
-                        Keep for clinician review
-                      </p>
+                      <a href="#recommendation-decisions" className="mt-auto pt-4 text-sm font-bold text-amber-800 underline decoration-amber-300 underline-offset-2 hover:decoration-amber-700">
+                        Review why this appeared
+                      </a>
                     )}
                   </li>
                 ))}
               </ol>
             </section>
           ) : null}
+
+          <RecommendationDecisionPanel
+            items={recommendationItems}
+            busyId={recommendationBusyId}
+            onDecision={updateRecommendationStatus}
+            onAdopt={adoptRecommendation}
+          />
 
           {sections.map((section, index) => (
             <ReportSection
@@ -426,6 +522,104 @@ export default function BlueprintWorkspaceClient({
       </div>
     </div>
   );
+}
+
+function RecommendationDecisionPanel({
+  items,
+  busyId,
+  onDecision,
+  onAdopt,
+}: {
+  items: RecommendationSummary[];
+  busyId: string | null;
+  onDecision: (itemId: string, decision: MemberRecommendationDecision) => void;
+  onAdopt: (item: RecommendationSummary) => void;
+}) {
+  if (!items.length) return null;
+  const ordered = [...items].sort((left, right) => {
+    const statusOrder: Record<RecommendationDecisionRecord["status"], number> = {
+      review: 0,
+      clinician_review: 1,
+      deferred: 2,
+      dismissed: 3,
+      adopted: 4,
+    };
+    return statusOrder[left.decision.status] - statusOrder[right.decision.status]
+      || left.proposal.name.localeCompare(right.proposal.name);
+  });
+  const activeCount = ordered.filter((item) => item.decision.status === "review" || item.decision.status === "clinician_review").length;
+
+  return (
+    <section id="recommendation-decisions" className="scroll-mt-24 rounded-2xl border border-[#9DCFC3] bg-[#F4FAF8] p-5 shadow-sm sm:p-6" aria-labelledby="recommendation-decisions-title">
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Live decision layer</p>
+      <h2 id="recommendation-decisions-title" className="mt-1 text-2xl font-bold text-[#041B2D]">Understand each idea before you act</h2>
+      <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-700">
+        This dated Blueprint stays unchanged. Your decisions below remain live across Blueprint, Today, and Routine. {activeCount} {activeCount === 1 ? "idea needs" : "ideas need"} a decision.
+      </p>
+      <ul className="mt-5 space-y-4">
+        {ordered.map((item) => {
+          const busy = busyId === item.proposal.id;
+          const active = item.decision.status === "review" || item.decision.status === "clinician_review";
+          const link = item.proposal.link_fullscript || item.proposal.link_amazon;
+          return (
+            <li key={item.proposal.id} className={`rounded-2xl border p-4 sm:p-5 ${active ? "border-[#BCE3DA] bg-white" : "border-slate-200 bg-slate-50"}`}>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h3 className="text-lg font-bold text-[#041B2D]">{item.proposal.name}</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-700">{item.decision.reason_snapshot}</p>
+                </div>
+                <span className={`w-fit shrink-0 rounded-full px-3 py-1 text-xs font-bold ${active ? "bg-amber-100 text-amber-900" : item.decision.status === "adopted" ? "bg-emerald-100 text-emerald-900" : "bg-slate-200 text-slate-700"}`}>
+                  {recommendationStatusLabel(item.decision.status)}
+                </span>
+              </div>
+              {item.decision.overlap_snapshot.length ? (
+                <p className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm leading-6 text-amber-950">
+                  <strong>Possible overlap:</strong> Your current routine includes {item.decision.overlap_snapshot.join(", ")}. Check the ingredient labels before adding another source.
+                </p>
+              ) : null}
+              {[item.proposal.dose, item.proposal.timing_text || item.proposal.timing].some(Boolean) ? (
+                <p className="mt-3 text-sm text-slate-600">
+                  <strong>Report starting guidance:</strong> {[item.proposal.dose, item.proposal.timing_text || item.proposal.timing].filter(Boolean).join(" · ")}
+                </p>
+              ) : null}
+              {active ? (
+                <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                  <button type="button" disabled={busy} onClick={() => void onAdopt(item)} className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 text-sm font-bold text-white hover:bg-[#06695F] disabled:opacity-60">
+                    {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />}
+                    {item.decision.status === "clinician_review" ? "Add after review" : "Add to Routine"}
+                  </button>
+                  <button type="button" disabled={busy} onClick={() => onDecision(item.proposal.id, "clinician_review")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-amber-300 bg-white px-4 py-3 text-sm font-bold text-amber-900 hover:bg-amber-50 disabled:opacity-60">
+                    <HeartPulse className="mr-2 h-4 w-4" aria-hidden="true" /> Ask my clinician
+                  </button>
+                  <button type="button" disabled={busy} onClick={() => onDecision(item.proposal.id, "deferred")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
+                    <Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> Not now
+                  </button>
+                  <button type="button" disabled={busy} onClick={() => onDecision(item.proposal.id, "dismissed")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
+                    <X className="mr-2 h-4 w-4" aria-hidden="true" /> Dismiss
+                  </button>
+                </div>
+              ) : item.decision.status !== "adopted" ? (
+                <button type="button" disabled={busy} onClick={() => onDecision(item.proposal.id, "review")} className="mt-4 inline-flex min-h-11 items-center rounded-xl border border-[#9DCFC3] bg-white px-4 py-2 text-sm font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">
+                  Return to active review
+                </button>
+              ) : (
+                <Link href="/routine" className="mt-4 inline-flex min-h-11 items-center text-sm font-bold text-[#087F72] hover:underline">Open in Routine</Link>
+              )}
+              {link ? <a href={link} target="_blank" rel="noopener noreferrer nofollow sponsored" className="mt-3 inline-flex text-sm font-bold text-[#087F72] hover:underline">Product information</a> : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function recommendationStatusLabel(status: RecommendationDecisionRecord["status"]): string {
+  if (status === "clinician_review") return "Discuss with clinician";
+  if (status === "deferred") return "Not now";
+  if (status === "dismissed") return "Dismissed";
+  if (status === "adopted") return "Added to Routine";
+  return "Needs review";
 }
 
 function SupplementEditor({
@@ -585,7 +779,7 @@ function ReportSection({
   const isCurrent = name === "Current Stack" || name === "Dosing & Notes";
   const isRecommendations = name === "Your Blueprint Recommendations";
   return (
-    <details id={isSafety ? "safety-notes" : undefined} open={defaultOpen} className="group scroll-mt-24 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <details id={isSafety ? "safety-notes" : isRecommendations ? "recommendation-report" : undefined} open={defaultOpen} className="group scroll-mt-24 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
       <summary className={`flex min-h-14 cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 font-bold marker:hidden ${isSafety ? "bg-amber-50 text-amber-950" : "bg-white text-[#041B2D]"}`}>
         {reportSectionTitle(name)}
         <ChevronDown className="h-5 w-5 shrink-0 transition group-open:rotate-180" aria-hidden="true" />

--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -13,6 +13,8 @@ import {
 import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
 import { regimenToLedger } from "@/lib/currentRegimenModel";
 import { canonicalRegimenTiming } from "@/lib/regimenSchedule";
+import { extractBlueprintGoalNames } from "@/lib/recommendationDecision";
+import { getStackRecommendationDecisions } from "@/lib/recommendationDecisionData";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 import BlueprintWorkspaceClient from "./BlueprintWorkspaceClient";
@@ -60,6 +62,12 @@ export default async function BlueprintPage({ params }: PageProps) {
   const report = parseBlueprintReport(markdown);
   await ensureCurrentRegimen(user.id, submission.id, submission);
   const regimen = await getCurrentRegimen(user.id);
+  const recommendations = await getStackRecommendationDecisions(
+    user.id,
+    stack.id,
+    regimen,
+    extractBlueprintGoalNames(report.sections.Goals),
+  );
   const supplementRegimen = regimen.filter((item) =>
     item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement"
   );
@@ -93,6 +101,7 @@ export default async function BlueprintPage({ params }: PageProps) {
         .filter(([, body]) => Boolean(body.trim()))
         .map(([name, body]) => ({ name, body }))}
       actions={buildBlueprintActionCandidates(report)}
+      recommendations={recommendations}
       initialSupplements={supplements}
       hasMemberOverride={hasOverride}
       initialStale={stale}

--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -43,6 +43,7 @@ import {
   type RegimenInstructionAuthority,
 } from "@/lib/medicationRecord";
 import { doseIntegrityIssue } from "@/lib/doseIntegrity";
+import type { MemberRecommendationDecision } from "@/lib/recommendationDecision";
 import ScheduleEditor, {
   scheduleDraft,
   scheduleDraftIsReady,
@@ -194,9 +195,9 @@ export default function RoutineClient({
   }
 
   async function adoptProposal(item: RoutineItem) {
-    if (isClinicianReviewProposal(item)) {
+    if (isClinicianReviewProposal(item) || (item.recommendation_overlaps?.length ?? 0) > 0) {
       const confirmed = window.confirm(
-        "This item was flagged for clinician or pharmacist review. Only add it if you have already decided it belongs in your routine."
+        "This idea needs an overlap or clinician review. Only add it if you have already decided it belongs in your routine."
       );
       if (!confirmed) return;
     }
@@ -215,12 +216,43 @@ export default function RoutineClient({
         message: `${item.name} was added to your current routine.`,
         undo: async () => {
           await updateItem(adoptedId, { active: false });
+          await fetch("/api/recommendations/decision", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ item_id: item.id, decision: "review" }),
+          });
           await refreshRoutine();
           setToast({ message: `${item.name} was returned to ideas to consider.` });
         },
       });
     } catch {
       setToast({ message: "We could not add that idea. Your current routine is unchanged." });
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function updateProposalDecision(item: RoutineItem, decision: MemberRecommendationDecision) {
+    setBusyId(item.id);
+    try {
+      const response = await fetch("/api/recommendations/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ item_id: item.id, decision }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? "recommendation_decision_failed");
+      await refreshRoutine();
+      const message = decision === "clinician_review"
+        ? `${item.name} is marked for clinician or pharmacist review.`
+        : decision === "deferred"
+          ? `${item.name} was moved out of your active ideas for now.`
+          : decision === "dismissed"
+            ? `${item.name} was dismissed for this health context.`
+            : `${item.name} is back under review.`;
+      setToast({ message });
+    } catch {
+      setToast({ message: "We could not save that recommendation decision. Nothing changed." });
     } finally {
       setBusyId(null);
     }
@@ -326,7 +358,7 @@ export default function RoutineClient({
       {activeView === "supplements" ? (
         <div className="space-y-5">
           <RoutineSection kind="supplement" items={supplements} busyId={busyId} onEdit={setEditing} onStop={stopTracking} />
-          <IdeasSection items={grouped.proposals} busyId={busyId} onAdopt={adoptProposal} />
+          <IdeasSection items={grouped.proposals} busyId={busyId} onAdopt={adoptProposal} onDecision={updateProposalDecision} />
         </div>
       ) : null}
 
@@ -555,7 +587,17 @@ function RoutineCard({
   );
 }
 
-function IdeasSection({ items, busyId, onAdopt }: { items: RoutineItem[]; busyId: string | null; onAdopt: (item: RoutineItem) => void }) {
+function IdeasSection({
+  items,
+  busyId,
+  onAdopt,
+  onDecision,
+}: {
+  items: RoutineItem[];
+  busyId: string | null;
+  onAdopt: (item: RoutineItem) => void;
+  onDecision: (item: RoutineItem, decision: MemberRecommendationDecision) => void;
+}) {
   return (
     <section className="scroll-mt-24 rounded-2xl border border-amber-200 bg-amber-50 p-5 shadow-sm sm:p-6" aria-labelledby="routine-ideas">
       <div className="flex items-start gap-3">
@@ -573,19 +615,33 @@ function IdeasSection({ items, busyId, onAdopt }: { items: RoutineItem[]; busyId
             return (
               <li key={item.id} className="rounded-2xl border border-amber-200 bg-white p-4">
                 <h3 className="text-lg font-bold text-[#041B2D]">{item.name}</h3>
-                <p className="mt-2 text-sm text-slate-700">{item.purpose || item.notes || "Review the evidence and safety context in your Blueprint."}</p>
+                <p className="mt-2 text-sm leading-6 text-slate-700">{item.recommendation_reason || item.purpose || "Review the evidence and safety context in your Blueprint."}</p>
+                {item.recommendation_overlaps?.length ? (
+                  <p className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm leading-6 text-amber-950">
+                    <strong>Check what you already take:</strong> Your current routine includes {item.recommendation_overlaps.join(", ")}. Review the ingredient label before adding another source.
+                  </p>
+                ) : null}
                 {clinicianReview ? <p className="mt-3 flex items-start rounded-xl bg-amber-100 p-3 text-sm font-semibold text-amber-900"><AlertTriangle className="mr-2 mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> Clinician or pharmacist review is recommended before adding this.</p> : null}
-                <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                <div className="mt-4 grid gap-2 sm:grid-cols-2">
                   <button
                     type="button"
                     disabled={busyId === item.id}
                     onClick={() => void onAdopt(item)}
-                    className="inline-flex min-h-12 flex-1 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white hover:bg-[#06695F] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
+                    className="inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white hover:bg-[#06695F] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
                   >
                     {busyId === item.id ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />}
                     {clinicianReview ? "Add after review" : "Add to current routine"}
                   </button>
-                  {link ? <a href={link} target="_blank" rel="noopener noreferrer nofollow sponsored" className="inline-flex min-h-12 items-center justify-center rounded-xl border border-amber-300 px-4 py-3 font-bold text-amber-900 hover:bg-amber-100"><ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" /> Product info</a> : null}
+                  <button type="button" disabled={busyId === item.id} onClick={() => void onDecision(item, "clinician_review")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-amber-300 px-4 py-3 font-bold text-amber-900 hover:bg-amber-100 disabled:opacity-60">
+                    <HeartPulse className="mr-2 h-4 w-4" aria-hidden="true" /> Ask my clinician
+                  </button>
+                  <button type="button" disabled={busyId === item.id} onClick={() => void onDecision(item, "deferred")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
+                    <Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> Not now
+                  </button>
+                  <button type="button" disabled={busyId === item.id} onClick={() => void onDecision(item, "dismissed")} className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700 hover:bg-slate-50 disabled:opacity-60">
+                    <X className="mr-2 h-4 w-4" aria-hidden="true" /> Dismiss
+                  </button>
+                  {link ? <a href={link} target="_blank" rel="noopener noreferrer nofollow sponsored" className="inline-flex min-h-12 items-center justify-center rounded-xl border border-amber-300 px-4 py-3 font-bold text-amber-900 hover:bg-amber-100 sm:col-span-2"><ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" /> Product information</a> : null}
                 </div>
               </li>
             );

--- a/app/api/recommendations/decision/route.ts
+++ b/app/api/recommendations/decision/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { isMemberRecommendationDecision } from "@/lib/recommendationDecision";
+import { updateRecommendationDecision } from "@/lib/recommendationDecisionData";
+import { requirePaidApi } from "@/lib/serverEntitlements";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  const body = await req.json().catch(() => null) as { item_id?: unknown; decision?: unknown } | null;
+  const itemId = typeof body?.item_id === "string" ? body.item_id.trim() : "";
+  if (!itemId) return NextResponse.json({ ok: false, error: "item_id_required" }, { status: 400 });
+  if (!isMemberRecommendationDecision(body?.decision)) {
+    return NextResponse.json({ ok: false, error: "invalid_decision" }, { status: 400 });
+  }
+
+  try {
+    const decision = await updateRecommendationDecision(entitlement.user.id, itemId, body.decision);
+    if (!decision) {
+      return NextResponse.json({ ok: false, error: "recommendation_decision_unavailable" }, { status: 409 });
+    }
+    return NextResponse.json({ ok: true, decision });
+  } catch (error) {
+    console.error("[recommendations/decision] failed", error);
+    return NextResponse.json({ ok: false, error: "recommendation_decision_failed" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "qa:pr80-refresh": "node --experimental-strip-types src/_tests_/blueprintRefreshRecovery.assert.ts",
     "qa:pr83": "node --experimental-strip-types src/_tests_/pr83.assert.ts && node src/_tests_/pr83Page.assert.mjs",
     "qa:pr84": "node --experimental-strip-types src/_tests_/pr84.assert.ts && node src/_tests_/pr84Page.assert.mjs",
+    "qa:pr85": "node --experimental-strip-types src/_tests_/pr85.assert.ts && node src/_tests_/pr85Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr85.assert.ts
+++ b/src/_tests_/pr85.assert.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+
+import {
+  buildRecommendationDecisionSeed,
+  extractBlueprintGoalNames,
+  isActionableRecommendationStatus,
+  isMemberRecommendationDecision,
+  recommendationOverlapNames,
+  recommendationPersonalReason,
+} from "../lib/recommendationDecision.ts";
+
+const goals = extractBlueprintGoalNames(`
+| Goal | What Progress Looks Like |
+| --- | --- |
+| Increase Energy | Support steadier daytime energy. |
+| Cognitive Performance | Support focus and memory. |
+| Improve Sleep | Build a consistent routine. |
+`);
+assert.deepEqual(goals, ["Increase Energy", "Cognitive Performance", "Improve Sleep"]);
+
+const current = [
+  { name: "Metformin" },
+  { name: "B-Complex" },
+  { name: "Methyl Protect" },
+  { name: "Omega-3" },
+];
+const proposal = {
+  id: "item-b12",
+  stack_id: "stack-1",
+  name: "Vitamin B12",
+  rationale: "Supports normal nervous-system function and energy metabolism.",
+  notes: "Blueprint status: New - consider",
+};
+
+assert.deepEqual(recommendationOverlapNames(proposal.name, current), ["B-Complex", "Methyl Protect"]);
+const reason = recommendationPersonalReason(proposal, current, goals);
+assert.match(reason, /current record includes Metformin/);
+assert.match(reason, /Increase Energy/);
+assert.match(reason, /not a finding that you are deficient/);
+
+const seed = buildRecommendationDecisionSeed(proposal, current, goals);
+assert.deepEqual(seed.overlap_snapshot, ["B-Complex", "Methyl Protect"]);
+assert.match(seed.context_fingerprint, /^pr85:[a-f0-9]{8}$/);
+assert.equal(buildRecommendationDecisionSeed(proposal, [...current].reverse(), goals).context_fingerprint, seed.context_fingerprint);
+assert.notEqual(
+  buildRecommendationDecisionSeed(proposal, current.filter((item) => item.name !== "Metformin"), goals).context_fingerprint,
+  seed.context_fingerprint,
+  "A meaningful regimen change must create a new decision context.",
+);
+
+assert.equal(isActionableRecommendationStatus("review"), true);
+assert.equal(isActionableRecommendationStatus("clinician_review"), true);
+assert.equal(isActionableRecommendationStatus("deferred"), false);
+assert.equal(isActionableRecommendationStatus("dismissed"), false);
+assert.equal(isActionableRecommendationStatus("adopted"), false);
+assert.equal(isMemberRecommendationDecision("dismissed"), true);
+assert.equal(isMemberRecommendationDecision("adopted"), false);
+
+console.log("PR85 recommendation decision assertions passed.");

--- a/src/_tests_/pr85Page.assert.mjs
+++ b/src/_tests_/pr85Page.assert.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const migration = fs.readFileSync("supabase/migrations/20260808221918_pr85_recommendation_decisions.sql", "utf8");
+const decisionData = fs.readFileSync("src/lib/recommendationDecisionData.ts", "utf8");
+const routineData = fs.readFileSync("src/lib/routineData.ts", "utf8");
+const routineClient = fs.readFileSync("app/(app)/routine/RoutineClient.tsx", "utf8");
+const blueprintPage = fs.readFileSync("app/(app)/blueprints/[stackId]/page.tsx", "utf8");
+const blueprintClient = fs.readFileSync("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx", "utf8");
+const today = fs.readFileSync("src/components/dashboard/TodayExperience.tsx", "utf8");
+const decisionApi = fs.readFileSync("app/api/recommendations/decision/route.ts", "utf8");
+
+assert.match(migration, /unique \(user_id, recommendation_key, context_fingerprint\)/i);
+assert.match(migration, /enable row level security/i);
+assert.match(migration, /auth\.uid\(\)\) = user_id/i);
+assert.match(migration, /grant select on table public\.recommendation_decisions to authenticated/i);
+assert.match(migration, /service_role/i);
+assert.match(decisionData, /onConflict: "user_id,recommendation_key,context_fingerprint"/);
+assert.match(decisionData, /isMissingDecisionTable/, "A code deployment before migration must fail soft rather than breaking paid pages.");
+assert.match(routineData, /isActionableRecommendationStatus/, "Routine and Today counts must use persisted decision state.");
+assert.match(routineClient, /Ask my clinician/);
+assert.match(routineClient, /Not now/);
+assert.match(routineClient, /Dismiss/);
+assert.match(blueprintPage, /getStackRecommendationDecisions/);
+assert.match(blueprintClient, /id="recommendation-decisions"/);
+assert.match(blueprintClient, /Possible overlap/);
+assert.match(blueprintClient, /Add to Routine/);
+assert.match(today, /#recommendation-decisions/);
+assert.match(decisionApi, /isMemberRecommendationDecision/);
+
+console.log("PR85 page and persistence assertions passed.");

--- a/src/_tests_/routinePage.assert.mjs
+++ b/src/_tests_/routinePage.assert.mjs
@@ -11,8 +11,10 @@ assert.match(page, /requireTier\(\["premium", "trial"\]/, "Routine must require 
 assert.match(page, /getRoutineData\(user\.id\)/, "Routine must render the canonical regimen on the server.");
 
 const data = read("src/lib/routineData.ts");
+const recommendationData = read("src/lib/recommendationDecisionData.ts");
 assert.match(data, /item_kind: item\.item_kind/, "Current items must use their persisted type.");
-assert.match(data, /\.eq\("is_current", false\)/, "Only unadopted Blueprint rows may appear as proposals.");
+assert.match(recommendationData, /\.eq\("is_current", false\)/, "Only unadopted Blueprint rows may appear as proposals.");
+assert.match(data, /isActionableRecommendationStatus/, "Routine must honor a member's persisted recommendation decision.");
 assert.match(data, /source_type: "blueprint_proposal"/, "Proposals need an explicit non-current source type.");
 
 const client = read("app/(app)/routine/RoutineClient.tsx");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -325,7 +325,11 @@ function CurrentBlueprintPanel({
           {blueprint.priorities.slice(0, 3).map((priority) => (
             <li key={priority.id} className="flex items-start gap-2">
               {priority.kind === "review_only" ? <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" aria-label="Review only" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#087F72]" aria-hidden="true" />}
-              <span>{priority.label}</span>
+              {priority.kind === "review_only" ? (
+                <a href={`/blueprints/${blueprint.stack_id}#recommendation-decisions`} className="font-semibold text-amber-900 underline decoration-amber-300 underline-offset-2 hover:decoration-amber-700">
+                  {priority.label} Review why this appeared and choose what to do.
+                </a>
+              ) : <span>{priority.label}</span>}
             </li>
           ))}
         </ul>

--- a/src/lib/currentRegimen.ts
+++ b/src/lib/currentRegimen.ts
@@ -14,6 +14,7 @@ import {
 import type { MedicationInstructionAuthority } from "@/lib/medicationRecord";
 import { regimenScheduleLabel, type RegimenSchedule } from "@/lib/regimenSchedule";
 import { normalizeHttpsUrl, type SupplementProductSource } from "@/lib/supplementProduct";
+import { updateRecommendationDecision } from "@/lib/recommendationDecisionData";
 
 const REGIMEN_COLUMNS = "id,user_id,source_submission_id,source_stack_item_id,item_kind,name,normalized_name,purpose,dose,timing,schedule,brand,reorder_url,image_url,product_source,product_sku,instruction_source,instruction_authority,active,created_at,updated_at";
 
@@ -150,6 +151,7 @@ export async function adoptStackRecommendation(userId: string, stackItemId: stri
   const { data, error: upsertError } = await admin.from("current_regimen_items")
     .upsert(row, { onConflict: "user_id,item_kind,normalized_name" }).select(REGIMEN_COLUMNS).maybeSingle();
   if (upsertError) throw upsertError;
+  await updateRecommendationDecision(userId, item.id, "adopted");
   return data as unknown as CurrentRegimenItem;
 }
 

--- a/src/lib/recommendationDecision.ts
+++ b/src/lib/recommendationDecision.ts
@@ -1,0 +1,188 @@
+export const RECOMMENDATION_DECISION_STATUSES = [
+  "review",
+  "clinician_review",
+  "deferred",
+  "dismissed",
+  "adopted",
+] as const;
+
+export type RecommendationDecisionStatus = (typeof RECOMMENDATION_DECISION_STATUSES)[number];
+export type MemberRecommendationDecision = Exclude<RecommendationDecisionStatus, "adopted">;
+
+export type RecommendationDecisionRecord = {
+  id: string;
+  stack_id: string;
+  stack_item_id: string;
+  recommendation_key: string;
+  context_fingerprint: string;
+  status: RecommendationDecisionStatus;
+  reason_snapshot: string;
+  overlap_snapshot: string[];
+  deferred_until: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type RecommendationProposalInput = {
+  id: string;
+  stack_id: string;
+  name: string;
+  rationale: string | null;
+  notes: string | null;
+};
+
+export type RecommendationContextItem = {
+  name: string;
+};
+
+export type RecommendationDecisionSeed = {
+  stack_id: string;
+  stack_item_id: string;
+  recommendation_key: string;
+  context_fingerprint: string;
+  reason_snapshot: string;
+  overlap_snapshot: string[];
+};
+
+const OVERLAP_FAMILIES: Array<{ recommendation: RegExp; current: RegExp }> = [
+  {
+    recommendation: /^(?:vitamin )?b12|methylcobalamin|cyanocobalamin/,
+    current: /(?:vitamin )?b12|methylcobalamin|cyanocobalamin|b[- ]?complex|methyl protect|multivitamin/,
+  },
+  { recommendation: /^vitamin d|cholecalciferol/, current: /vitamin d|cholecalciferol|multivitamin/ },
+  { recommendation: /^magnesium/, current: /magnesium/ },
+  { recommendation: /omega[- ]?3|fish oil/, current: /omega[- ]?3|fish oil/ },
+  { recommendation: /coq10|coenzyme q10/, current: /coq10|coenzyme q10/ },
+];
+
+const GOAL_MATCHERS: Array<{ signal: RegExp; goal: RegExp }> = [
+  { signal: /energy|fatigue|b12|mitochond|carnitine/, goal: /energy|cognitive/ },
+  { signal: /sleep|bedtime|glycine|magnesium|theanine|melatonin/, goal: /sleep/ },
+  { signal: /muscle|strength|recovery|creatine|protein|collagen/, goal: /muscle|strength/ },
+  { signal: /inflamm|joint|curcumin|omega/, goal: /inflamm|joint/ },
+  { signal: /weight|metabolic|glucose|fiber/, goal: /weight|metabolic/ },
+  { signal: /skin|hair|nail|collagen/, goal: /skin|hair|nail/ },
+  { signal: /longevity|healthy aging|resilience/, goal: /longevity/ },
+];
+
+export function normalizeRecommendationName(value: string): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+export function isRecommendationDecisionStatus(value: unknown): value is RecommendationDecisionStatus {
+  return typeof value === "string" && RECOMMENDATION_DECISION_STATUSES.includes(value as RecommendationDecisionStatus);
+}
+
+export function isMemberRecommendationDecision(value: unknown): value is MemberRecommendationDecision {
+  return isRecommendationDecisionStatus(value) && value !== "adopted";
+}
+
+export function isActionableRecommendationStatus(status: RecommendationDecisionStatus | null | undefined): boolean {
+  return status === "review" || status === "clinician_review";
+}
+
+export function recommendationNeedsClinicianReview(notes: string | null | undefined): boolean {
+  return /clinician review|pharmacist|interaction|contraindicat|use caution|avoid/i.test(notes ?? "");
+}
+
+export function extractBlueprintGoalNames(goalsMarkdown: string): string[] {
+  const rows = String(goalsMarkdown ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("|") && !/^\|\s*-+/.test(line));
+  if (rows.length < 2) return [];
+  const seen = new Set<string>();
+  const goals: string[] = [];
+  for (const row of rows.slice(1)) {
+    const goal = row.split("|").map((cell) => cell.trim())[1]?.replace(/[*_`]/g, "").trim();
+    const key = normalizeRecommendationName(goal ?? "");
+    if (!goal || !key || seen.has(key)) continue;
+    seen.add(key);
+    goals.push(goal);
+  }
+  return goals;
+}
+
+export function recommendationOverlapNames(
+  recommendationName: string,
+  currentItems: RecommendationContextItem[],
+): string[] {
+  const recommendation = normalizeRecommendationName(recommendationName);
+  const family = OVERLAP_FAMILIES.find((candidate) => candidate.recommendation.test(recommendation));
+  const overlaps = currentItems.filter((item) => {
+    const current = normalizeRecommendationName(item.name);
+    if (!current) return false;
+    if (current === recommendation || current.includes(recommendation) || recommendation.includes(current)) return true;
+    return family?.current.test(current) ?? false;
+  });
+  return [...new Set(overlaps.map((item) => item.name.trim()).filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function alignedGoals(name: string, rationale: string | null, goals: string[]): string[] {
+  const signal = normalizeRecommendationName(`${name} ${rationale ?? ""}`);
+  const matching = goals.filter((goal) =>
+    GOAL_MATCHERS.some((matcher) => matcher.signal.test(signal) && matcher.goal.test(normalizeRecommendationName(goal)))
+  );
+  return matching.length ? matching.slice(0, 3) : goals.slice(0, 2);
+}
+
+export function recommendationPersonalReason(
+  proposal: Pick<RecommendationProposalInput, "name" | "rationale">,
+  currentItems: RecommendationContextItem[],
+  goals: string[],
+): string {
+  const normalizedName = normalizeRecommendationName(proposal.name);
+  const currentNames = currentItems.map((item) => normalizeRecommendationName(item.name));
+  const goalsForRecommendation = alignedGoals(proposal.name, proposal.rationale, goals);
+  const goalText = goalsForRecommendation.length
+    ? ` It also aligns with your recorded ${goalsForRecommendation.join(" and ")} priorities.`
+    : "";
+
+  if (/^(?:vitamin )?b12|methylcobalamin|cyanocobalamin/.test(normalizedName) && currentNames.includes("metformin")) {
+    return `This appeared because your current record includes Metformin, which the Blueprint treats as a reason to review B12 status.${goalText} This is not a finding that you are deficient.`;
+  }
+
+  const rationale = proposal.rationale?.trim();
+  if (rationale) {
+    return `This appeared because your Blueprint connected it to your reported goals and health context.${goalText} Report rationale: ${rationale}`;
+  }
+  return `This appeared because your Blueprint connected it to your reported goals and current health context.${goalText}`;
+}
+
+function hash(value: string): string {
+  let result = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    result ^= value.charCodeAt(index);
+    result = Math.imul(result, 16777619);
+  }
+  return (result >>> 0).toString(16).padStart(8, "0");
+}
+
+export function buildRecommendationDecisionSeed(
+  proposal: RecommendationProposalInput,
+  currentItems: RecommendationContextItem[],
+  goals: string[],
+): RecommendationDecisionSeed {
+  const recommendationKey = normalizeRecommendationName(proposal.name);
+  const overlapNames = recommendationOverlapNames(proposal.name, currentItems);
+  const reason = recommendationPersonalReason(proposal, currentItems, goals);
+  const context = JSON.stringify({
+    recommendationKey,
+    reason,
+    overlapNames: overlapNames.map(normalizeRecommendationName),
+    currentItems: currentItems.map((item) => normalizeRecommendationName(item.name)).filter(Boolean).sort(),
+    goals: goals.map(normalizeRecommendationName).filter(Boolean).sort(),
+    notes: proposal.notes?.trim() ?? "",
+  });
+  return {
+    stack_id: proposal.stack_id,
+    stack_item_id: proposal.id,
+    recommendation_key: recommendationKey,
+    context_fingerprint: `pr85:${hash(context)}`,
+    reason_snapshot: reason,
+    overlap_snapshot: overlapNames,
+  };
+}

--- a/src/lib/recommendationDecisionData.ts
+++ b/src/lib/recommendationDecisionData.ts
@@ -1,0 +1,182 @@
+import "server-only";
+
+import type { CurrentRegimenItem } from "@/lib/currentRegimenModel";
+import {
+  buildRecommendationDecisionSeed,
+  type MemberRecommendationDecision,
+  type RecommendationDecisionRecord,
+  type RecommendationDecisionSeed,
+  type RecommendationProposalInput,
+} from "@/lib/recommendationDecision";
+import { normalizeRegimenName } from "@/lib/currentRegimenModel";
+import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+export type StackRecommendationProposal = RecommendationProposalInput & {
+  brand: string | null;
+  dose: string | null;
+  timing: string | null;
+  timing_text: string | null;
+  link_amazon: string | null;
+  link_fullscript: string | null;
+  refill_days_left: number | null;
+  last_refilled_at: string | null;
+  created_at: string | null;
+};
+
+export type StackRecommendationDecision = {
+  proposal: StackRecommendationProposal;
+  decision: RecommendationDecisionRecord;
+};
+
+const DECISION_COLUMNS = "id,stack_id,stack_item_id,recommendation_key,context_fingerprint,status,reason_snapshot,overlap_snapshot,deferred_until,created_at,updated_at";
+
+function isMissingDecisionTable(error: { code?: string; message?: string } | null | undefined): boolean {
+  return error?.code === "42P01"
+    || error?.code === "PGRST205"
+    || /recommendation_decisions.*(?:does not exist|schema cache)/i.test(error?.message ?? "");
+}
+
+function fallbackDecision(seed: RecommendationDecisionSeed): RecommendationDecisionRecord {
+  const now = new Date().toISOString();
+  return {
+    id: `pending:${seed.stack_item_id}`,
+    ...seed,
+    status: "review",
+    deferred_until: null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function normalizeDecision(row: Record<string, unknown>): RecommendationDecisionRecord {
+  return {
+    id: String(row.id),
+    stack_id: String(row.stack_id),
+    stack_item_id: String(row.stack_item_id),
+    recommendation_key: String(row.recommendation_key),
+    context_fingerprint: String(row.context_fingerprint),
+    status: row.status as RecommendationDecisionRecord["status"],
+    reason_snapshot: String(row.reason_snapshot ?? ""),
+    overlap_snapshot: Array.isArray(row.overlap_snapshot)
+      ? row.overlap_snapshot.filter((value): value is string => typeof value === "string")
+      : [],
+    deferred_until: typeof row.deferred_until === "string" ? row.deferred_until : null,
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+export async function getStackRecommendationDecisions(
+  userId: string,
+  stackId: string,
+  currentItems: CurrentRegimenItem[],
+  goals: string[],
+): Promise<StackRecommendationDecision[]> {
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from("stacks_items")
+    .select("id,stack_id,name,brand,dose,timing,timing_text,notes,rationale,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,created_at")
+    .eq("stack_id", stackId)
+    .eq("user_id", userId)
+    .eq("is_current", false);
+  if (error) throw error;
+
+  const currentNames = new Set(currentItems.map((item) => normalizeRegimenName(item.name)));
+  const proposals = (data ?? [])
+    .filter((item) => {
+      const name = typeof item.name === "string" ? item.name.trim() : "";
+      return Boolean(
+        name
+        && isEligibleSupplementName(name)
+        && !isMedicationOrHormoneName(name)
+        && !currentNames.has(normalizeRegimenName(name))
+      );
+    })
+    .map((item) => ({
+      id: item.id,
+      stack_id: item.stack_id,
+      name: item.name,
+      brand: item.brand,
+      dose: item.dose,
+      timing: item.timing,
+      timing_text: item.timing_text,
+      notes: item.notes,
+      rationale: item.rationale,
+      link_amazon: item.link_amazon,
+      link_fullscript: item.link_fullscript,
+      refill_days_left: item.refill_days_left,
+      last_refilled_at: item.last_refilled_at,
+      created_at: item.created_at,
+    })) as StackRecommendationProposal[];
+
+  if (!proposals.length) return [];
+
+  const seeds = proposals.map((proposal) => buildRecommendationDecisionSeed(proposal, currentItems, goals));
+  const { error: upsertError } = await admin.from("recommendation_decisions").upsert(
+    seeds.map((seed) => ({ user_id: userId, ...seed })),
+    { onConflict: "user_id,recommendation_key,context_fingerprint" },
+  );
+  if (upsertError && !isMissingDecisionTable(upsertError)) throw upsertError;
+  if (upsertError) {
+    console.warn("[recommendations] decision migration is not applied yet; using review-only fallback records");
+    return proposals.map((proposal, index) => ({ proposal, decision: fallbackDecision(seeds[index]) }));
+  }
+
+  const { data: decisions, error: decisionError } = await admin
+    .from("recommendation_decisions")
+    .select(DECISION_COLUMNS)
+    .eq("user_id", userId)
+    .in("context_fingerprint", seeds.map((seed) => seed.context_fingerprint));
+  if (decisionError) throw decisionError;
+  const decisionMap = new Map<string, RecommendationDecisionRecord>(
+    (decisions ?? []).map((row) => {
+      const decision = normalizeDecision(row as Record<string, unknown>);
+      return [`${decision.recommendation_key}:${decision.context_fingerprint}`, decision] as const;
+    }),
+  );
+
+  return proposals.map((proposal, index) => {
+    const seed = seeds[index];
+    const key = `${seed.recommendation_key}:${seed.context_fingerprint}`;
+    return { proposal, decision: decisionMap.get(key) ?? fallbackDecision(seed) };
+  });
+}
+
+export async function updateRecommendationDecision(
+  userId: string,
+  stackItemId: string,
+  status: MemberRecommendationDecision | "adopted",
+): Promise<RecommendationDecisionRecord | null> {
+  const admin = getSupabaseAdmin();
+  const { data: current, error: currentError } = await admin
+    .from("recommendation_decisions")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("stack_item_id", stackItemId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (currentError) {
+    if (isMissingDecisionTable(currentError)) return null;
+    throw currentError;
+  }
+  if (!current?.id) return null;
+
+  const { data, error } = await admin
+    .from("recommendation_decisions")
+    .update({
+      status,
+      deferred_until: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", current.id)
+    .eq("user_id", userId)
+    .select(DECISION_COLUMNS)
+    .maybeSingle();
+  if (error) {
+    if (isMissingDecisionTable(error)) return null;
+    throw error;
+  }
+  return data ? normalizeDecision(data as Record<string, unknown>) : null;
+}

--- a/src/lib/routine.ts
+++ b/src/lib/routine.ts
@@ -1,4 +1,5 @@
 import type { RegimenInstructionAuthority } from "./medicationRecord.ts";
+import type { RecommendationDecisionStatus } from "./recommendationDecision.ts";
 import {
   isRegimenScheduleDue,
   localDateString,
@@ -24,6 +25,9 @@ export type RoutineItem = {
   timing: string | null;
   timing_text?: string | null;
   notes: string | null;
+  recommendation_status?: RecommendationDecisionStatus | null;
+  recommendation_reason?: string | null;
+  recommendation_overlaps?: string[];
   item_kind: RoutineItemKind;
   instruction_source?: "intake" | "member_update" | "adopted_recommendation" | "manual_add" | null;
   instruction_authority?: RegimenInstructionAuthority | null;
@@ -122,6 +126,7 @@ export function routineInstructionAuthorityLabel(authority: RoutineItem["instruc
   return null;
 }
 
-export function isClinicianReviewProposal(item: Pick<RoutineItem, "notes">): boolean {
-  return /clinician review|pharmacist|interaction|contraindicat|use caution|avoid/i.test(item.notes ?? "");
+export function isClinicianReviewProposal(item: Pick<RoutineItem, "notes" | "recommendation_status">): boolean {
+  return item.recommendation_status === "clinician_review"
+    || /clinician review|pharmacist|interaction|contraindicat|use caution|avoid/i.test(item.notes ?? "");
 }

--- a/src/lib/routineData.ts
+++ b/src/lib/routineData.ts
@@ -1,7 +1,11 @@
 import "server-only";
 
+import { parseBlueprintReport } from "@/lib/blueprintReport";
+import { blueprintMarkdownFromStack } from "@/lib/blueprintSafetyStatus";
 import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
-import { normalizeRegimenName, regimenKindForSupplement } from "@/lib/currentRegimenModel";
+import { regimenKindForSupplement } from "@/lib/currentRegimenModel";
+import { extractBlueprintGoalNames, isActionableRecommendationStatus } from "@/lib/recommendationDecision";
+import { getStackRecommendationDecisions } from "@/lib/recommendationDecisionData";
 import type { RoutineItem } from "@/lib/routine";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
@@ -12,7 +16,7 @@ export async function getRoutineData(userId: string): Promise<{
   const admin = getSupabaseAdmin();
   const { data: latestStack, error: stackError } = await admin
     .from("stacks")
-    .select("id,submission_id,created_at")
+    .select("id,submission_id,created_at,sections,summary")
     .eq("user_id", userId)
     .order("created_at", { ascending: false })
     .limit(1)
@@ -21,7 +25,6 @@ export async function getRoutineData(userId: string): Promise<{
 
   if (latestStack?.submission_id) await ensureCurrentRegimen(userId, latestStack.submission_id);
   const regimen = await getCurrentRegimen(userId);
-  const currentNames = new Set(regimen.map((item) => normalizeRegimenName(item.name)));
   const current: RoutineItem[] = regimen.map((item) => ({
     id: item.id,
     stack_id: latestStack?.id ?? null,
@@ -53,14 +56,12 @@ export async function getRoutineData(userId: string): Promise<{
 
   let proposals: RoutineItem[] = [];
   if (latestStack?.id) {
-    const { data, error } = await admin.from("stacks_items")
-      .select("id,stack_id,name,brand,dose,timing,timing_text,notes,rationale,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,created_at")
-      .eq("stack_id", latestStack.id)
-      .eq("is_current", false);
-    if (error) throw error;
-    proposals = (data ?? [])
-      .filter((item) => !currentNames.has(normalizeRegimenName(item.name ?? "")))
-      .map((item) => ({
+    const report = parseBlueprintReport(blueprintMarkdownFromStack(latestStack));
+    const goals = extractBlueprintGoalNames(report.sections.Goals);
+    const decisions = await getStackRecommendationDecisions(userId, latestStack.id, regimen, goals);
+    proposals = decisions
+      .filter(({ decision }) => isActionableRecommendationStatus(decision.status))
+      .map(({ proposal: item, decision }) => ({
         id: item.id,
         stack_id: item.stack_id,
         name: item.name,
@@ -74,6 +75,9 @@ export async function getRoutineData(userId: string): Promise<{
         timing: item.timing_text ?? item.timing,
         timing_text: item.timing_text,
         notes: item.notes,
+        recommendation_status: decision.status,
+        recommendation_reason: decision.reason_snapshot,
+        recommendation_overlaps: decision.overlap_snapshot,
         item_kind: regimenKindForSupplement(item.name),
         instruction_source: null,
         instruction_authority: null,
@@ -90,5 +94,12 @@ export async function getRoutineData(userId: string): Promise<{
       }));
   }
 
-  return { latestStack: latestStack ?? null, items: [...current, ...proposals] };
+  return {
+    latestStack: latestStack ? {
+      id: latestStack.id,
+      submission_id: latestStack.submission_id,
+      created_at: latestStack.created_at,
+    } : null,
+    items: [...current, ...proposals],
+  };
 }

--- a/supabase/migrations/20260808221918_pr85_recommendation_decisions.sql
+++ b/supabase/migrations/20260808221918_pr85_recommendation_decisions.sql
@@ -1,0 +1,37 @@
+create table if not exists public.recommendation_decisions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  stack_id uuid not null references public.stacks(id) on delete cascade,
+  stack_item_id uuid not null references public.stacks_items(id) on delete cascade,
+  recommendation_key text not null,
+  context_fingerprint text not null,
+  status text not null default 'review'
+    check (status in ('review', 'clinician_review', 'deferred', 'dismissed', 'adopted')),
+  reason_snapshot text not null,
+  overlap_snapshot jsonb not null default '[]'::jsonb
+    check (jsonb_typeof(overlap_snapshot) = 'array'),
+  deferred_until date,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, recommendation_key, context_fingerprint)
+);
+
+create index if not exists recommendation_decisions_user_status_idx
+  on public.recommendation_decisions (user_id, status, updated_at desc);
+
+create index if not exists recommendation_decisions_stack_item_idx
+  on public.recommendation_decisions (stack_item_id);
+
+alter table public.recommendation_decisions enable row level security;
+
+create policy "recommendation_decisions: select own"
+  on public.recommendation_decisions for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.recommendation_decisions from anon;
+revoke insert, update, delete on table public.recommendation_decisions from authenticated;
+grant select on table public.recommendation_decisions to authenticated;
+grant select, insert, update, delete on table public.recommendation_decisions to service_role;
+
+comment on table public.recommendation_decisions is
+  'Owner-scoped live decisions layered over dated Blueprint recommendations. Dismissal and deferral never rewrite historical Blueprint content.';

--- a/supabase/migrations/20260808233730_pr85_tighten_recommendation_decision_privileges.sql
+++ b/supabase/migrations/20260808233730_pr85_tighten_recommendation_decision_privileges.sql
@@ -1,0 +1,6 @@
+-- Existing projects may grant new public tables to API roles by default.
+-- PR85 writes only through the server-side service role, so keep client access read-only.
+revoke all on table public.recommendation_decisions from anon;
+revoke insert, update, delete on table public.recommendation_decisions from authenticated;
+grant select on table public.recommendation_decisions to authenticated;
+grant select, insert, update, delete on table public.recommendation_decisions to service_role;


### PR DESCRIPTION
## What changed

- adds an owner-scoped live recommendation decision layer without rewriting dated Blueprint reports
- explains why each recommendation appeared and discloses known overlap with the current regimen
- lets paid members add an idea to Routine, defer it, dismiss it, or mark it for clinician or pharmacist review
- keeps actionable idea state consistent across Blueprint, Today, and Routine
- marks adopted recommendations and restores review state when adoption is undone
- adds focused coverage for the B12 regression scenario
- adds and applies the recommendation decision migrations with RLS and least-privilege grants

## Why

PR84 made the canonical regimen reliable, but Blueprint recommendations were still static prose. That made flags difficult to understand, caused unexplained suggestions such as B12, and gave members no durable way to decide what to do with an idea.

PR85 turns each recommendation into an explainable, persistent member decision while preserving the historical Blueprint as a dated record.

## Member impact

Members can now understand the reason and overlap context before acting. Dismissed or deferred ideas leave the active counts across Today and Routine and do not immediately reappear unless the underlying health context meaningfully changes.

For the B12 regression scenario, the product explains the recorded Metformin context and energy or cognitive goal alignment, flags overlapping products such as B-Complex or Methyl Protect, and explicitly avoids claiming a deficiency.

## Database and security

The production Supabase migrations were applied before publication. Verification confirmed:

- RLS enabled
- anonymous table access revoked
- authenticated access limited to owner-scoped reads
- direct authenticated writes revoked
- service-role CRUD retained for server-controlled actions
- no Supabase security-advisor finding for the new table

## Validation

- `npm.cmd run qa:pr85`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr84`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `git diff --check`

The PR remains draft until the authenticated Vercel Preview is exercised end to end.