### PR TITLE
PR96: Make weekly progress meaningful

### DIFF
--- a/app/onboarding/OnboardingHandoffClient.tsx
+++ b/app/onboarding/OnboardingHandoffClient.tsx
@@ -118,8 +118,8 @@ export default function OnboardingHandoffClient() {
     <Shell>
       <div className="mb-8 flex items-center justify-between gap-4">
         <div>
-          <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">Your first week</p>
-          <p className="mt-1 text-sm text-slate-500">About three minutes</p>
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]">{active ? "Your weekly practice" : "Your first weekly practice"}</p>
+          <p className="mt-1 text-sm text-slate-500">{active ? "Update what needs to change" : "About three minutes"}</p>
         </div>
         <div className="text-right">
           <p className="text-sm font-semibold text-[#041B2D]">{active && step === 6 ? "Ready" : `Step ${step} of 6`}</p>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "qa:pr93": "node src/_tests_/pr93BlueprintNavigation.assert.mjs",
     "qa:pr94": "node src/_tests_/pr94TodayMomentum.assert.mjs",
     "qa:pr95": "node src/_tests_/pr95WeeklyPracticeControl.assert.mjs",
+    "qa:pr96": "node --experimental-strip-types src/_tests_/today.assert.ts && node src/_tests_/pr96MeaningfulEngagement.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr94TodayMomentum.assert.mjs
+++ b/src/_tests_/pr94TodayMomentum.assert.mjs
@@ -7,9 +7,9 @@ const today = readFileSync("src/components/dashboard/TodayExperience.tsx", "utf8
 assert.doesNotMatch(blueprint, /Choose one focus for this week/);
 assert.doesNotMatch(blueprint, /Start this weekly practice/);
 assert.match(today, /Weekly practice momentum/);
-assert.match(today, /Weekly promise kept/);
-assert.match(today, /Your first small win starts the momentum/);
-assert.match(today, /minimum version counts/);
-assert.match(today, /planned reps/);
+assert.match(today, /Weekly promise/);
+assert.match(today, /weeklyMomentum/);
+assert.match(today, /Minimum version complete/);
+assert.match(today, /planned repetitions/);
 
 console.log("PR94 Today momentum assertions passed.");

--- a/src/_tests_/pr96MeaningfulEngagement.assert.mjs
+++ b/src/_tests_/pr96MeaningfulEngagement.assert.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const today = readFileSync("src/components/dashboard/TodayExperience.tsx", "utf8");
+const onboarding = readFileSync("app/onboarding/OnboardingHandoffClient.tsx", "utf8");
+
+assert.match(today, /Weekly promise/);
+assert.match(today, /Minimum version complete/);
+assert.match(today, /You came back today/);
+assert.match(today, /Returning after a gap is a consistency win/);
+assert.match(today, /This week&apos;s direction/);
+assert.doesNotMatch(today, /moved your identity forward/);
+
+assert.match(onboarding, /Your weekly practice/);
+assert.match(onboarding, /Your first weekly practice/);
+assert.doesNotMatch(onboarding, />Your first week</);
+
+console.log("PR96 meaningful engagement assertions passed.");

--- a/src/_tests_/today.assert.ts
+++ b/src/_tests_/today.assert.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { completionCount, isCompletionKind, parseLocalDate, weekBounds } from "../lib/today";
+import { completionCount, isCompletionKind, parseLocalDate, returnedAfterGap, weeklyMomentum, weekBounds } from "../lib/today.ts";
 
 const now = new Date("2026-07-21T23:30:00.000Z");
 
@@ -29,5 +29,23 @@ assert.equal(completionCount([
   { completion_date: "2026-07-20", completion_kind: "full" },
   { completion_date: "2026-07-21", completion_kind: "full" },
 ]), 2);
+
+assert.deepEqual(weeklyMomentum(0, 5), {
+  stage: "ready",
+  label: "Ready",
+  message: "Complete the full or minimum version when your cue appears.",
+  remaining: 5,
+});
+assert.equal(weeklyMomentum(2, 5).stage, "building");
+assert.equal(weeklyMomentum(5, 5).stage, "kept");
+
+assert.equal(returnedAfterGap("2026-07-23", [
+  { completion_date: "2026-07-20", completion_kind: "full" },
+  { completion_date: "2026-07-23", completion_kind: "minimum" },
+]), true);
+assert.equal(returnedAfterGap("2026-07-21", [
+  { completion_date: "2026-07-20", completion_kind: "full" },
+  { completion_date: "2026-07-21", completion_kind: "full" },
+]), false);
 
 console.log("today assertions passed");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -7,13 +7,14 @@ import {
   Check,
   CheckCircle2,
   Circle,
+  Goal,
   Loader2,
   RotateCcw,
   Sparkles,
 } from "lucide-react";
 
 import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
-import type { CompletionKind, DailyPracticeCompletion } from "@/lib/today";
+import { returnedAfterGap, weeklyMomentum, type CompletionKind, type DailyPracticeCompletion } from "@/lib/today";
 import { isReviewDue, reviewDueDate } from "@/lib/weeklyReview";
 import {
   blueprintSafetyLabel,
@@ -150,7 +151,8 @@ export default function TodayExperience({
   const target = experiment.frequency_per_week ?? 1;
   const recordingPastDate = !!initialCompletionDate && initialCompletionDate !== toLocalDate(new Date());
   const progressPercent = Math.min(100, Math.round((completedCount / target) * 100));
-  const momentumMessage = weeklyMomentumMessage(completedCount, target);
+  const momentum = weeklyMomentum(completedCount, target);
+  const returnWin = !!localDate && returnedAfterGap(localDate, completions);
   const reviewDue = !!localDate && isReviewDue(experiment.week_start, localDate);
   const weekEnded = !!localDate && localDate > reviewDueDate(experiment.week_start);
   const weekNotStarted = !!localDate && localDate < experiment.week_start;
@@ -204,7 +206,7 @@ export default function TodayExperience({
         <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-2xl">
             <p className="flex items-center gap-2 text-sm font-semibold text-[#087F72]">
-              <Sparkles className="h-4 w-4" /> {identityLabel(experiment.identity_direction)}
+              <Sparkles className="h-4 w-4" /> This week&apos;s direction: {identityLabel(experiment.identity_direction)}
             </p>
             <h2 className="mt-3 text-3xl font-bold leading-tight text-[#041B2D] sm:text-4xl">{experiment.action_label}</h2>
             <p className="mt-4 text-base leading-7 text-slate-600">
@@ -236,9 +238,17 @@ export default function TodayExperience({
                 <CheckCircle2 className="mt-0.5 h-6 w-6 shrink-0 text-[#087F72]" />
                 <div>
                   <p className="font-bold text-[#041B2D]">
-                    {todayCompletion.completion_kind === "minimum" ? "Your minimum version counts." : recordingPastDate ? "That practice is recorded." : "Today's practice is complete."}
+                    {todayCompletion.completion_kind === "minimum" ? "Minimum version complete." : recordingPastDate ? "That practice is recorded." : returnWin ? "You came back today." : "Full version complete."}
                   </p>
-                  <p className="mt-1 text-sm text-slate-600">You kept the promise small and moved your identity forward.</p>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {todayCompletion.completion_kind === "minimum"
+                      ? "You protected the routine on a hard day. That repetition counts fully toward this week's plan."
+                      : returnWin
+                        ? "Returning after a gap is a consistency win. Your progress continues from here."
+                        : completedCount >= target
+                          ? "This completion kept your weekly promise. Extra repetitions are optional."
+                          : `Repetition ${completedCount} of ${target} is recorded for this week.`}
+                  </p>
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
@@ -265,17 +275,21 @@ export default function TodayExperience({
           {error ? <p className="mt-3 text-sm font-medium text-rose-700">{error}</p> : null}
         </div>
 
-        <div className="mt-8 border-t border-slate-200 pt-6">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-5 sm:p-6" aria-live="polite">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">This week</p>
-              <p className="mt-1 text-lg font-bold text-[#041B2D]">{completedCount} of {target} planned reps</p>
+              <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]"><Goal className="h-4 w-4" /> Weekly promise</p>
+              <p className="mt-2 text-2xl font-bold text-[#041B2D]">{completedCount} of {target}</p>
+              <p className="mt-1 text-sm text-slate-600">planned repetitions completed</p>
             </div>
-            <p className="text-sm font-medium text-slate-600">{momentumMessage}</p>
+            <div className={`w-fit rounded-full px-3 py-1.5 text-xs font-bold ${momentum.stage === "kept" ? "bg-emerald-100 text-emerald-800" : momentum.stage === "building" ? "bg-teal-100 text-teal-800" : "bg-white text-slate-700 ring-1 ring-slate-200"}`}>
+              {momentum.label}
+            </div>
           </div>
           <div className="mt-4 h-3 overflow-hidden rounded-full bg-slate-100" role="progressbar" aria-label="Weekly practice momentum" aria-valuemin={0} aria-valuemax={target} aria-valuenow={Math.min(completedCount, target)}>
             <div className="h-full rounded-full bg-gradient-to-r from-[#08A88A] to-[#58CDB8] transition-[width] duration-500" style={{ width: `${progressPercent}%` }} />
           </div>
+          <p className="mt-3 text-sm font-medium leading-6 text-slate-700">{momentum.message}</p>
           <div className="mt-4 grid grid-cols-7 gap-2" aria-label={`${completedCount} weekly completions`}>
             {weekDays.map((day) => {
               const completion = completions.find((item) => item.completion_date === day);
@@ -295,14 +309,6 @@ export default function TodayExperience({
       </div>
     </section>
   );
-}
-
-function weeklyMomentumMessage(completed: number, target: number): string {
-  if (completed >= target) return "Weekly promise kept. Anything extra is a bonus.";
-  if (completed === 0) return "Your first small win starts the momentum.";
-  if (completed === 1) return "Momentum started. Repeat when your cue appears.";
-  const remaining = target - completed;
-  return `${remaining} ${remaining === 1 ? "repetition" : "repetitions"} left to keep this week's promise.`;
 }
 
 function CurrentBlueprintPanel({

--- a/src/lib/today.ts
+++ b/src/lib/today.ts
@@ -5,6 +5,13 @@ export type DailyPracticeCompletion = {
   completion_kind: CompletionKind;
 };
 
+export type WeeklyMomentum = {
+  stage: "ready" | "building" | "kept";
+  label: string;
+  message: string;
+  remaining: number;
+};
+
 const LOCAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DAY_MS = 86_400_000;
 
@@ -34,4 +41,35 @@ export function weekBounds(localDate: string): { start: string; end: string; day
 
 export function completionCount(completions: DailyPracticeCompletion[]): number {
   return new Set(completions.map((completion) => completion.completion_date)).size;
+}
+
+export function weeklyMomentum(completed: number, target: number): WeeklyMomentum {
+  const safeTarget = Math.max(1, target);
+  const safeCompleted = Math.max(0, completed);
+  const remaining = Math.max(0, safeTarget - safeCompleted);
+  if (remaining === 0) {
+    return { stage: "kept", label: "Promise kept", message: "You completed the weekly practice you planned. Extra repetitions are optional.", remaining };
+  }
+  if (safeCompleted === 0) {
+    return { stage: "ready", label: "Ready", message: "Complete the full or minimum version when your cue appears.", remaining };
+  }
+  return {
+    stage: "building",
+    label: "Building consistency",
+    message: `${remaining} ${remaining === 1 ? "repetition" : "repetitions"} remaining in this week's plan.`,
+    remaining,
+  };
+}
+
+export function returnedAfterGap(localDate: string, completions: DailyPracticeCompletion[]): boolean {
+  if (!completions.some((completion) => completion.completion_date === localDate)) return false;
+  const earlier = completions
+    .map((completion) => completion.completion_date)
+    .filter((date) => date < localDate)
+    .sort();
+  const previous = earlier.at(-1);
+  if (!previous) return false;
+  const previousTime = new Date(`${previous}T12:00:00.000Z`).getTime();
+  const currentTime = new Date(`${localDate}T12:00:00.000Z`).getTime();
+  return currentTime - previousTime > DAY_MS;
 }


### PR DESCRIPTION
## What changed

- replace the decorative Today progress treatment with meaningful weekly states: Ready, Building consistency, and Promise kept
- give specific feedback for a full completion, a minimum-version completion, and returning after a gap
- make clear that the minimum version counts fully toward the weekly plan
- show the exact remaining repetitions and preserve the seven-day completion history
- describe identity as this week's direction rather than a permanent trait
- show returning members `Your weekly practice` instead of `Your first week`

## Why

The first gamification pass mostly added a progress bar and generic encouragement. It did not explain what the member accomplished or help them recover after an imperfect week. This version rewards real behavior and useful resilience without points, punitive streaks, or guilt.

## User impact

Members can see what counts today, what changed after they record it, how close they are to their chosen weekly plan, and why returning after a gap still matters. Returning members also receive language appropriate to their actual stage.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run qa:pr94`
- `npm.cmd run qa:pr95`
- `npm.cmd run qa:pr96`
