### PR TITLE
PR90: Require measured elemental magnesium dose

### DIFF
--- a/src/_tests_/blueprintRefreshRecovery.assert.ts
+++ b/src/_tests_/blueprintRefreshRecovery.assert.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 
 import {
   BLUEPRINT_MIN_RECOMMENDATIONS,
@@ -8,6 +9,10 @@ import {
 
 assert.equal(BLUEPRINT_MIN_RECOMMENDATIONS, 5);
 assert.equal(BLUEPRINT_TARGET_RECOMMENDATIONS, 10);
+
+const workspaceSource = fs.readFileSync("src/lib/blueprintWorkspace.ts", "utf8");
+assert.match(workspaceSource, /BLUEPRINT_ENGINE_VERSION/);
+assert.match(workspaceSource, /blueprint_engine_version:\s*BLUEPRINT_ENGINE_VERSION/g);
 
 assert.equal(validateBlueprintRecommendationMix([
   "Current - optimize",

--- a/src/_tests_/safetyEngine.assert.ts
+++ b/src/_tests_/safetyEngine.assert.ts
@@ -96,7 +96,7 @@ const magnesiumUpperLimitRule = {
 };
 const ambiguousCompoundDose = evaluateSafetyCandidates(
   {},
-  [{ name: "Magnesium Threonate", dose: "2000 mg", is_current: true }],
+  [{ name: "Magnesium Threonate", dose: "2000mg compound weight; elemental amount not recorded", is_current: true }],
   { interactions: [], rules: [magnesiumUpperLimitRule] },
 );
 assert.equal(ambiguousCompoundDose.status, "review", "A magnesium compound weight must not be treated as an elemental overdose");

--- a/src/lib/blueprintWorkspace.ts
+++ b/src/lib/blueprintWorkspace.ts
@@ -14,6 +14,9 @@ import {
 
 export const MAX_MEMBER_SUPPLEMENTS = 30;
 export const MEMBER_SUPPLEMENT_OVERRIDE_KEY = "member_current_supplements";
+// Increment only when a report or safety-engine change requires members to
+// regenerate an otherwise unchanged Blueprint.
+export const BLUEPRINT_ENGINE_VERSION = "2026-08-09.3";
 
 export type MemberSupplement = {
   id: string;
@@ -162,8 +165,12 @@ export function blueprintInputSnapshotHash(
         payload_json: submission.payload_json ?? null,
       };
   const source = typeof canonicalRegimen === "undefined"
-    ? submissionSource
-    : { ...submissionSource, canonical_current_regimen: canonicalRegimen };
+    ? { ...submissionSource, blueprint_engine_version: BLUEPRINT_ENGINE_VERSION }
+    : {
+        ...submissionSource,
+        canonical_current_regimen: canonicalRegimen,
+        blueprint_engine_version: BLUEPRINT_ENGINE_VERSION,
+      };
   return createHash("sha256")
     .update(JSON.stringify(stableValue(source)))
     .digest("hex");

--- a/src/lib/safetyEngine.ts
+++ b/src/lib/safetyEngine.ts
@@ -187,7 +187,8 @@ function comparableRuleUnit(unit?: string | null): string {
 function magnesiumDoseBasisIsExplicit(candidate: SafetyCandidate): boolean {
   const identity = healthItemIdentityKey(candidate.name);
   if (!identity.startsWith("magnesium-") || identity === "magnesium-unspecified") return true;
-  return /\belemental\b/i.test(String(candidate.dose ?? ""));
+  const dose = String(candidate.dose ?? "");
+  return /(?:\b\d+(?:\.\d+)?\s*(?:mcg|mg|g)\s+(?:of\s+)?elemental(?:\s+magnesium)?\b|\belemental(?:\s+magnesium)?\s*:?\s*\d+(?:\.\d+)?\s*(?:mcg|mg|g)\b)/i.test(dose);
 }
 
 function worstDecision(findings: SafetyFinding[]): SafetyDecision {


### PR DESCRIPTION
## What changed
- require an actual elemental-magnesium quantity before treating a magnesium-form dose as comparable with the supplemental upper limit
- cover the exact production wording: 2000mg compound weight; elemental amount not recorded
- add a Blueprint engine version to the freshness hash so material report and safety fixes can regenerate unchanged health inputs

## Root cause
PR89 looked only for the word elemental. The phrase elemental amount not recorded therefore looked explicit even though it contains no elemental quantity, preserving the false Stop and review result. Production also reused the prior report whenever health inputs were unchanged, so engine fixes could not replace a dated result without a meaningless member edit.

## User impact
Ambiguous compound-weight entries now request Supplement Facts verification. Explicit values such as 400 mg elemental magnesium still receive the stronger upper-limit warning. When report logic materially changes, incrementing the engine version makes the existing Blueprint stale once and allows a real regeneration.

## Production evidence
Blueprint 46e864fd-5ea7-40c2-b713-a190b51e145e confirmed that refresh, persistence, warning consolidation, B12 classification, and malformed-item cleanup work. It also reproduced the exact dose-basis and engine-freshness edge cases fixed here.

## Validation
- npm.cmd run qa:pr80-refresh
- npm.cmd run qa:safety-engine
- npm.cmd run qa:blueprint-safety
- npm.cmd run typecheck
- git diff --check