### PR TITLE
PR89: Clarify and consolidate safety signals

### DIFF
--- a/src/_tests_/safetyEngine.assert.ts
+++ b/src/_tests_/safetyEngine.assert.ts
@@ -86,4 +86,46 @@ const duplicateCandidates = evaluateSafetyCandidates(
 assert.equal(duplicateCandidates.candidates.length, 1, "Canonical duplicate candidates should be evaluated once");
 assert.equal(duplicateCandidates.findings.length, 0, "A missing library row should not warn repeatedly about an existing routine item");
 
+const magnesiumUpperLimitRule = {
+  rule_type: "UL",
+  entity_a_name: "Magnesium",
+  max_daily_amount: 350,
+  unit: "mg",
+  message: "Do not exceed 350 mg/day of magnesium from supplements.",
+  severity: "danger",
+};
+const ambiguousCompoundDose = evaluateSafetyCandidates(
+  {},
+  [{ name: "Magnesium Threonate", dose: "2000 mg", is_current: true }],
+  { interactions: [], rules: [magnesiumUpperLimitRule] },
+);
+assert.equal(ambiguousCompoundDose.status, "review", "A magnesium compound weight must not be treated as an elemental overdose");
+assert.equal(ambiguousCompoundDose.findings[0]?.code, "dose_basis_unclear");
+assert.match(ambiguousCompoundDose.findings[0]?.message ?? "", /elemental magnesium/i);
+
+const explicitElementalDose = evaluateSafetyCandidates(
+  {},
+  [{ name: "Magnesium Threonate", dose: "400 mg elemental magnesium", is_current: true }],
+  { interactions: [], rules: [magnesiumUpperLimitRule] },
+);
+assert.equal(explicitElementalDose.status, "blocked", "An explicitly elemental magnesium dose above the limit must remain blocked");
+assert.equal(explicitElementalDose.findings[0]?.code, "upper_limit");
+
+const groupedSafety = evaluateSafetyCandidates(
+  { medications: ["Levothyroxine"] },
+  [{ name: "Magnesium Glycinate", dose: "210 mg", is_current: true }],
+  {
+    interactions,
+    rules: [{
+      rule_type: "SPACING",
+      entity_a_name: "Levothyroxine",
+      message: "Separate calcium, iron, and magnesium supplements by at least 4 hours.",
+    }],
+  },
+);
+const groupedSection = applySafetyEvaluationToMarkdown(report, groupedSafety);
+assert.equal((groupedSection.match(/Clinician review: Magnesium Glycinate:/g) ?? []).length, 1, "Distinct concerns for one item should render under one heading");
+assert.match(groupedSection, /thyroid medication by at least 4 hours/);
+assert.match(groupedSection, /calcium, iron, and magnesium supplements/);
+
 console.log("Safety engine assertions passed.");

--- a/src/lib/safetyEngine.ts
+++ b/src/lib/safetyEngine.ts
@@ -1,4 +1,4 @@
-import { healthItemIdentityKey } from "./healthItemIdentity.ts";
+import { canonicalHealthItemDisplayName, healthItemIdentityKey } from "./healthItemIdentity.ts";
 
 export type SafetySeverity = "info" | "warning" | "danger";
 export type SafetyDecision = "clear" | "review" | "blocked";
@@ -184,6 +184,12 @@ function comparableRuleUnit(unit?: string | null): string {
   return "";
 }
 
+function magnesiumDoseBasisIsExplicit(candidate: SafetyCandidate): boolean {
+  const identity = healthItemIdentityKey(candidate.name);
+  if (!identity.startsWith("magnesium-") || identity === "magnesium-unspecified") return true;
+  return /\belemental\b/i.test(String(candidate.dose ?? ""));
+}
+
 function worstDecision(findings: SafetyFinding[]): SafetyDecision {
   return findings.some((finding) => finding.decision === "blocked")
     ? "blocked"
@@ -322,7 +328,18 @@ export function evaluateSafetyCandidates(
         const max = Number(rule.max_daily_amount);
         const unit = comparableRuleUnit(rule.unit);
         if (dose && Number.isFinite(max) && unit && dose.unit === unit && dose.amount > max) {
-          addFinding(findings, finding("upper_limit", candidate.name, rule.message || `${candidate.name} exceeds the structured adult upper limit.`, "danger", "rules", rule.source_url));
+          if (!magnesiumDoseBasisIsExplicit(candidate)) {
+            addFinding(findings, finding(
+              "dose_basis_unclear",
+              candidate.name,
+              `The recorded ${candidate.dose} may describe the full compound rather than elemental magnesium. Check the Supplement Facts line for the elemental magnesium amount before comparing it with the supplemental upper limit.`,
+              "warning",
+              "rules",
+              rule.source_url,
+            ));
+          } else {
+            addFinding(findings, finding("upper_limit", candidate.name, rule.message || `${candidate.name} exceeds the structured adult upper limit.`, "danger", "rules", rule.source_url));
+          }
         }
       }
 
@@ -370,15 +387,22 @@ export function unavailableSafetyEvaluation(candidates: SafetyCandidate[], reaso
   };
 }
 
-function findingLabel(finding: SafetyFinding): string {
-  return finding.decision === "blocked" ? "Stop and review" : "Clinician review";
-}
-
 export function safetySectionFromEvaluation(evaluation: SafetyEvaluation): string {
   const uniqueFindings: SafetyFinding[] = [];
   for (const item of evaluation.findings) addFinding(uniqueFindings, item);
-  const bullets = uniqueFindings.length
-    ? uniqueFindings.map((item) => `- **${findingLabel(item)}: ${item.item}:** ${item.message}`)
+  const findingsByItem = new Map<string, SafetyFinding[]>();
+  for (const item of uniqueFindings) {
+    const key = healthItemIdentityKey(item.item) || normalize(item.item);
+    findingsByItem.set(key, [...(findingsByItem.get(key) ?? []), item]);
+  }
+  const bullets = findingsByItem.size
+    ? Array.from(findingsByItem.values()).map((items) => {
+      const decision = worstDecision(items);
+      const label = decision === "blocked" ? "Stop and review" : "Clinician review";
+      const name = canonicalHealthItemDisplayName(items[0].item);
+      const messages = Array.from(new Set(items.map((item) => item.message.trim()))).join(" ");
+      return `- **${label}: ${name}:** ${messages}`;
+    })
     : ["- **No material flags identified:** No specific interaction requiring action was identified from the reported information and structured rules. Recheck whenever medications, supplements, pregnancy status, conditions, or procedures change."];
   return [
     "## Contraindications & Med Interactions",


### PR DESCRIPTION
## What changed
- group multiple actionable findings for the same health item under one safety heading
- distinguish magnesium compound weight from explicitly elemental magnesium before applying the supplemental upper limit
- replace a false overdose-style stop with a clear request to verify the Supplement Facts elemental amount when dose basis is ambiguous
- preserve the stronger stop-and-review result when an explicitly elemental magnesium dose exceeds the structured limit

## Root cause
The safety renderer emitted one bullet per rule, so Magnesium Glycinate appeared repeatedly even when each line represented a different concern. The upper-limit evaluator also treated any recorded magnesium-form weight as elemental magnesium. A 2,000 mg Magnesium Threonate compound entry was therefore compared directly with the 350 mg supplemental magnesium limit.

## User impact
Safety notes now scan as one decision per item and avoid an unsupported high-severity warning when the recorded dose does not say it is elemental magnesium.

## Validation
- npm.cmd run qa:safety-engine
- npm.cmd run qa:blueprint-safety
- npm.cmd run typecheck
- git diff --check