### PR TITLE
PR95: Restore weekly practice control

### DIFF
--- a/app/api/activation/route.ts
+++ b/app/api/activation/route.ts
@@ -14,7 +14,7 @@ import { resolveBlueprintActionFromRequest } from "@/lib/blueprintActionHandoff"
 import { isHour, isIanaTimeZone } from "@/lib/accountSettings";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
-import { isReminderTiming } from "@/lib/reminderSchedule";
+import { isQuietHour, isReminderTiming } from "@/lib/reminderSchedule";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -125,8 +125,24 @@ export async function GET(req: NextRequest) {
   try {
     const auth = await requirePaidUser();
     if (auth.error || !auth.user) return responseForAuthError(auth.error ?? "unauthorized");
-    const experiment = await getOrCreateExperiment(req, auth.user.id);
-    return NextResponse.json({ ok: true, experiment });
+    const [experiment, { data: preferences, error: preferencesError }] = await Promise.all([
+      getOrCreateExperiment(req, auth.user.id),
+      getSupabaseAdmin()
+        .from("user_preferences")
+        .select("timezone, quiet_start_hour, quiet_end_hour")
+        .eq("user_id", auth.user.id)
+        .maybeSingle(),
+    ]);
+    if (preferencesError) throw preferencesError;
+    return NextResponse.json({
+      ok: true,
+      experiment,
+      reminder_context: {
+        timezone: preferences?.timezone ?? "UTC",
+        quiet_start_hour: preferences?.quiet_start_hour ?? 21,
+        quiet_end_hour: preferences?.quiet_end_hour ?? 7,
+      },
+    });
   } catch (error) {
     console.error("[activation] load failed", error);
     return NextResponse.json({ ok: false, error: "activation_unavailable" }, { status: 500 });
@@ -144,7 +160,7 @@ export async function PUT(req: NextRequest) {
     }
 
     const experiment = await getOrCreateExperiment(req, auth.user.id);
-    if (experiment.status === "active" && step !== 5) {
+    if (experiment.status === "active" && step === 6) {
       return NextResponse.json({ ok: true, experiment });
     }
 
@@ -203,6 +219,19 @@ export async function PUT(req: NextRequest) {
         && (!isIanaTimeZone(body.timezone) || (usesPracticeHour && !isHour(body.reminder_hour)))
       ) {
         return NextResponse.json({ ok: false, error: "choose_reminder_time" }, { status: 400 });
+      }
+      if (usesPracticeHour) {
+        const { data: preferences, error: preferencesError } = await getSupabaseAdmin()
+          .from("user_preferences")
+          .select("quiet_start_hour, quiet_end_hour")
+          .eq("user_id", auth.user.id)
+          .maybeSingle();
+        if (preferencesError) throw preferencesError;
+        const quietStartHour = preferences?.quiet_start_hour ?? 21;
+        const quietEndHour = preferences?.quiet_end_hour ?? 7;
+        if (isQuietHour(Number(body.reminder_hour), quietStartHour, quietEndHour)) {
+          return NextResponse.json({ ok: false, error: "reminder_in_quiet_hours" }, { status: 400 });
+        }
       }
       changes.reminder_preference = body.reminder_preference;
       changes.reminder_timing = body.reminder_timing;

--- a/app/onboarding/OnboardingHandoffClient.tsx
+++ b/app/onboarding/OnboardingHandoffClient.tsx
@@ -12,7 +12,7 @@ import {
   type ReminderPreference,
   type WeeklyExperiment,
 } from "@/lib/activation";
-import type { ReminderTiming } from "@/lib/reminderSchedule";
+import { isQuietHour, type ReminderTiming } from "@/lib/reminderSchedule";
 
 type FormState = {
   identity_direction: IdentityDirection | null;
@@ -24,6 +24,12 @@ type FormState = {
   reminder_timing: ReminderTiming;
   reminder_hour: number;
   timezone: string;
+};
+
+type ReminderContext = {
+  timezone: string;
+  quiet_start_hour: number;
+  quiet_end_hour: number;
 };
 
 const EMPTY_FORM: FormState = {
@@ -45,20 +51,27 @@ export default function OnboardingHandoffClient() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reminderContext, setReminderContext] = useState<ReminderContext>({
+    timezone: "UTC",
+    quiet_start_hour: 21,
+    quiet_end_hour: 7,
+  });
 
   useEffect(() => {
     let cancelled = false;
     fetch("/api/activation", { cache: "no-store" })
       .then(async (response) => {
         const json = await response.json().catch(() => null);
-        if (!response.ok || !json?.experiment) throw new Error("We could not load your first-week setup.");
-        return json.experiment as WeeklyExperiment;
+        if (!response.ok || !json?.experiment) throw new Error("We could not load your weekly setup.");
+        return json as { experiment: WeeklyExperiment; reminder_context?: ReminderContext };
       })
-      .then((loaded) => {
+      .then(({ experiment: loaded, reminder_context }) => {
         if (cancelled) return;
         setExperiment(loaded);
-        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        setForm({ ...formFromExperiment(loaded), timezone: timezone || "UTC" });
+        const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const context = reminder_context ?? { timezone: detectedTimezone || "UTC", quiet_start_hour: 21, quiet_end_hour: 7 };
+        setReminderContext(context);
+        setForm({ ...formFromExperiment(loaded), timezone: context.timezone || detectedTimezone || "UTC" });
         setStep(nextOnboardingStep(loaded));
       })
       .catch((loadError) => { if (!cancelled) setError(loadError?.message ?? "Setup is unavailable."); })
@@ -126,15 +139,17 @@ export default function OnboardingHandoffClient() {
           timing={form.reminder_timing}
           reminderHour={form.reminder_hour}
           timezone={form.timezone}
+          quietStartHour={reminderContext.quiet_start_hour}
+          quietEndHour={reminderContext.quiet_end_hour}
           onChange={(changes) => setForm({ ...form, ...changes })}
         />
       )}
-      {step === 6 && <ConfirmationStep form={form} active={active} onEditReminders={() => setStep(5)} />}
+      {step === 6 && <ConfirmationStep form={form} active={active} onEditPlan={() => setStep(1)} onEditReminders={() => setStep(5)} />}
 
       {error && <p className="mt-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">{error}</p>}
 
       <div className="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-        {!active && step > 1 ? (
+        {step > 1 && !(active && step === 6) ? (
           <button type="button" onClick={() => { setError(null); setStep(step - 1); }} className="inline-flex items-center justify-center rounded-xl px-4 py-3 font-semibold text-slate-600 hover:bg-slate-100">
             <ArrowLeft className="mr-2 h-4 w-4" /> Back
           </button>
@@ -181,12 +196,16 @@ function ReminderStep({
   timing,
   reminderHour,
   timezone,
+  quietStartHour,
+  quietEndHour,
   onChange,
 }: {
   preference: ReminderPreference;
   timing: ReminderTiming;
   reminderHour: number;
   timezone: string;
+  quietStartHour: number;
+  quietEndHour: number;
   onChange: (changes: Partial<Pick<FormState, "reminder_preference" | "reminder_timing" | "reminder_hour">>) => void;
 }) {
   const options: Array<{
@@ -220,11 +239,11 @@ function ReminderStep({
         <label className="mt-5 block text-sm font-bold text-[#041B2D]">
           {timing === "next_day" ? "Check in around" : timing === "prepare_before" ? "Help me prepare around" : "Send at"}
           <select value={reminderHour} onChange={(event) => onChange({ reminder_hour: Number(event.target.value) })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal">
-            {Array.from({ length: 14 }, (_, index) => index + 7).map((hour) => (
+            {Array.from({ length: 24 }, (_, hour) => hour).filter((hour) => !isQuietHour(hour, quietStartHour, quietEndHour)).map((hour) => (
               <option key={hour} value={hour}>{new Intl.DateTimeFormat("en-US", { hour: "numeric", timeZone: "UTC" }).format(new Date(Date.UTC(2026, 0, 1, hour)))}</option>
             ))}
           </select>
-          <span className="mt-2 block font-normal text-slate-500">Local time in {timezone}. We keep emails outside your 9 PM through 7 AM quiet window.</span>
+          <span className="mt-2 block font-normal text-slate-500">Local time in {timezone}. Your quiet hours are {formatHour(quietStartHour)} to {formatHour(quietEndHour)}.</span>
         </label>
       )}
       {preference === "email" && timing === "account_default" ? <p className="mt-5 rounded-xl bg-slate-50 p-4 text-sm text-slate-600">This existing practice uses your account default time. Choose another option above to tailor it.</p> : null}
@@ -232,8 +251,8 @@ function ReminderStep({
   );
 }
 
-function ConfirmationStep({ form, active, onEditReminders }: { form: FormState; active: boolean; onEditReminders: () => void }) {
-  return <section><CheckCircle2 className="h-10 w-10 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">{active ? "Your week is active" : "Your first week is ready"}</h1><p className="mt-3 leading-7 text-slate-600">This is one vote for the person you are becoming. Keep it small, notice what works, and review after the week.</p><div className="mt-6 space-y-4 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5"><Summary label="Identity" value={identityLabel(form.identity_direction)} /><Summary label="This week I will" value={form.action_label} /><Summary label="My cue" value={`After I ${form.cue}`} /><Summary label="Target" value={`${form.frequency_per_week} ${form.frequency_per_week === 1 ? "day" : "days"} this week`} /><Summary label="On a hard day" value={form.minimum_version} /><Summary label="Reminder plan" value={reminderSummary(form)} /></div>{active ? <button type="button" onClick={onEditReminders} className="mt-5 min-h-11 rounded-xl border border-[#9DCFC3] px-4 py-2 font-bold text-[#087F72] hover:bg-[#EAFBF8]">Change reminder plan</button> : null}</section>;
+function ConfirmationStep({ form, active, onEditPlan, onEditReminders }: { form: FormState; active: boolean; onEditPlan: () => void; onEditReminders: () => void }) {
+  return <section><CheckCircle2 className="h-10 w-10 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">{active ? "Your week is active" : "Your first week is ready"}</h1><p className="mt-3 leading-7 text-slate-600">Use this plan while it fits your life. You can change it when your schedule or priorities change.</p><div className="mt-6 space-y-4 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5"><Summary label="This week's direction" value={identityLabel(form.identity_direction)} /><Summary label="This week I will" value={form.action_label} /><Summary label="My cue" value={`After I ${form.cue}`} /><Summary label="Target" value={`${form.frequency_per_week} ${form.frequency_per_week === 1 ? "day" : "days"} this week`} /><Summary label="On a hard day" value={form.minimum_version} /><Summary label="Reminder plan" value={reminderSummary(form)} /></div>{active ? <div className="mt-5 flex flex-wrap gap-3"><button type="button" onClick={onEditPlan} className="min-h-11 rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F]">Edit weekly plan</button><button type="button" onClick={onEditReminders} className="min-h-11 rounded-xl border border-[#9DCFC3] px-4 py-2 font-bold text-[#087F72] hover:bg-[#EAFBF8]">Change reminder plan</button></div> : null}</section>;
 }
 
 function Summary({ label, value }: { label: string; value: string }) {
@@ -276,6 +295,7 @@ function errorMessage(code: string | undefined) {
   if (code === "add_safe_minimum_version") return "Add a small lifestyle version that can count on a hard day.";
   if (code === "choose_reminder_timing") return "Choose when reminder support would be useful for this practice.";
   if (code === "choose_reminder_time") return "Choose a valid local reminder time.";
+  if (code === "reminder_in_quiet_hours") return "Choose a reminder time outside the quiet hours saved in Settings.";
   if (code === "complete_required_steps") return "One of the earlier steps is incomplete. Go back and review your plan.";
   return "We could not save that step. Please try again.";
 }
@@ -288,4 +308,9 @@ function reminderSummary(form: FormState): string {
   if (form.reminder_timing === "prepare_before") return `Prepare beforehand around ${time}`;
   if (form.reminder_timing === "next_day") return `Check in the next morning around ${time}`;
   return `Remind me at the cue around ${time}`;
+}
+
+function formatHour(hour: number): string {
+  return new Intl.DateTimeFormat("en-US", { hour: "numeric", timeZone: "UTC" })
+    .format(new Date(Date.UTC(2026, 0, 1, hour)));
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "qa:pr91": "node src/_tests_/pr91BlueprintWorkspace.assert.mjs",
     "qa:pr93": "node src/_tests_/pr93BlueprintNavigation.assert.mjs",
     "qa:pr94": "node src/_tests_/pr94TodayMomentum.assert.mjs",
+    "qa:pr95": "node src/_tests_/pr95WeeklyPracticeControl.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr95WeeklyPracticeControl.assert.mjs
+++ b/src/_tests_/pr95WeeklyPracticeControl.assert.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const activationRoute = readFileSync("app/api/activation/route.ts", "utf8");
+const onboarding = readFileSync("app/onboarding/OnboardingHandoffClient.tsx", "utf8");
+
+assert.match(activationRoute, /quiet_start_hour, quiet_end_hour/);
+assert.match(activationRoute, /experiment\.status === "active" && step === 6/);
+assert.match(activationRoute, /reminder_in_quiet_hours/);
+assert.doesNotMatch(activationRoute, /experiment\.status === "active" && step !== 5/);
+
+assert.match(onboarding, /Array\.from\(\{ length: 24 \}/);
+assert.match(onboarding, /filter\(\(hour\) => !isQuietHour/);
+assert.match(onboarding, /Your quiet hours are \{formatHour\(quietStartHour\)\} to \{formatHour\(quietEndHour\)\}/);
+assert.doesNotMatch(onboarding, /9 PM through 7 AM quiet window/);
+assert.match(onboarding, /Edit weekly plan/);
+assert.match(onboarding, /This week's direction/);
+assert.doesNotMatch(onboarding, /This is one vote for the person you are becoming/);
+
+console.log("PR95 weekly practice control assertions passed.");


### PR DESCRIPTION
## What changed

- load the member's current timezone and quiet hours into the weekly-practice editor
- offer all 24 reminder hours except hours inside the member's saved quiet window
- validate quiet hours again on the server before saving a practice reminder
- allow an active week's identity direction, practice, cue, target, minimum version, and reminder plan to be edited
- replace the vague identity-gamification sentence with practical language about adapting the weekly plan
- rename the summary label from permanent-sounding `Identity` to `This week's direction`

## Root cause

The onboarding client hardcoded a 9 PM–7 AM quiet window and only rendered reminder choices from 7 AM through 8 PM. Separately, the activation API silently returned an unchanged active experiment for every edit step except reminders. Those two behaviors made updated account settings appear stale and made the original identity impossible to change.

## User impact

A member with quiet hours ending at 5 AM can select a 5 AM reminder. Members can also revise the weekly direction and practice when their goals or schedule change, instead of being trapped by their initial onboarding choices.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run qa:reminders`
- `npm.cmd run qa:pr75`
- `npm.cmd run qa:pr94`
- `npm.cmd run qa:pr95`
