### PR TITLE
Protect Blueprint health item integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "qa:pr84": "node --experimental-strip-types src/_tests_/pr84.assert.ts && node src/_tests_/pr84Page.assert.mjs",
     "qa:pr85": "node --experimental-strip-types src/_tests_/pr85.assert.ts && node src/_tests_/pr85Page.assert.mjs",
     "qa:pr85-1": "node src/_tests_/pr85_1ReportMaterialization.assert.mjs",
+    "qa:pr86": "node --experimental-strip-types src/_tests_/pr86HealthItemIntegrity.assert.ts",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/currentRegimen.assert.mjs
+++ b/src/_tests_/currentRegimen.assert.mjs
@@ -15,9 +15,11 @@ assert.match(writePrivileges, /revoke update[^;]*from authenticated/i, "Member r
 const combined = read("app/api/stacks/combined/route.ts");
 assert.match(combined, /getRoutineData/, "Today must read the canonical routine data service.");
 const routineData = read("src/lib/routineData.ts");
+const recommendationData = read("src/lib/recommendationDecisionData.ts");
 assert.match(routineData, /getCurrentRegimen/, "Routine data must read the canonical current regimen.");
-assert.match(routineData, /\.eq\("stack_id", latestStack\.id\)/, "Only the newest Blueprint may provide proposals.");
-assert.match(routineData, /\.eq\("is_current", false\)/, "Blueprint recommendations must remain proposals until adopted.");
+assert.match(routineData, /getStackRecommendationDecisions\([\s\S]*latestStack\.id/, "Only the newest Blueprint may provide proposals.");
+assert.match(recommendationData, /\.eq\("stack_id", stackId\)/, "Recommendation loading must remain scoped to the selected Blueprint.");
+assert.match(recommendationData, /\.eq\("is_current", false\)/, "Blueprint recommendations must remain proposals until adopted.");
 assert.doesNotMatch(routineData, /\.eq\("user_id", userId\)[\s\S]*\.eq\("is_current", true\)/, "Historical current flags must not drive Today.");
 
 const supplements = read("app/api/blueprints/[stackId]/supplements/route.ts");

--- a/src/_tests_/pr86HealthItemIntegrity.assert.ts
+++ b/src/_tests_/pr86HealthItemIntegrity.assert.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import { healthItemIdentityKey, validateGeneratedHealthItemIntegrity } from "../lib/healthItemIdentity.ts";
+
+assert.equal(healthItemIdentityKey("Vitamin B12"), healthItemIdentityKey("b12 (methylcobalamin)"));
+assert.notEqual(healthItemIdentityKey("Magnesium Glycinate"), healthItemIdentityKey("Magnesium Threonate"));
+assert.equal(healthItemIdentityKey("Magtein"), healthItemIdentityKey("Magnesium L-Threonate"));
+
+const proposalSource = fs.readFileSync("src/lib/reportRecommendationProposals.ts", "utf8");
+const parserSource = fs.readFileSync("src/lib/parseMarkdownToItems.ts", "utf8");
+const generatorSource = fs.readFileSync("src/lib/generateStack.ts", "utf8");
+assert.match(proposalSource, /currentNames\.has\(healthItemIdentityKey\(name\)\)/);
+assert.match(parserSource, /canonicalHealthItemDisplayName/);
+assert.match(generatorSource, /healthItemIdentityKey/);
+assert.match(generatorSource, /validateGeneratedHealthItemIntegrity/);
+
+const current = [
+  { name: "Vitamin D", dose: "5000 IU", timing: "Daily at 10:30 AM" },
+  { name: "Magnesium Glycinate", dose: "210 mg", timing: "Daily at 8:30 PM" },
+  { name: "Magnesium Threonate", dose: "2000 mg", timing: "Daily at 8:30 AM and 10:30 AM" },
+];
+const validPersisted = current.map((item) => ({ ...item, is_current: true }));
+assert.deepEqual(validateGeneratedHealthItemIntegrity(current, validPersisted), []);
+
+assert.deepEqual(
+  validateGeneratedHealthItemIntegrity(current, [
+    { ...validPersisted[0], dose: "5000mg" },
+    validPersisted[1],
+    validPersisted[2],
+  ]),
+  ["changed-current-dose:Vitamin D"],
+  "A changed unit must block Blueprint persistence",
+);
+
+assert.deepEqual(
+  validateGeneratedHealthItemIntegrity(current, validPersisted, [{ name: "Magnesium Bisglycinate" }]),
+  ["current-item-proposed-as-new:Magnesium Bisglycinate"],
+);
+
+console.log("PR86 health-item integrity assertions passed.");

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -37,6 +37,7 @@ import {
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
 import { ensureCurrentRegimen } from "@/lib/currentRegimen";
 import { extractReportRecommendationProposals } from "@/lib/reportRecommendationProposals";
+import { healthItemIdentityKey, validateGeneratedHealthItemIntegrity } from "@/lib/healthItemIdentity";
 import {
   BLUEPRINT_MIN_RECOMMENDATIONS,
   BLUEPRINT_TARGET_RECOMMENDATIONS,
@@ -481,9 +482,9 @@ function sanitizeBlueprintTable(
 ): string {
   const rows = blueprintTable.split(/\r?\n/).filter((line) => /^\s*\|\s*\d+\s*\|/.test(line));
   const allowed = new Set(allowedNames.map((name) => name.toLowerCase()));
-  const currentSupplements = new Set(currentLedger
-    .filter((item) => item.kind === "supplement")
-    .map((item) => normalizeSupplementName(item.name).toLowerCase()));
+  const currentSupplementsByIdentity = new Map(currentLedger
+    .filter((item) => item.kind === "supplement" || item.kind === "endocrine_active_supplement")
+    .map((item) => [healthItemIdentityKey(item.name), item] as const));
   const parsedItems = rows.flatMap((row) => {
     const cells = row.split("|").slice(1, -1).map((cell) => cell.trim());
     const name = validItemName(cells[1]);
@@ -501,17 +502,21 @@ function sanitizeBlueprintTable(
   }
   const candidateNames = new Set<string>();
   const deduped = candidates.filter((item) => {
-    const key = normalizeSupplementName(item.name).toLowerCase();
+    const key = healthItemIdentityKey(item.name);
     if (candidateNames.has(key)) return false;
     candidateNames.add(key);
     return true;
   });
-  const classified = deduped.map((item) => ({
-    ...item,
-    status: currentSupplements.has(normalizeSupplementName(item.name).toLowerCase())
+  const classified = deduped.map((item) => {
+    const current = currentSupplementsByIdentity.get(healthItemIdentityKey(item.name));
+    return {
+      ...item,
+      name: current?.name ?? item.name,
+      status: current
         ? "Current - optimize" as const
         : "New - consider" as const,
-  }));
+    };
+  });
   const currentPool = classified.filter((item) => item.status === "Current - optimize").slice(0, 5);
   const clinicianPool: typeof classified = [];
   const newPool = classified.filter((item) => item.status === "New - consider");
@@ -521,8 +526,8 @@ function sanitizeBlueprintTable(
   selected.push(...newPool.slice(0, requiredNew));
   selected.push(...clinicianPool);
   if (selected.length < minRows) {
-    const selectedNames = new Set(selected.map((item) => normalizeSupplementName(item.name).toLowerCase()));
-    selected.push(...newPool.filter((item) => !selectedNames.has(normalizeSupplementName(item.name).toLowerCase())).slice(0, minRows - selected.length));
+    const selectedNames = new Set(selected.map((item) => healthItemIdentityKey(item.name)));
+    selected.push(...newPool.filter((item) => !selectedNames.has(healthItemIdentityKey(item.name))).slice(0, minRows - selected.length));
   }
   const items = selected.slice(0, minRows);
   const header = "| Rank | Supplement | Status | Why it Matters |\n| --- | --- | --- | --- |";
@@ -2344,7 +2349,7 @@ const safetyInput = {
   is_premium: mode === "premium",
 };
 
-  const itemKey = (name: string) => normalizeSupplementName(name).toLowerCase();
+  const itemKey = (name: string) => healthItemIdentityKey(name);
   const currentKindByName = new Map(currentStackLedger.map((item) => [itemKey(item.name), item.kind]));
   const safetyCandidates = filteredItems.filter((item) => {
     const currentKind = currentKindByName.get(itemKey(item.name));
@@ -2420,7 +2425,9 @@ const safetyInput = {
     return attachEvidence({
       ...source,
       name,
-      is_current: currentStackLedger.some((item) => item.kind === "supplement" && itemKey(item.name) === itemKey(name)),
+      is_current: currentStackLedger.some((item) =>
+        (item.kind === "supplement" || item.kind === "endocrine_active_supplement") && itemKey(item.name) === itemKey(name)
+      ),
     });
   });
   const missingBlueprintEvidence = evidenceAlignedItems
@@ -2433,12 +2440,15 @@ const safetyInput = {
   const withEvidence: StackItem[] = finalStack.map((item) => evidenceByName.get(itemKey(item.name)) ?? item);
   const persistedItemsByName = new Map<string, StackItem>();
   for (const item of withEvidence) {
-    const key = normalizeSupplementName(item.name).toLowerCase();
+    const key = itemKey(item.name);
     const ledgerItem = currentStackLedger.find((current) =>
-      normalizeSupplementName(current.name).toLowerCase() === key
+      itemKey(current.name) === key
     );
     const persistedItem: StackItem = {
       ...item,
+      name: ledgerItem?.name ?? item.name,
+      dose: ledgerItem?.dose ?? item.dose ?? null,
+      timing: ledgerItem?.timing ?? item.timing ?? null,
       is_current: Boolean(ledgerItem) || item.is_current,
       notes: ledgerItem
         ? `Current ${currentStackKindLabel(ledgerItem.kind).toLowerCase()} reported in intake.${ledgerItem.purpose ? ` Purpose: ${ledgerItem.purpose}` : ""}`
@@ -2447,7 +2457,7 @@ const safetyInput = {
     persistedItemsByName.set(key, ledgerItem && ledgerItem.kind !== "supplement" ? clearShoppingLinks(persistedItem) : persistedItem);
   }
   for (const item of currentStackLedger) {
-    const key = normalizeSupplementName(item.name).toLowerCase();
+    const key = itemKey(item.name);
     if (!persistedItemsByName.has(key)) {
       persistedItemsByName.set(key, {
         name: item.name,
@@ -2484,12 +2494,18 @@ const safetyInput = {
     console.warn("[validation] canonical report issues", canonicalIssues);
     throw new Error(`Refusing to persist invalid canonical report: ${canonicalIssues.join(", ")}`);
   }
-  const persistedNames = new Set(itemsForPersistence.map((item) => normalizeSupplementName(item.name).toLowerCase()));
-  for (const proposal of extractReportRecommendationProposals(
+  const reportProposals = extractReportRecommendationProposals(
     canonicalReport.canonicalMarkdown,
     currentStackLedger.map((item) => item.name),
-  )) {
-    const key = normalizeSupplementName(proposal.name).toLowerCase();
+  );
+  const integrityIssues = validateGeneratedHealthItemIntegrity(currentStackLedger, itemsForPersistence, reportProposals);
+  if (integrityIssues.length) {
+    console.warn("[validation] health item integrity issues", integrityIssues);
+    throw new Error(`Refusing to persist health-item integrity failure: ${integrityIssues.join(", ")}`);
+  }
+  const persistedNames = new Set(itemsForPersistence.map((item) => itemKey(item.name)));
+  for (const proposal of reportProposals) {
+    const key = itemKey(proposal.name);
     if (persistedNames.has(key)) continue;
     itemsForPersistence.push({ ...proposal, is_current: false });
     persistedNames.add(key);

--- a/src/lib/healthItemIdentity.ts
+++ b/src/lib/healthItemIdentity.ts
@@ -1,0 +1,112 @@
+function simpleKey(value: string): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[.*_`#]/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Stable ingredient identity used for regimen matching and deduplication.
+ * This is deliberately narrower than evidence matching: two ingredients may
+ * share an evidence source without being interchangeable regimen items.
+ */
+export function healthItemIdentityKey(value: string): string {
+  const key = simpleKey(value);
+  if (!key) return "";
+
+  if (/^(?:vitamin )?b ?12(?: methylcobalamin)?$/.test(key) || key === "methylcobalamin") return "vitamin-b12";
+  if (/^(?:vitamin )?d ?3?$/.test(key) || key === "cholecalciferol") return "vitamin-d";
+  if (/^(?:magnesium )?(?:l )?threonate$/.test(key) || key === "magtein") return "magnesium-threonate";
+  if (/^magnesium (?:bis)?glycinate$/.test(key)) return "magnesium-glycinate";
+  if (/^magnesium citrate$/.test(key)) return "magnesium-citrate";
+  if (/^magnesium malate$/.test(key)) return "magnesium-malate";
+  if (/^magnesium taurate$/.test(key)) return "magnesium-taurate";
+  if (/^magnesium oxide$/.test(key)) return "magnesium-oxide";
+  if (/^magnesium chloride$/.test(key)) return "magnesium-chloride";
+  if (/^magnesium sulfate$/.test(key) || key === "epsom salt") return "magnesium-sulfate";
+  if (key === "magnesium") return "magnesium-unspecified";
+  if (/^(?:omega ?3|fish oil|epa dha)$/.test(key)) return "omega-3";
+  if (/^(?:vitamin )?b complex$/.test(key) || key === "b vitamins") return "b-complex";
+  if (/^(?:coq ?10|ubiquinone|ubiquinol)$/.test(key)) return "coq10";
+  if (/^(?:creatine|creatine monohydrate)$/.test(key)) return "creatine-monohydrate";
+
+  return key.replace(/ /g, "-");
+}
+
+export function canonicalHealthItemDisplayName(value: string): string {
+  const trimmed = String(value ?? "").replace(/[.*_`#]/g, "").replace(/\s+/g, " ").trim();
+  switch (healthItemIdentityKey(trimmed)) {
+    case "vitamin-b12": return "Vitamin B12";
+    case "vitamin-d": return "Vitamin D";
+    case "magnesium-threonate": return "Magnesium Threonate";
+    case "magnesium-glycinate": return "Magnesium Glycinate";
+    case "magnesium-citrate": return "Magnesium Citrate";
+    case "magnesium-malate": return "Magnesium Malate";
+    case "magnesium-taurate": return "Magnesium Taurate";
+    case "magnesium-oxide": return "Magnesium Oxide";
+    case "magnesium-chloride": return "Magnesium Chloride";
+    case "magnesium-sulfate": return "Magnesium Sulfate";
+    case "magnesium-unspecified": return "Magnesium";
+    case "omega-3": return "Omega-3";
+    case "b-complex": return "B-Complex";
+    case "coq10": return "CoQ10";
+    case "creatine-monohydrate": return "Creatine Monohydrate";
+    default: return trimmed;
+  }
+}
+
+type IntegrityItem = {
+  name: string;
+  dose?: string | null;
+  timing?: string | null;
+  is_current?: boolean | null;
+};
+
+function exactInstruction(value: string | null | undefined): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function validateGeneratedHealthItemIntegrity(
+  currentItems: IntegrityItem[],
+  persistedItems: IntegrityItem[],
+  proposedItems: IntegrityItem[] = [],
+): string[] {
+  const issues: string[] = [];
+  const currentByKey = new Map<string, IntegrityItem>();
+  for (const item of currentItems) {
+    const key = healthItemIdentityKey(item.name);
+    if (!key) continue;
+    if (currentByKey.has(key)) issues.push(`duplicate-current-identity:${key}`);
+    currentByKey.set(key, item);
+  }
+
+  const persistedCurrentByKey = new Map(
+    persistedItems
+      .filter((item) => item.is_current === true)
+      .map((item) => [healthItemIdentityKey(item.name), item] as const)
+      .filter(([key]) => Boolean(key)),
+  );
+
+  for (const [key, current] of currentByKey) {
+    const persisted = persistedCurrentByKey.get(key);
+    if (!persisted) {
+      issues.push(`missing-current-item:${current.name}`);
+      continue;
+    }
+    if (exactInstruction(persisted.dose) !== exactInstruction(current.dose)) {
+      issues.push(`changed-current-dose:${current.name}`);
+    }
+    if (exactInstruction(persisted.timing) !== exactInstruction(current.timing)) {
+      issues.push(`changed-current-timing:${current.name}`);
+    }
+  }
+
+  for (const proposal of proposedItems) {
+    const key = healthItemIdentityKey(proposal.name);
+    if (key && currentByKey.has(key)) issues.push(`current-item-proposed-as-new:${proposal.name}`);
+  }
+
+  return Array.from(new Set(issues));
+}

--- a/src/lib/parseMarkdownToItems.ts
+++ b/src/lib/parseMarkdownToItems.ts
@@ -3,7 +3,7 @@
 // Central, single-source parser for converting the Markdown report into
 // normalized stack items used by the DB/UI.
 
-import { normalizeSupplementName } from "@/lib/evidence";
+import { canonicalHealthItemDisplayName } from "@/lib/healthItemIdentity";
 
 export type ParsedItem = {
   name: string;
@@ -118,7 +118,7 @@ export function parseMarkdownToItems(md: string): ParsedItem[] {
       const cleaned = cleanName(rawName);
       if (!cleaned || SEE_DN.test(cleaned)) return;
 
-      const canonical = normalizeSupplementName(cleaned);
+      const canonical = canonicalHealthItemDisplayName(cleaned);
       const rationale = whyIndex >= 0 && cols[whyIndex] ? String(cols[whyIndex]).trim() : null;
       const status = statusIndex >= 0 && cols[statusIndex] ? String(cols[statusIndex]).trim() : null;
 
@@ -152,7 +152,7 @@ export function parseMarkdownToItems(md: string): ParsedItem[] {
       const cleaned = cleanName(raw);
       if (!cleaned || SEE_DN.test(cleaned)) return;
 
-      const canonical = normalizeSupplementName(cleaned);
+      const canonical = canonicalHealthItemDisplayName(cleaned);
       const key = canonical.toLowerCase();
       const purpose = purposeIndex >= 0 ? cols[purposeIndex] || null : null;
       const dose = doseIndex >= 0 ? cols[doseIndex] || null : null;
@@ -205,7 +205,7 @@ export function parseMarkdownToItems(md: string): ParsedItem[] {
       const cleaned = cleanName(nameRaw);
       if (!cleaned || SEE_DN.test(cleaned)) continue;
 
-      const canonical = normalizeSupplementName(cleaned);
+      const canonical = canonicalHealthItemDisplayName(cleaned);
       const firstSentence = (remainder.split(/[.!?]/)[0] || remainder).trim();
       const doseCandidate = firstSentence.replace(/\s+/g, " ").replace(/^[–—-]\s*/, "").trim();
 

--- a/src/lib/recommendationDecisionData.ts
+++ b/src/lib/recommendationDecisionData.ts
@@ -8,7 +8,7 @@ import {
   type RecommendationDecisionSeed,
   type RecommendationProposalInput,
 } from "@/lib/recommendationDecision";
-import { normalizeRegimenName } from "@/lib/currentRegimenModel";
+import { healthItemIdentityKey } from "@/lib/healthItemIdentity";
 import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
 import { extractReportRecommendationProposals } from "@/lib/reportRecommendationProposals";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
@@ -85,11 +85,11 @@ export async function getStackRecommendationDecisions(
     .eq("is_current", false);
   if (error) throw error;
 
-  const storedNames = new Set((data ?? []).map((item) => normalizeRegimenName(item.name)));
+  const storedNames = new Set((data ?? []).map((item) => healthItemIdentityKey(item.name)));
   const reportProposals = extractReportRecommendationProposals(
     reportMarkdown,
     currentItems.map((item) => item.name),
-  ).filter((item) => !storedNames.has(normalizeRegimenName(item.name)));
+  ).filter((item) => !storedNames.has(healthItemIdentityKey(item.name)));
 
   if (reportProposals.length) {
     for (const proposal of reportProposals) {
@@ -118,7 +118,7 @@ export async function getStackRecommendationDecisions(
     data = refreshed.data;
   }
 
-  const currentNames = new Set(currentItems.map((item) => normalizeRegimenName(item.name)));
+  const currentNames = new Set(currentItems.map((item) => healthItemIdentityKey(item.name)));
   const proposals = (data ?? [])
     .filter((item) => {
       const name = typeof item.name === "string" ? item.name.trim() : "";
@@ -126,7 +126,7 @@ export async function getStackRecommendationDecisions(
         name
         && isEligibleSupplementName(name)
         && !isMedicationOrHormoneName(name)
-        && !currentNames.has(normalizeRegimenName(name))
+        && !currentNames.has(healthItemIdentityKey(name))
       );
     })
     .map((item) => ({

--- a/src/lib/reportRecommendationProposals.ts
+++ b/src/lib/reportRecommendationProposals.ts
@@ -1,4 +1,4 @@
-import { normalizeRegimenName } from "@/lib/currentRegimenModel";
+import { healthItemIdentityKey } from "@/lib/healthItemIdentity";
 import { parseMarkdownToItems, type ParsedItem } from "@/lib/parseMarkdownToItems";
 import { isEligibleSupplementName, isMedicationOrHormoneName } from "@/lib/supplementEligibility";
 
@@ -25,7 +25,7 @@ export function extractReportRecommendationProposals(
   reportMarkdown: string,
   currentItemNames: string[],
 ): ReportRecommendationProposal[] {
-  const currentNames = new Set(currentItemNames.map(normalizeRegimenName).filter(Boolean));
+  const currentNames = new Set(currentItemNames.map(healthItemIdentityKey).filter(Boolean));
 
   return parseMarkdownToItems(reportMarkdown).filter((item): item is ParsedItem & { name: string } => {
     const name = item.name?.trim();
@@ -35,7 +35,7 @@ export function extractReportRecommendationProposals(
       && ACTIONABLE_REPORT_STATUS.test(reportStatus(item.notes))
       && isEligibleSupplementName(name)
       && !isMedicationOrHormoneName(name)
-      && !currentNames.has(normalizeRegimenName(name))
+      && !currentNames.has(healthItemIdentityKey(name))
     );
   });
 }


### PR DESCRIPTION
## What changed

- Added one canonical identity system for health-item matching across Blueprint generation and recommendation decisions.
- Treats Vitamin B12, B12, and methylcobalamin as the same ingredient.
- Keeps Magnesium Glycinate and Magnesium Threonate as distinct regimen items even when they share evidence.
- Copies current dose and timing values from the canonical Routine ledger before persistence.
- Blocks Blueprint persistence when a current dose or timing changes, a current item disappears, or a current ingredient is promoted as a new proposal.
- Added regression coverage for Luke's B12, magnesium, and Vitamin D unit failure cases.

## Why

The production audit found that the latest Blueprint recommended B12 even though it was already active, collapsed two magnesium forms, and changed Vitamin D from 5,000 IU to 5,000 mg. The Routine ledger was correct; inconsistent name normalization during report generation caused the corruption.

## User impact

Blueprint recommendations now reconcile against the current Routine using ingredient identity instead of display-name spelling. If generation cannot preserve current health information exactly, the new report is rejected and the existing valid version remains available.

## Validation

- `npm run qa:pr86`
- `npm run qa:pr85-1`
- `npm run qa:pr85`
- `npm run qa:pr84`
- `npm run qa:current-regimen`
- `npm run qa:blueprints`
- `npm run qa:blueprint-safety`
- `npm run qa:safety-engine`
- `npm run qa:routine`
- `npm run typecheck`
- `npm run build` with inert build-only environment values
- `git diff --check`
