### PR TITLE
PR85.1: Materialize report-only Blueprint recommendations

### DIFF
--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -67,6 +67,7 @@ export default async function BlueprintPage({ params }: PageProps) {
     stack.id,
     regimen,
     extractBlueprintGoalNames(report.sections.Goals),
+    report.canonicalMarkdown,
   );
   const supplementRegimen = regimen.filter((item) =>
     item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "qa:pr83": "node --experimental-strip-types src/_tests_/pr83.assert.ts && node src/_tests_/pr83Page.assert.mjs",
     "qa:pr84": "node --experimental-strip-types src/_tests_/pr84.assert.ts && node src/_tests_/pr84Page.assert.mjs",
     "qa:pr85": "node --experimental-strip-types src/_tests_/pr85.assert.ts && node src/_tests_/pr85Page.assert.mjs",
+    "qa:pr85-1": "node src/_tests_/pr85_1ReportMaterialization.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr85Page.assert.mjs
+++ b/src/_tests_/pr85Page.assert.mjs
@@ -25,7 +25,7 @@ assert.match(blueprintPage, /getStackRecommendationDecisions/);
 assert.match(blueprintClient, /id="recommendation-decisions"/);
 assert.match(blueprintClient, /Possible overlap/);
 assert.match(blueprintClient, /Add to Routine/);
-assert.match(today, /#recommendation-decisions/);
+assert.match(today, /"recommendation-decisions" : "recommendation-report"/, "Today must link to the live actions when present and the dated report otherwise.");
 assert.match(decisionApi, /isMemberRecommendationDecision/);
 
 console.log("PR85 page and persistence assertions passed.");

--- a/src/_tests_/pr85_1ReportMaterialization.assert.mjs
+++ b/src/_tests_/pr85_1ReportMaterialization.assert.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const helper = fs.readFileSync("src/lib/reportRecommendationProposals.ts", "utf8");
+const decisionData = fs.readFileSync("src/lib/recommendationDecisionData.ts", "utf8");
+const blueprintPage = fs.readFileSync("app/(app)/blueprints/[stackId]/page.tsx", "utf8");
+const routineData = fs.readFileSync("src/lib/routineData.ts", "utf8");
+const currentContext = fs.readFileSync("src/lib/currentBlueprintContext.ts", "utf8");
+const today = fs.readFileSync("src/components/dashboard/TodayExperience.tsx", "utf8");
+const generator = fs.readFileSync("src/lib/generateStack.ts", "utf8");
+const migration = fs.readFileSync("supabase/migrations/20260809150602_pr85_1_unique_report_recommendation_proposals.sql", "utf8");
+
+assert.match(helper, /parseMarkdownToItems\(reportMarkdown\)/, "The dated report must be the source for missing proposals.");
+assert.match(helper, /ACTIONABLE_REPORT_STATUS/, "Only an explicit actionable report status may be materialized.");
+assert.match(helper, /item\.is_current === false/, "Current regimen entries must never become proposals.");
+assert.match(helper, /!currentNames\.has/, "A report idea already in the regimen must not be duplicated.");
+assert.match(decisionData, /extractReportRecommendationProposals/, "Decision loading must repair missing report-only proposals.");
+assert.match(decisionData, /insertError\.code !== "23505"/, "Concurrent materialization must resolve safely.");
+assert.match(decisionData, /refreshed/, "The materialized database row must be reloaded before decisions are created.");
+assert.match(blueprintPage, /report\.canonicalMarkdown/, "Blueprint loading must provide the canonical report text.");
+assert.match(routineData, /report\.canonicalMarkdown/, "Routine loading must see the same report-only ideas.");
+assert.match(currentContext, /actionable_recommendation_count/, "Today must know whether its action link has a live target.");
+assert.match(today, /"recommendation-decisions" : "recommendation-report"/, "Today must never link to an absent decision panel.");
+assert.match(generator, /extractReportRecommendationProposals/, "Future Blueprint generation must persist report-only proposals.");
+assert.match(migration, /unique index[\s\S]*stack_id, lower\(btrim\(name\)\)[\s\S]*where is_current = false/i);
+assert.match(migration, /Rollback:/, "The schema change must document rollback.");
+
+console.log("PR85.1 report materialization assertions passed.");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -326,8 +326,10 @@ function CurrentBlueprintPanel({
             <li key={priority.id} className="flex items-start gap-2">
               {priority.kind === "review_only" ? <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" aria-label="Review only" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#087F72]" aria-hidden="true" />}
               {priority.kind === "review_only" ? (
-                <a href={`/blueprints/${blueprint.stack_id}#recommendation-decisions`} className="font-semibold text-amber-900 underline decoration-amber-300 underline-offset-2 hover:decoration-amber-700">
-                  {priority.label} Review why this appeared and choose what to do.
+                <a href={`/blueprints/${blueprint.stack_id}#${(blueprint.actionable_recommendation_count ?? 0) > 0 ? "recommendation-decisions" : "recommendation-report"}`} className="font-semibold text-amber-900 underline decoration-amber-300 underline-offset-2 hover:decoration-amber-700">
+                  {priority.label} {(blueprint.actionable_recommendation_count ?? 0) > 0
+                    ? "Review why this appeared and choose what to do."
+                    : "Review this recommendation in your report."}
                 </a>
               ) : <span>{priority.label}</span>}
             </li>

--- a/src/lib/blueprintContext.ts
+++ b/src/lib/blueprintContext.ts
@@ -14,6 +14,7 @@ export type CurrentBlueprintContext = {
   safety_status: BlueprintSafetyStatus;
   safety_acknowledged: boolean;
   needs_refresh: boolean;
+  actionable_recommendation_count?: number;
   priorities: BlueprintPriorityContext[];
 };
 

--- a/src/lib/currentBlueprintContext.ts
+++ b/src/lib/currentBlueprintContext.ts
@@ -14,6 +14,8 @@ import {
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
 import { ensureCurrentRegimen, getCurrentRegimen } from "@/lib/currentRegimen";
 import { regimenToLedger } from "@/lib/currentRegimenModel";
+import { extractBlueprintGoalNames, isActionableRecommendationStatus } from "@/lib/recommendationDecision";
+import { getStackRecommendationDecisions } from "@/lib/recommendationDecisionData";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 type StackSource = {
@@ -44,7 +46,10 @@ export async function getCurrentBlueprintContext(userId: string): Promise<Curren
   if (!latest) return null;
 
   const stack = latest as StackSource;
+  const markdown = blueprintMarkdownFromStack(stack);
+  const report = parseBlueprintReport(markdown);
   let needsRefresh = false;
+  let regimen: Awaited<ReturnType<typeof getCurrentRegimen>> | null = null;
   if (stack.submission_id) {
     const { data: submission, error: submissionError } = await admin
       .from("submissions")
@@ -55,18 +60,29 @@ export async function getCurrentBlueprintContext(userId: string): Promise<Curren
     if (submissionError) throw submissionError;
     if (submission) {
       await ensureCurrentRegimen(userId, submission.id, submission);
-      const regimen = await getCurrentRegimen(userId);
+      regimen = await getCurrentRegimen(userId);
       const currentHash = blueprintInputSnapshotHash(submission, regimenToLedger(regimen));
       needsRefresh = !stack.input_snapshot_hash || stack.input_snapshot_hash !== currentHash;
     }
   }
+  regimen ??= await getCurrentRegimen(userId);
+  const recommendations = await getStackRecommendationDecisions(
+    userId,
+    stack.id,
+    regimen,
+    extractBlueprintGoalNames(report.sections.Goals),
+    report.canonicalMarkdown,
+  );
 
   return {
     stack_id: stack.id,
     created_at: stack.created_at,
-    safety_status: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(stack)),
+    safety_status: deriveBlueprintSafetyStatus(markdown),
     safety_acknowledged: Boolean(stack.safety_acknowledged_at),
     needs_refresh: needsRefresh,
+    actionable_recommendation_count: recommendations.filter(({ decision }) =>
+      isActionableRecommendationStatus(decision.status)
+    ).length,
     priorities: stackActions(stack).map(({ id, label, category, kind }) => ({ id, label, category, kind })),
   };
 }

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -36,6 +36,7 @@ import {
 } from "@/lib/supplementEligibility";
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
 import { ensureCurrentRegimen } from "@/lib/currentRegimen";
+import { extractReportRecommendationProposals } from "@/lib/reportRecommendationProposals";
 import {
   BLUEPRINT_MIN_RECOMMENDATIONS,
   BLUEPRINT_TARGET_RECOMMENDATIONS,
@@ -2482,6 +2483,16 @@ const safetyInput = {
   if (canonicalIssues.length) {
     console.warn("[validation] canonical report issues", canonicalIssues);
     throw new Error(`Refusing to persist invalid canonical report: ${canonicalIssues.join(", ")}`);
+  }
+  const persistedNames = new Set(itemsForPersistence.map((item) => normalizeSupplementName(item.name).toLowerCase()));
+  for (const proposal of extractReportRecommendationProposals(
+    canonicalReport.canonicalMarkdown,
+    currentStackLedger.map((item) => item.name),
+  )) {
+    const key = normalizeSupplementName(proposal.name).toLowerCase();
+    if (persistedNames.has(key)) continue;
+    itemsForPersistence.push({ ...proposal, is_current: false });
+    persistedNames.add(key);
   }
   md = canonicalReport.canonicalMarkdown;
   const persistedSafetyStatus = deriveBlueprintSafetyStatus(md);

--- a/src/lib/recommendationDecisionData.ts
+++ b/src/lib/recommendationDecisionData.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/recommendationDecision";
 import { normalizeRegimenName } from "@/lib/currentRegimenModel";
 import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
+import { extractReportRecommendationProposals } from "@/lib/reportRecommendationProposals";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export type StackRecommendationProposal = RecommendationProposalInput & {
@@ -30,6 +31,7 @@ export type StackRecommendationDecision = {
 };
 
 const DECISION_COLUMNS = "id,stack_id,stack_item_id,recommendation_key,context_fingerprint,status,reason_snapshot,overlap_snapshot,deferred_until,created_at,updated_at";
+const PROPOSAL_COLUMNS = "id,stack_id,name,brand,dose,timing,timing_text,notes,rationale,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,created_at";
 
 function isMissingDecisionTable(error: { code?: string; message?: string } | null | undefined): boolean {
   return error?.code === "42P01"
@@ -72,15 +74,49 @@ export async function getStackRecommendationDecisions(
   stackId: string,
   currentItems: CurrentRegimenItem[],
   goals: string[],
+  reportMarkdown: string,
 ): Promise<StackRecommendationDecision[]> {
   const admin = getSupabaseAdmin();
-  const { data, error } = await admin
+  let { data, error } = await admin
     .from("stacks_items")
-    .select("id,stack_id,name,brand,dose,timing,timing_text,notes,rationale,is_current,link_amazon,link_fullscript,refill_days_left,last_refilled_at,created_at")
+    .select(PROPOSAL_COLUMNS)
     .eq("stack_id", stackId)
     .eq("user_id", userId)
     .eq("is_current", false);
   if (error) throw error;
+
+  const storedNames = new Set((data ?? []).map((item) => normalizeRegimenName(item.name)));
+  const reportProposals = extractReportRecommendationProposals(
+    reportMarkdown,
+    currentItems.map((item) => item.name),
+  ).filter((item) => !storedNames.has(normalizeRegimenName(item.name)));
+
+  if (reportProposals.length) {
+    for (const proposal of reportProposals) {
+      const { error: insertError } = await admin.from("stacks_items").insert({
+        stack_id: stackId,
+        user_id: userId,
+        name: proposal.name,
+        dose: proposal.dose ?? null,
+        timing: proposal.timing ?? null,
+        timing_text: proposal.timing_text ?? null,
+        timing_bucket: proposal.timing_bucket ?? null,
+        notes: proposal.notes ?? null,
+        rationale: proposal.rationale ?? null,
+        is_current: false,
+      });
+      if (insertError && insertError.code !== "23505") throw insertError;
+    }
+
+    const refreshed = await admin
+      .from("stacks_items")
+      .select(PROPOSAL_COLUMNS)
+      .eq("stack_id", stackId)
+      .eq("user_id", userId)
+      .eq("is_current", false);
+    if (refreshed.error) throw refreshed.error;
+    data = refreshed.data;
+  }
 
   const currentNames = new Set(currentItems.map((item) => normalizeRegimenName(item.name)));
   const proposals = (data ?? [])

--- a/src/lib/reportRecommendationProposals.ts
+++ b/src/lib/reportRecommendationProposals.ts
@@ -1,0 +1,41 @@
+import { normalizeRegimenName } from "@/lib/currentRegimenModel";
+import { parseMarkdownToItems, type ParsedItem } from "@/lib/parseMarkdownToItems";
+import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
+
+const ACTIONABLE_REPORT_STATUS = /^new\s+consider$/i;
+
+function reportStatus(notes: string | null | undefined): string {
+  return String(notes ?? "")
+    .replace(/^Blueprint status:\s*/i, "")
+    .replace(/[\u2010-\u2015-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export type ReportRecommendationProposal = Pick<
+  ParsedItem,
+  "name" | "rationale" | "dose" | "timing" | "timing_text" | "timing_bucket" | "notes"
+>;
+
+/**
+ * Returns only explicit, actionable ideas from the dated report. Current items,
+ * medication-like entries, and non-actionable statuses remain report text only.
+ */
+export function extractReportRecommendationProposals(
+  reportMarkdown: string,
+  currentItemNames: string[],
+): ReportRecommendationProposal[] {
+  const currentNames = new Set(currentItemNames.map(normalizeRegimenName).filter(Boolean));
+
+  return parseMarkdownToItems(reportMarkdown).filter((item): item is ParsedItem & { name: string } => {
+    const name = item.name?.trim();
+    return Boolean(
+      name
+      && item.is_current === false
+      && ACTIONABLE_REPORT_STATUS.test(reportStatus(item.notes))
+      && isEligibleSupplementName(name)
+      && !isMedicationOrHormoneName(name)
+      && !currentNames.has(normalizeRegimenName(name))
+    );
+  });
+}

--- a/src/lib/routineData.ts
+++ b/src/lib/routineData.ts
@@ -58,7 +58,13 @@ export async function getRoutineData(userId: string): Promise<{
   if (latestStack?.id) {
     const report = parseBlueprintReport(blueprintMarkdownFromStack(latestStack));
     const goals = extractBlueprintGoalNames(report.sections.Goals);
-    const decisions = await getStackRecommendationDecisions(userId, latestStack.id, regimen, goals);
+    const decisions = await getStackRecommendationDecisions(
+      userId,
+      latestStack.id,
+      regimen,
+      goals,
+      report.canonicalMarkdown,
+    );
     proposals = decisions
       .filter(({ decision }) => isActionableRecommendationStatus(decision.status))
       .map(({ proposal: item, decision }) => ({

--- a/supabase/migrations/20260809150602_pr85_1_unique_report_recommendation_proposals.sql
+++ b/supabase/migrations/20260809150602_pr85_1_unique_report_recommendation_proposals.sql
@@ -1,0 +1,8 @@
+-- Prevent concurrent page loads from materializing the same report-only idea twice.
+-- Rollback: drop index if exists public.stacks_items_unique_report_proposal_idx;
+create unique index if not exists stacks_items_unique_report_proposal_idx
+  on public.stacks_items (stack_id, lower(btrim(name)))
+  where is_current = false;
+
+comment on index public.stacks_items_unique_report_proposal_idx is
+  'One live proposal per normalized supplement name and Blueprint stack; dated report text remains immutable.';


### PR DESCRIPTION
## Purpose

Repair the PR85 action loop when a dated Blueprint contains a genuine recommendation, such as Vitamin B12, but no matching non-current `stacks_items` record exists.

## What changed

- Parse explicit `New - consider` recommendations from canonical Blueprint Markdown.
- Materialize missing owner-scoped proposal rows without modifying the dated report.
- Reuse the existing PR85 decision, overlap, clinician-review, defer, dismiss, and adoption paths.
- Keep Blueprint, Today, and Routine aligned to the same recommendation state.
- Give Today a truthful report fallback instead of linking to an absent decision panel.
- Ensure future generation persists report-only recommendations.
- Add a partial unique index that prevents duplicate proposal rows during concurrent loads.

## User impact

Luke's B12 recommendation can now show its personalized reason and overlap with current B-complex products, then be reviewed, deferred, dismissed, sent for clinician review, or added to Routine. Today and Routine no longer disagree with the Blueprint.

## Root cause

The original PR85 loader only queried existing `stacks_items` rows where `is_current = false`. The current Blueprint contained B12 in report Markdown but did not persist a corresponding proposal row, so the action panel returned nothing and Today linked to a missing anchor.

## Verification

- `npm.cmd run qa:pr85-1`
- `npm.cmd run qa:pr85`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr84`
- `npm.cmd run typecheck`
- Optimized Next.js production build
- `git diff --check`
- Supabase migration applied and exact index definition verified

## Database and rollback

Migration: `20260809150602_pr85_1_unique_report_recommendation_proposals.sql`

Rollback:

```sql
drop index if exists public.stacks_items_unique_report_proposal_idx;
```

The migration adds no table, policy, or client privilege. Supabase advisors reported existing project-level warnings but no PR85.1-specific blocking issue.

## Preview QA still required

- Open Luke's current Blueprint and confirm the B12 decision card appears.
- Confirm the reason references the recorded context and overlap warning.
- Exercise clinician review, defer, dismiss/restore, and Add to Routine.
- Confirm Today and Routine counts align and Today has no dead link.
