### PR TITLE
PR94: Make Today progress motivating

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -22,7 +22,6 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { BlueprintActionCandidate } from "@/lib/blueprintActions";
 import type { MemberSupplement } from "@/lib/blueprintWorkspace";
 import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
@@ -64,7 +63,6 @@ type RecommendationSummary = {
 type Props = {
   stack: StackSummary;
   sections: Array<{ name: string; body: string }>;
-  actions: BlueprintActionCandidate[];
   recommendations: RecommendationSummary[];
   initialSupplements: MemberSupplement[];
   hasMemberOverride: boolean;
@@ -77,7 +75,6 @@ type Props = {
 export default function BlueprintWorkspaceClient({
   stack,
   sections,
-  actions,
   recommendations,
   initialSupplements,
   hasMemberOverride,
@@ -96,7 +93,6 @@ export default function BlueprintWorkspaceClient({
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshIssue, setRefreshIssue] = useState<string | null>(null);
-  const [handoffId, setHandoffId] = useState<string | null>(null);
   const [safetyAcknowledged, setSafetyAcknowledged] = useState(Boolean(stack.safetyAcknowledgedAt));
   const [acknowledgingSafety, setAcknowledgingSafety] = useState(false);
   const [recommendationItems, setRecommendationItems] = useState(recommendations);
@@ -199,27 +195,6 @@ export default function BlueprintWorkspaceClient({
           : "We could not create an updated version right now. Your saved changes and current Blueprint are still available. This is a service issue, so there is nothing you need to correct. Please try again in a few minutes."
       );
       setRefreshing(false);
-    }
-  }
-
-  async function startWeeklyPractice(actionId: string) {
-    setHandoffId(actionId);
-    setError(null);
-    try {
-      const response = await fetch("/api/blueprint-action", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ stack_id: stack.id, action_id: actionId }),
-      });
-      const data = await response.json().catch(() => null);
-      if (!response.ok || !data?.ok) {
-        throw new Error("We could not start that practice. Please try again.");
-      }
-      trackProductEvent({ event_name: "blueprint_action_selected", source: "blueprints" });
-      window.location.assign("/onboarding");
-    } catch (actionError) {
-      setError(actionError instanceof Error ? actionError.message : "We could not start that practice.");
-      setHandoffId(null);
     }
   }
 
@@ -453,37 +428,6 @@ export default function BlueprintWorkspaceClient({
               <SupplementList supplements={supplements} />
             )}
           </section>
-
-          {actions.length > 0 ? (
-            <section className="rounded-2xl border border-[#9DCFC3] bg-gradient-to-r from-[#EFF5FA] to-[#E6F7F3] p-6 shadow-sm">
-              <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#122945]">Turn insight into practice</p>
-              <h2 className="mt-1 text-2xl font-bold text-[#041B2D]">Choose one focus for this week</h2>
-              <p className="mt-2 text-sm leading-6 text-slate-600">
-                Lifestyle actions can enter your weekly practice. Supplement or medication changes remain review-only.
-              </p>
-              <ol className="mt-5 grid gap-3 sm:grid-cols-2">
-                {actions.map((action, index) => (
-                  <li key={action.id} className="flex flex-col rounded-xl bg-white p-4 shadow-sm">
-                    <p className="text-sm leading-6 text-slate-800"><strong>{index + 1}.</strong> {action.label}</p>
-                    {action.kind === "lifestyle" ? (
-                      <button
-                        type="button"
-                        onClick={() => startWeeklyPractice(action.id)}
-                        disabled={handoffId !== null}
-                        className="mt-auto pt-4 text-left text-sm font-bold text-[#087F72] hover:underline disabled:opacity-50"
-                      >
-                        {handoffId === action.id ? "Saving..." : "Start this weekly practice"}
-                      </button>
-                    ) : (
-                      <a href="#recommendation-decisions" className="mt-auto pt-4 text-sm font-bold text-amber-800 underline decoration-amber-300 underline-offset-2 hover:decoration-amber-700">
-                        Review why this appeared
-                      </a>
-                    )}
-                  </li>
-                ))}
-              </ol>
-            </section>
-          ) : null}
 
           <RecommendationDecisionPanel
             items={recommendationItems}

--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation";
 
 import { requireTier } from "@/app/_auth/requireTier";
-import { buildBlueprintActionCandidates } from "@/lib/blueprintActions";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
 import {
   blueprintMarkdownFromStack,
@@ -101,7 +100,6 @@ export default async function BlueprintPage({ params }: PageProps) {
       sections={Object.entries(report.sections)
         .filter(([, body]) => Boolean(body.trim()))
         .map(([name, body]) => ({ name, body }))}
-      actions={buildBlueprintActionCandidates(report)}
       recommendations={recommendations}
       initialSupplements={supplements}
       hasMemberOverride={hasOverride}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "qa:pr86": "node --experimental-strip-types src/_tests_/pr86HealthItemIntegrity.assert.ts",
     "qa:pr91": "node src/_tests_/pr91BlueprintWorkspace.assert.mjs",
     "qa:pr93": "node src/_tests_/pr93BlueprintNavigation.assert.mjs",
+    "qa:pr94": "node src/_tests_/pr94TodayMomentum.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr94TodayMomentum.assert.mjs
+++ b/src/_tests_/pr94TodayMomentum.assert.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const blueprint = readFileSync("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx", "utf8");
+const today = readFileSync("src/components/dashboard/TodayExperience.tsx", "utf8");
+
+assert.doesNotMatch(blueprint, /Choose one focus for this week/);
+assert.doesNotMatch(blueprint, /Start this weekly practice/);
+assert.match(today, /Weekly practice momentum/);
+assert.match(today, /Weekly promise kept/);
+assert.match(today, /Your first small win starts the momentum/);
+assert.match(today, /minimum version counts/);
+assert.match(today, /planned reps/);
+
+console.log("PR94 Today momentum assertions passed.");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -149,7 +149,8 @@ export default function TodayExperience({
 
   const target = experiment.frequency_per_week ?? 1;
   const recordingPastDate = !!initialCompletionDate && initialCompletionDate !== toLocalDate(new Date());
-  const targetMet = completedCount >= target;
+  const progressPercent = Math.min(100, Math.round((completedCount / target) * 100));
+  const momentumMessage = weeklyMomentumMessage(completedCount, target);
   const reviewDue = !!localDate && isReviewDue(experiment.week_start, localDate);
   const weekEnded = !!localDate && localDate > reviewDueDate(experiment.week_start);
   const weekNotStarted = !!localDate && localDate < experiment.week_start;
@@ -270,7 +271,10 @@ export default function TodayExperience({
               <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">This week</p>
               <p className="mt-1 text-lg font-bold text-[#041B2D]">{completedCount} of {target} planned reps</p>
             </div>
-            <p className="text-sm text-slate-600">{targetMet ? "Weekly target met. Extra reps are optional." : "Small repetitions compound."}</p>
+            <p className="text-sm font-medium text-slate-600">{momentumMessage}</p>
+          </div>
+          <div className="mt-4 h-3 overflow-hidden rounded-full bg-slate-100" role="progressbar" aria-label="Weekly practice momentum" aria-valuemin={0} aria-valuemax={target} aria-valuenow={Math.min(completedCount, target)}>
+            <div className="h-full rounded-full bg-gradient-to-r from-[#08A88A] to-[#58CDB8] transition-[width] duration-500" style={{ width: `${progressPercent}%` }} />
           </div>
           <div className="mt-4 grid grid-cols-7 gap-2" aria-label={`${completedCount} weekly completions`}>
             {weekDays.map((day) => {
@@ -291,6 +295,14 @@ export default function TodayExperience({
       </div>
     </section>
   );
+}
+
+function weeklyMomentumMessage(completed: number, target: number): string {
+  if (completed >= target) return "Weekly promise kept. Anything extra is a bonus.";
+  if (completed === 0) return "Your first small win starts the momentum.";
+  if (completed === 1) return "Momentum started. Repeat when your cue appears.";
+  const remaining = target - completed;
+  return `${remaining} ${remaining === 1 ? "repetition" : "repetitions"} left to keep this week's promise.`;
 }
 
 function CurrentBlueprintPanel({


### PR DESCRIPTION
## What changed

- removed the nonfunctional weekly-practice selector from the long-term Blueprint workspace
- added a truthful weekly momentum bar to Today using saved practice completions
- added encouraging milestone copy for the first repetition, continued momentum, and keeping the weekly promise
- preserved the minimum version as a valid completion and the weekly review as the place to keep, shrink, swap, pause, or advance a practice

## Why

Blueprint should explain long-term direction, priorities, evidence, and safety. Weekly practice belongs in the weekly behavior loop, while Today should make the next small action clear and rewarding. This creates an Atomic Habits-aligned loop without arbitrary points, punitive streaks, or guilt.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run qa:pr91`
- `npm.cmd run qa:pr93`
- `npm.cmd run qa:pr94`
- Next.js production compilation succeeds; local page-data collection stops because `OPENAI_API_KEY` is not present in this checkout
