### PR TITLE
PR88: Repair Blueprint refresh and safety deduplication

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -185,12 +185,15 @@ export default function BlueprintWorkspaceClient({
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data?.ok || !data?.stack_id) {
-        throw new Error("refresh_unavailable");
+        throw new Error(data?.error ?? "refresh_unavailable");
       }
       window.location.assign(`/blueprints/${encodeURIComponent(data.stack_id)}?refreshed=1`);
-    } catch {
+    } catch (refreshError) {
+      const validationFailed = refreshError instanceof Error && refreshError.message === "blueprint_refresh_validation_failed";
       setRefreshIssue(
-        "We could not create an updated version right now. Your saved changes and current Blueprint are still available. This is a service issue, so there is nothing you need to correct. Please try again in a few minutes."
+        validationFailed
+          ? "We protected your saved health information because the updated report did not match it exactly. Your current Blueprint is unchanged. This is an internal report issue, not something you need to correct."
+          : "We could not create an updated version right now. Your saved changes and current Blueprint are still available. This is a service issue, so there is nothing you need to correct. Please try again in a few minutes."
       );
       setRefreshing(false);
     }
@@ -362,7 +365,7 @@ export default function BlueprintWorkspaceClient({
                 className="mt-4 inline-flex min-h-11 items-center rounded-xl bg-amber-800 px-5 py-3 text-sm font-bold text-white hover:bg-amber-900 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {refreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />}
-                {refreshing ? "Refreshing Blueprint..." : refreshIssue ? "Try Blueprint refresh again" : "Refresh Blueprint and safety review"}
+                {refreshing ? "Building your updated Blueprint (usually under a minute)..." : refreshIssue ? "Try Blueprint refresh again" : "Refresh Blueprint and safety review"}
               </button>
             </div>
           </div>

--- a/app/api/blueprints/[stackId]/refresh/route.ts
+++ b/app/api/blueprints/[stackId]/refresh/route.ts
@@ -110,9 +110,11 @@ export async function POST(_req: Request, { params }: RouteContext) {
 
     return NextResponse.json({ ok: true, stack_id: refreshedStackId, reused: false });
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const validationFailed = errorMessage.startsWith("Refusing to persist health-item integrity failure:");
     console.error("[blueprints/refresh] failed", {
       submissionId,
-      message: error instanceof Error ? error.message : String(error),
+      message: errorMessage,
     });
     await recordProductEventSafely({
       user_id: entitlement.user.id,
@@ -120,7 +122,7 @@ export async function POST(_req: Request, { params }: RouteContext) {
       source: "blueprints",
     });
     return NextResponse.json(
-      { ok: false, error: "blueprint_refresh_failed" },
+      { ok: false, error: validationFailed ? "blueprint_refresh_validation_failed" : "blueprint_refresh_failed" },
       { status: 500 }
     );
   }

--- a/src/_tests_/pr86HealthItemIntegrity.assert.ts
+++ b/src/_tests_/pr86HealthItemIntegrity.assert.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 import { healthItemIdentityKey, validateGeneratedHealthItemIntegrity } from "../lib/healthItemIdentity.ts";
+import parseMarkdownToItems from "../lib/parseMarkdownToItems.ts";
 
 assert.equal(healthItemIdentityKey("Vitamin B12"), healthItemIdentityKey("b12 (methylcobalamin)"));
 assert.notEqual(healthItemIdentityKey("Magnesium Glycinate"), healthItemIdentityKey("Magnesium Threonate"));
@@ -14,6 +15,8 @@ assert.match(proposalSource, /currentNames\.has\(healthItemIdentityKey\(name\)\)
 assert.match(parserSource, /canonicalHealthItemDisplayName/);
 assert.match(generatorSource, /healthItemIdentityKey/);
 assert.match(generatorSource, /validateGeneratedHealthItemIntegrity/);
+assert.match(generatorSource, /ledgerItem \? \(ledgerItem\.dose \?\? null\) : \(item\.dose \?\? null\)/);
+assert.match(generatorSource, /ledgerItem \? \(ledgerItem\.timing \?\? null\) : \(item\.timing \?\? null\)/);
 
 const current = [
   { name: "Vitamin D", dose: "5000 IU", timing: "Daily at 10:30 AM" },
@@ -22,6 +25,36 @@ const current = [
 ];
 const validPersisted = current.map((item) => ({ ...item, is_current: true }));
 assert.deepEqual(validateGeneratedHealthItemIntegrity(current, validPersisted), []);
+
+const blankCurrentInstructions = [
+  { name: "Pregnenolone", dose: null, timing: null },
+  { name: "Collagen peptides", dose: null, timing: "Morning" },
+];
+const modelEnrichedItems = blankCurrentInstructions.map((item) => ({
+  ...item,
+  dose: item.dose ?? "Model-suggested dose",
+  is_current: true,
+}));
+assert.deepEqual(
+  validateGeneratedHealthItemIntegrity(blankCurrentInstructions, modelEnrichedItems),
+  ["changed-current-dose:Pregnenolone", "changed-current-dose:Collagen peptides"],
+  "Blank member instructions must remain blank rather than falling through to model guidance",
+);
+
+const parsedRoutine = parseMarkdownToItems([
+  "## Current Stack",
+  "",
+  "| Current Item | Type | Purpose | Dosage | Timing |",
+  "| --- | --- | --- | --- | --- |",
+  "| Magnesium Glycinate | Supplement | Sleep | 210 mg | Evening |",
+  "",
+  "## Dosing & Notes",
+  "",
+  "- **Magnesium Glycinate** -- Your reported routine: 210 mg, evening.",
+].join("\n"));
+assert.equal(parsedRoutine.length, 1, "A current item and its routine note must remain one item");
+assert.equal(parsedRoutine[0]?.name, "Magnesium Glycinate");
+assert.doesNotMatch(parsedRoutine[0]?.name ?? "", /reported routine/i);
 
 assert.deepEqual(
   validateGeneratedHealthItemIntegrity(current, [

--- a/src/_tests_/safetyEngine.assert.ts
+++ b/src/_tests_/safetyEngine.assert.ts
@@ -75,4 +75,15 @@ assert.match(patched, /\| 2 \| Unmapped compound \| Clinician review \|/, "A pro
 assert.match(patched, /Clinician review: Unmapped compound/, "The customer-visible safety section must use the canonical structured finding.");
 assert.doesNotMatch(patched, /Placeholder/, "The structured safety section must replace generated placeholder content.");
 
+const duplicateCandidates = evaluateSafetyCandidates(
+  {},
+  [
+    { name: "Magnesium Glycinate", is_current: false },
+    { name: "magnesium bisglycinate", is_current: true },
+  ],
+  { interactions: [], rules: [] },
+);
+assert.equal(duplicateCandidates.candidates.length, 1, "Canonical duplicate candidates should be evaluated once");
+assert.equal(duplicateCandidates.findings.length, 0, "A missing library row should not warn repeatedly about an existing routine item");
+
 console.log("Safety engine assertions passed.");

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -37,7 +37,7 @@ import {
 import { blueprintInputSnapshotHash } from "@/lib/blueprintWorkspace";
 import { ensureCurrentRegimen } from "@/lib/currentRegimen";
 import { extractReportRecommendationProposals } from "@/lib/reportRecommendationProposals";
-import { healthItemIdentityKey, validateGeneratedHealthItemIntegrity } from "@/lib/healthItemIdentity";
+import { canonicalHealthItemDisplayName, healthItemIdentityKey, validateGeneratedHealthItemIntegrity } from "@/lib/healthItemIdentity";
 import {
   BLUEPRINT_MIN_RECOMMENDATIONS,
   BLUEPRINT_TARGET_RECOMMENDATIONS,
@@ -1060,7 +1060,7 @@ function normalizeSupplementName(name: string): string {
   if (collapsed.includes("vitamin b complex") || collapsed.includes("b complex") || collapsed.includes("b-vitamins")) return "B-Vitamins";
   if (collapsed.startsWith("omega")) return "Omega-3";
   if (collapsed.startsWith("vitamin d")) return "Vitamin D";
-  if (collapsed.startsWith("mag")) return "Magnesium";
+  if (collapsed.startsWith("mag")) return canonicalHealthItemDisplayName(name);
   if (collapsed.startsWith("ashwa")) return "Ashwagandha";
   if (collapsed.startsWith("bacopa")) return "Bacopa Monnieri";
   if (collapsed.startsWith("coq")) return "CoQ10";
@@ -2447,8 +2447,11 @@ const safetyInput = {
     const persistedItem: StackItem = {
       ...item,
       name: ledgerItem?.name ?? item.name,
-      dose: ledgerItem?.dose ?? item.dose ?? null,
-      timing: ledgerItem?.timing ?? item.timing ?? null,
+      // The member's current regimen is authoritative, including an
+      // intentionally blank dose or timing. Never replace missing member data
+      // with model-generated instructions.
+      dose: ledgerItem ? (ledgerItem.dose ?? null) : (item.dose ?? null),
+      timing: ledgerItem ? (ledgerItem.timing ?? null) : (item.timing ?? null),
       is_current: Boolean(ledgerItem) || item.is_current,
       notes: ledgerItem
         ? `Current ${currentStackKindLabel(ledgerItem.kind).toLowerCase()} reported in intake.${ledgerItem.purpose ? ` Purpose: ${ledgerItem.purpose}` : ""}`

--- a/src/lib/parseMarkdownToItems.ts
+++ b/src/lib/parseMarkdownToItems.ts
@@ -3,7 +3,7 @@
 // Central, single-source parser for converting the Markdown report into
 // normalized stack items used by the DB/UI.
 
-import { canonicalHealthItemDisplayName } from "@/lib/healthItemIdentity";
+import { canonicalHealthItemDisplayName } from "./healthItemIdentity.ts";
 
 export type ParsedItem = {
   name: string;
@@ -196,7 +196,7 @@ export function parseMarkdownToItems(md: string): ParsedItem[] {
       const line = raw.replace(/^\s*[-*]\s*/, "");
       // Split only on a deliberate item delimiter. Plain hyphens inside
       // "evidence-informed", "label-directed", or "3-5 g" are content.
-      const split = line.match(/^(.+?)(?:\s+[—–-]\s+|:\s+)(.+)$/);
+      const split = line.match(/^(.+?)(?:\s+(?:--|—|–|-)\s+|:\s+)(.+)$/);
       if (!split) continue;
 
       const nameRaw = split[1].trim();

--- a/src/lib/safetyEngine.ts
+++ b/src/lib/safetyEngine.ts
@@ -1,3 +1,5 @@
+import { healthItemIdentityKey } from "./healthItemIdentity.ts";
+
 export type SafetySeverity = "info" | "warning" | "danger";
 export type SafetyDecision = "clear" | "review" | "blocked";
 export type SafetySource = "interactions" | "rules" | "intake" | "system";
@@ -237,7 +239,16 @@ export function evaluateSafetyCandidates(
   const hasUpcomingProcedure = contextMatches([...procedures, ...conditions], /\b(?:surgery|procedure|operation|colonoscopy|endoscopy|dental\s+extraction)\b/i);
   const unknownMedications = medications.filter((medication) => !RECOGNIZED_MED_RE.test(medication));
 
-  const candidateResults = candidates.map((candidate): SafetyCandidateResult => {
+  const candidatesByIdentity = new Map<string, SafetyCandidate>();
+  for (const candidate of candidates) {
+    const key = healthItemIdentityKey(candidate.name);
+    if (!key) continue;
+    const existing = candidatesByIdentity.get(key);
+    if (!existing || candidate.is_current === true) candidatesByIdentity.set(key, candidate);
+  }
+  const uniqueCandidates = Array.from(candidatesByIdentity.values());
+
+  const candidateResults = uniqueCandidates.map((candidate): SafetyCandidateResult => {
     const findings: SafetyFinding[] = [];
     const match = mergedInteraction(candidate.name, sources.interactions);
 
@@ -248,7 +259,9 @@ export function evaluateSafetyCandidates(
     }
 
     if (!match) {
-      addFinding(findings, finding("interaction_record_missing", candidate.name, `No structured interaction record matched ${candidate.name}. A clinician or pharmacist should review it before a new start.`, "warning", "system"));
+      if (candidate.is_current !== true) {
+        addFinding(findings, finding("interaction_record_missing", candidate.name, `No structured interaction record matched ${candidate.name}. A clinician or pharmacist should review it before a new start.`, "warning", "system"));
+      }
     } else {
       if (hasThyroidMedication && match.binds_thyroid_meds) {
         addFinding(findings, finding("thyroid_spacing", candidate.name, `Separate ${candidate.name} from thyroid medication by at least ${match.sep_hours_thyroid ?? 4} hours, or follow the pharmacist's timing instructions.`, "warning", "interactions"));
@@ -318,7 +331,7 @@ export function evaluateSafetyCandidates(
       }
     }
 
-    if (unknownMedications.length) {
+    if (unknownMedications.length && candidate.is_current !== true) {
       addFinding(findings, finding("unknown_medication", candidate.name, `The interaction library did not classify ${unknownMedications.join(", ")}. Proposed supplements require pharmacist or clinician review before use.`, "warning", "system"));
     }
 


### PR DESCRIPTION
## What changed
- preserve intentionally blank member doses and timing during Blueprint generation
- recognize double-hyphen routine-note delimiters so they cannot become fake health-item names
- deduplicate safety candidates by canonical ingredient identity and prefer the current regimen record
- stop producing missing-library warnings for items already in the member's routine
- preserve magnesium forms during evidence normalization
- return clearer validation failures and set realistic refresh progress expectations

## Root cause
PR87 correctly added an integrity guard, but persistence still used nullish fallback from the member ledger to model-generated instructions. Blank doses for Pregnenolone, Collagen peptides, and psyllium were therefore replaced, and the guard rejected every refresh after generation completed. Separately, the dosing parser did not recognize the generated double-hyphen delimiter, creating malformed duplicate candidates such as Magnesium Glycinate plus Magnesium Glycinate -- Your reported routine.

## User impact
A successful refresh can now create a new canonical Blueprint without fabricating current instructions. The new safety section evaluates each canonical item once, keeps distinct magnesium forms distinct, and reserves missing-library warnings for proposed additions.

## Validation
- npm.cmd run qa:pr86
- npm.cmd run qa:safety-engine
- npm.cmd run qa:blueprint-safety
- npm.cmd run qa:pr85-1
- npm.cmd run qa:blueprints
- npm.cmd run typecheck
- next build compiled and typechecked; local prerender requires the production Supabase environment variables not present in this checkout