### PR TITLE
PR97 — Focus Today on personalized momentum

### DIFF
--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -112,8 +112,19 @@ export default function RoutineClient({
   }, [toast]);
 
   useEffect(() => {
-    if (window.location.hash === "#routine-ideas") setActiveView("supplements");
-  }, []);
+    const hash = window.location.hash;
+    if (hash === "#routine-ideas") {
+      setActiveView("supplements");
+      return;
+    }
+    const prefix = "#edit-routine-item-";
+    if (!hash.startsWith(prefix)) return;
+    const itemId = decodeURIComponent(hash.slice(prefix.length));
+    const item = initialItems.find((candidate) => candidate.id === itemId);
+    if (!item) return;
+    setActiveView(item.item_kind === "medication" ? "medications" : item.item_kind === "hormone" ? "hormones" : "supplements");
+    setEditing(item);
+  }, [initialItems]);
 
   async function refreshRoutine() {
     const response = await fetch("/api/stacks/combined", { cache: "no-store" });

--- a/app/(app)/routine/TodayDoses.tsx
+++ b/app/(app)/routine/TodayDoses.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { AlertTriangle, Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
+import { AlertTriangle, ArrowRight, Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { regimenDoseDaypart, type AsNeededRegimenItem, type RegimenDoseDay, type RegimenDoseOccurrence, type RegimenDoseStatus } from "@/lib/regimenDose";
@@ -12,10 +13,12 @@ export default function TodayDoses({
   refreshToken,
   scheduleReviewItems,
   onEditSchedule,
+  variant = "routine",
 }: {
   refreshToken: number;
   scheduleReviewItems: RoutineItem[];
-  onEditSchedule: (item: RoutineItem) => void;
+  onEditSchedule?: (item: RoutineItem) => void;
+  variant?: "routine" | "today";
 }) {
   const [day, setDay] = useState<RegimenDoseDay | null>(null);
   const [loading, setLoading] = useState(true);
@@ -136,10 +139,12 @@ export default function TodayDoses({
     <section className="rounded-2xl border border-[#9DCFC3] bg-white p-5 shadow-sm sm:p-6" aria-labelledby="today-doses-heading">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Today</p>
-          <h2 id="today-doses-heading" className="mt-1 text-2xl font-bold text-[#041B2D]">Your dose checklist</h2>
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">{variant === "today" ? "Your routine" : "Today"}</p>
+          <h2 id="today-doses-heading" className="mt-1 text-2xl font-bold text-[#041B2D]">{variant === "today" ? "What is due today" : "Your dose checklist"}</h2>
           <p className="mt-1 text-sm leading-6 text-slate-600">
-            Mark each scheduled occurrence separately. This records what happened and does not change your instructions.
+            {variant === "today"
+              ? "Record your scheduled items here. LVE360 follows the schedule you entered; it does not choose doses or replace prescription instructions, pharmacist guidance, or a safety-critical alarm."
+              : "Mark each scheduled occurrence separately. This records what happened and does not change your instructions."}
           </p>
         </div>
         <p className="rounded-full bg-[#EAFBF8] px-3 py-2 text-sm font-bold text-[#06695F]">{formatDay(date)}</p>
@@ -211,7 +216,7 @@ export default function TodayDoses({
             {!day.occurrences.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No scheduled doses are due today.</p> : null}
           </div>
 
-          {day.asNeeded.length ? (
+          {variant === "routine" && day.asNeeded.length ? (
             <div className="mt-6 border-t border-slate-200 pt-5">
               <h3 className="font-bold text-[#041B2D]">As needed</h3>
               <p className="mt-1 text-sm text-slate-600">These items never appear overdue. Record one only when you take it under your existing instructions.</p>
@@ -230,8 +235,12 @@ export default function TodayDoses({
               <h3 id="schedule-review-heading" className="font-bold">Complete {scheduleReviewItems.length} schedule{scheduleReviewItems.length === 1 ? "" : "s"}</h3>
               <p className="mt-1 text-sm leading-6">These items need a structured time or cadence before they can appear in the checklist.</p>
               <div className="mt-3 flex flex-wrap gap-2">
-                {scheduleReviewItems.map((item) => (
-                  <button key={item.id} type="button" onClick={() => onEditSchedule(item)} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
+                {scheduleReviewItems.map((item) => variant === "today" ? (
+                  <Link key={item.id} href={`/routine#edit-routine-item-${encodeURIComponent(item.id)}`} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
+                    <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> Edit {item.name} <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                  </Link>
+                ) : (
+                  <button key={item.id} type="button" onClick={() => onEditSchedule?.(item)} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
                     <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> Edit {item.name}
                   </button>
                 ))}
@@ -239,13 +248,17 @@ export default function TodayDoses({
             </section>
           ) : null}
 
-          <details className="mt-6 border-t border-slate-200 pt-5">
+          {variant === "routine" ? <details className="mt-6 border-t border-slate-200 pt-5">
             <summary className="flex min-h-12 cursor-pointer items-center font-bold text-[#041B2D]"><History className="mr-2 h-5 w-5" aria-hidden="true" /> Recent dose history</summary>
             <div className="mt-3 space-y-2">
               {day.history.map((entry) => <div key={entry.eventId} className="flex flex-col gap-1 rounded-xl bg-slate-50 p-3 text-sm sm:flex-row sm:items-center sm:justify-between"><span className="font-semibold text-[#041B2D]">{entry.itemName}{entry.dose ? `, ${entry.dose}` : ""}</span><span className="text-slate-600">{formatDay(entry.date)}{entry.time ? ` at ${entry.time}` : ""} · {entry.status === "taken" ? "Taken" : "Skipped"}</span></div>)}
               {!day.history.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No dose records yet.</p> : null}
             </div>
-          </details>
+          </details> : (
+            <Link href="/routine" className="mt-5 inline-flex min-h-11 items-center text-sm font-bold text-[#087F72] hover:underline">
+              Open full Routine <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+            </Link>
+          )}
         </>
       ) : null}
     </section>

--- a/app/(app)/today/TodayClient.tsx
+++ b/app/(app)/today/TodayClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import DailyLog from "@/components/dashboard/DailyLog";
 import TodayExperience from "@/components/dashboard/TodayExperience";
-import TodaysPlan from "@/components/dashboard/TodaysPlan";
+import TodayRoutineAgenda from "@/components/dashboard/TodayRoutineAgenda";
 import type { WeeklyExperiment } from "@/lib/activation";
 import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "@/lib/blueprintContext";
 import type { PremiumActivationProgress } from "@/lib/premiumActivation";
@@ -50,11 +50,11 @@ export default function TodayClient({
               onCompletionStateChange={setFirstActionComplete}
             />
 
+            <TodayRoutineAgenda />
+
             <section id="daily-log" aria-label="Quick check-in">
               <DailyLog />
             </section>
-
-            <TodaysPlan />
           </>
         ) : null}
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "qa:pr94": "node src/_tests_/pr94TodayMomentum.assert.mjs",
     "qa:pr95": "node src/_tests_/pr95WeeklyPracticeControl.assert.mjs",
     "qa:pr96": "node --experimental-strip-types src/_tests_/today.assert.ts && node src/_tests_/pr96MeaningfulEngagement.assert.mjs",
+    "qa:pr97": "node src/_tests_/pr97UnifiedDailyAgenda.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr97UnifiedDailyAgenda.assert.mjs
+++ b/src/_tests_/pr97UnifiedDailyAgenda.assert.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const todayClient = readFileSync("app/(app)/today/TodayClient.tsx", "utf8");
+const todayAgenda = readFileSync("src/components/dashboard/TodayRoutineAgenda.tsx", "utf8");
+const doseChecklist = readFileSync("app/(app)/routine/TodayDoses.tsx", "utf8");
+const routineClient = readFileSync("app/(app)/routine/RoutineClient.tsx", "utf8");
+
+assert.match(todayClient, /<TodayRoutineAgenda\s*\/>/, "Today must render the actionable routine agenda");
+assert.doesNotMatch(todayClient, /<TodaysPlan\s*\/>/, "Today must not retain the passive routine summary");
+
+assert.match(todayAgenda, /<TodayDoses/, "Today and Routine must reuse the same dose checklist component");
+assert.match(todayAgenda, /groupRoutineItems\(items\)\.current\.filter\(\(item\) => !item\.schedule\)/, "Today must name items with missing schedules");
+
+assert.match(doseChecklist, /variant\?: "routine" \| "today"/, "Dose checklist must support a focused Today presentation");
+assert.match(doseChecklist, /recordGroup\(label, occurrences\)/, "Daypart batch completion must remain available");
+assert.match(doseChecklist, /void record\(occurrence, "taken"\)/, "Taken action must remain available");
+assert.match(doseChecklist, /void record\(occurrence, "skipped"\)/, "Skipped action must remain available");
+assert.match(doseChecklist, /void undo\(occurrence\.eventId\)/, "Undo must remain available");
+assert.match(doseChecklist, /variant === "routine" && day\.asNeeded\.length/, "As-needed items must stay out of the scheduled Today agenda");
+assert.match(doseChecklist, /does not choose doses or replace prescription instructions/, "Today must explain the medication-tracking boundary");
+assert.match(doseChecklist, /edit-routine-item-/, "Missing schedules must link to a specific Routine item");
+
+assert.match(routineClient, /#edit-routine-item-/, "Routine must recognize item-specific edit links");
+assert.match(routineClient, /setEditing\(item\)/, "Item-specific edit links must open the editor");
+
+console.log("PR97 unified daily agenda assertions passed.");

--- a/src/components/dashboard/TodayRoutineAgenda.tsx
+++ b/src/components/dashboard/TodayRoutineAgenda.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import TodayDoses from "@/app/(app)/routine/TodayDoses";
+import { groupRoutineItems, type RoutineItem } from "@/lib/routine";
+
+export default function TodayRoutineAgenda() {
+  const [items, setItems] = useState<RoutineItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/stacks/combined", { cache: "no-store" })
+      .then(async (response) => {
+        const body = await response.json().catch(() => null);
+        if (!response.ok || !body?.ok) throw new Error("routine_unavailable");
+        if (!cancelled) setItems(body.items ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setUnavailable(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const scheduleReviewItems = useMemo(
+    () => groupRoutineItems(items).current.filter((item) => !item.schedule),
+    [items],
+  );
+
+  if (loading) {
+    return (
+      <section className="flex min-h-32 items-center justify-center rounded-2xl border border-slate-200 bg-white p-5 text-slate-600 shadow-sm" aria-label="Loading today's routine">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin text-[#087F72]" aria-hidden="true" /> Loading today&apos;s routine
+      </section>
+    );
+  }
+
+  if (unavailable) {
+    return (
+      <section className="flex items-start rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-950 shadow-sm" role="alert">
+        <AlertTriangle className="mr-2 mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" /> We could not load today&apos;s routine. Your records are unchanged. Open Routine to try again.
+      </section>
+    );
+  }
+
+  return (
+    <TodayDoses
+      refreshToken={0}
+      scheduleReviewItems={scheduleReviewItems}
+      variant="today"
+    />
+  );
+}


### PR DESCRIPTION
## What changed

- Replaces Today’s passive routine count with a compact **Daily Rhythm** card.
- Chooses one next scheduled item based on the member’s recorded time and completion state.
- Allows that single next item to be marked taken or skipped without recreating the full Routine checklist.
- Shows lightweight momentum through a progress bar and Morning, Afternoon, and Evening completion chips.
- Adapts the coaching message as the member starts, builds momentum, or completes the routine.
- Deep-links schedule problems to the exact item editor.
- Keeps batch actions, complete checklists, as-needed items, editing, clinician printing, and history in Routine.

## Why

The initial PR97 implementation solved continuity too literally and made Today resemble Routine. The revised design focuses on engagement: one focused habit, one personalized routine nudge, and one clear next action. Detailed operational work stays where it belongs.

## Product principles

- Helpful progress, not arbitrary points.
- One clear action instead of another checklist.
- Contextual personalization without falsely labeling deterministic rules as generative AI.
- Medication tracking follows member-entered instructions and never chooses dosing.

## Validation

- `npm.cmd run qa:pr97`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr96`
- `npm.cmd run typecheck`
- `git diff --check`

## Deployment notes

- No Supabase migration.
- No new environment variables.
- Stripe behavior unchanged.
- A deeper evidence-safe AI coach should be developed separately from the older AI-insights implementation.