### PR TITLE
PR98 — Focus Today on personalized momentum

### DIFF
--- a/app/(app)/routine/TodayDoses.tsx
+++ b/app/(app)/routine/TodayDoses.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { AlertTriangle, ArrowRight, Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
-import Link from "next/link";
+import { AlertTriangle, Check, Clock3, History, Loader2, Pencil, RotateCcw, SkipForward } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { regimenDoseDaypart, type AsNeededRegimenItem, type RegimenDoseDay, type RegimenDoseOccurrence, type RegimenDoseStatus } from "@/lib/regimenDose";
@@ -13,12 +12,10 @@ export default function TodayDoses({
   refreshToken,
   scheduleReviewItems,
   onEditSchedule,
-  variant = "routine",
 }: {
   refreshToken: number;
   scheduleReviewItems: RoutineItem[];
-  onEditSchedule?: (item: RoutineItem) => void;
-  variant?: "routine" | "today";
+  onEditSchedule: (item: RoutineItem) => void;
 }) {
   const [day, setDay] = useState<RegimenDoseDay | null>(null);
   const [loading, setLoading] = useState(true);
@@ -139,12 +136,10 @@ export default function TodayDoses({
     <section className="rounded-2xl border border-[#9DCFC3] bg-white p-5 shadow-sm sm:p-6" aria-labelledby="today-doses-heading">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">{variant === "today" ? "Your routine" : "Today"}</p>
-          <h2 id="today-doses-heading" className="mt-1 text-2xl font-bold text-[#041B2D]">{variant === "today" ? "What is due today" : "Your dose checklist"}</h2>
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Today</p>
+          <h2 id="today-doses-heading" className="mt-1 text-2xl font-bold text-[#041B2D]">Your dose checklist</h2>
           <p className="mt-1 text-sm leading-6 text-slate-600">
-            {variant === "today"
-              ? "Record your scheduled items here. LVE360 follows the schedule you entered; it does not choose doses or replace prescription instructions, pharmacist guidance, or a safety-critical alarm."
-              : "Mark each scheduled occurrence separately. This records what happened and does not change your instructions."}
+            Mark each scheduled occurrence separately. This records what happened and does not change your instructions.
           </p>
         </div>
         <p className="rounded-full bg-[#EAFBF8] px-3 py-2 text-sm font-bold text-[#06695F]">{formatDay(date)}</p>
@@ -216,7 +211,7 @@ export default function TodayDoses({
             {!day.occurrences.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No scheduled doses are due today.</p> : null}
           </div>
 
-          {variant === "routine" && day.asNeeded.length ? (
+          {day.asNeeded.length ? (
             <div className="mt-6 border-t border-slate-200 pt-5">
               <h3 className="font-bold text-[#041B2D]">As needed</h3>
               <p className="mt-1 text-sm text-slate-600">These items never appear overdue. Record one only when you take it under your existing instructions.</p>
@@ -235,12 +230,8 @@ export default function TodayDoses({
               <h3 id="schedule-review-heading" className="font-bold">Complete {scheduleReviewItems.length} schedule{scheduleReviewItems.length === 1 ? "" : "s"}</h3>
               <p className="mt-1 text-sm leading-6">These items need a structured time or cadence before they can appear in the checklist.</p>
               <div className="mt-3 flex flex-wrap gap-2">
-                {scheduleReviewItems.map((item) => variant === "today" ? (
-                  <Link key={item.id} href={`/routine#edit-routine-item-${encodeURIComponent(item.id)}`} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
-                    <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> Edit {item.name} <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
-                  </Link>
-                ) : (
-                  <button key={item.id} type="button" onClick={() => onEditSchedule?.(item)} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
+                {scheduleReviewItems.map((item) => (
+                  <button key={item.id} type="button" onClick={() => onEditSchedule(item)} className="inline-flex min-h-11 items-center rounded-xl border border-amber-300 bg-white px-3 py-2 text-sm font-bold text-amber-950 hover:bg-amber-100">
                     <Pencil className="mr-2 h-4 w-4" aria-hidden="true" /> Edit {item.name}
                   </button>
                 ))}
@@ -248,17 +239,13 @@ export default function TodayDoses({
             </section>
           ) : null}
 
-          {variant === "routine" ? <details className="mt-6 border-t border-slate-200 pt-5">
+          <details className="mt-6 border-t border-slate-200 pt-5">
             <summary className="flex min-h-12 cursor-pointer items-center font-bold text-[#041B2D]"><History className="mr-2 h-5 w-5" aria-hidden="true" /> Recent dose history</summary>
             <div className="mt-3 space-y-2">
               {day.history.map((entry) => <div key={entry.eventId} className="flex flex-col gap-1 rounded-xl bg-slate-50 p-3 text-sm sm:flex-row sm:items-center sm:justify-between"><span className="font-semibold text-[#041B2D]">{entry.itemName}{entry.dose ? `, ${entry.dose}` : ""}</span><span className="text-slate-600">{formatDay(entry.date)}{entry.time ? ` at ${entry.time}` : ""} · {entry.status === "taken" ? "Taken" : "Skipped"}</span></div>)}
               {!day.history.length ? <p className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No dose records yet.</p> : null}
             </div>
-          </details> : (
-            <Link href="/routine" className="mt-5 inline-flex min-h-11 items-center text-sm font-bold text-[#087F72] hover:underline">
-              Open full Routine <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
-            </Link>
-          )}
+          </details>
         </>
       ) : null}
     </section>

--- a/src/_tests_/pr97UnifiedDailyAgenda.assert.mjs
+++ b/src/_tests_/pr97UnifiedDailyAgenda.assert.mjs
@@ -9,17 +9,20 @@ const routineClient = readFileSync("app/(app)/routine/RoutineClient.tsx", "utf8"
 assert.match(todayClient, /<TodayRoutineAgenda\s*\/>/, "Today must render the actionable routine agenda");
 assert.doesNotMatch(todayClient, /<TodaysPlan\s*\/>/, "Today must not retain the passive routine summary");
 
-assert.match(todayAgenda, /<TodayDoses/, "Today and Routine must reuse the same dose checklist component");
+assert.doesNotMatch(todayAgenda, /<TodayDoses/, "Today must not duplicate the full Routine checklist");
 assert.match(todayAgenda, /groupRoutineItems\(items\)\.current\.filter\(\(item\) => !item\.schedule\)/, "Today must name items with missing schedules");
+assert.match(todayAgenda, /Personalized nudge/, "Today must frame routine support as a personalized nudge");
+assert.match(todayAgenda, /Your daily rhythm/, "Today must present lightweight routine momentum");
+assert.match(todayAgenda, /nextOccurrence\(remaining\)/, "Today must select one next useful action");
+assert.match(todayAgenda, /coachMessage\(completed, occurrences\.length\)/, "Today must adapt coaching language to progress");
+assert.match(todayAgenda, /Mark taken/, "Today must make the next action immediately recordable");
+assert.match(todayAgenda, /Open full Routine/, "Detailed routine work must remain in Routine");
 
-assert.match(doseChecklist, /variant\?: "routine" \| "today"/, "Dose checklist must support a focused Today presentation");
 assert.match(doseChecklist, /recordGroup\(label, occurrences\)/, "Daypart batch completion must remain available");
 assert.match(doseChecklist, /void record\(occurrence, "taken"\)/, "Taken action must remain available");
 assert.match(doseChecklist, /void record\(occurrence, "skipped"\)/, "Skipped action must remain available");
 assert.match(doseChecklist, /void undo\(occurrence\.eventId\)/, "Undo must remain available");
-assert.match(doseChecklist, /variant === "routine" && day\.asNeeded\.length/, "As-needed items must stay out of the scheduled Today agenda");
-assert.match(doseChecklist, /does not choose doses or replace prescription instructions/, "Today must explain the medication-tracking boundary");
-assert.match(doseChecklist, /edit-routine-item-/, "Missing schedules must link to a specific Routine item");
+assert.match(doseChecklist, /day\.asNeeded\.length/, "As-needed items must remain available in Routine");
 
 assert.match(routineClient, /#edit-routine-item-/, "Routine must recognize item-specific edit links");
 assert.match(routineClient, /setEditing\(item\)/, "Item-specific edit links must open the editor");

--- a/src/components/dashboard/TodayRoutineAgenda.tsx
+++ b/src/components/dashboard/TodayRoutineAgenda.tsx
@@ -1,59 +1,193 @@
 "use client";
 
-import { AlertTriangle, Loader2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, ArrowRight, Check, Clock3, Loader2, Sparkles, Trophy } from "lucide-react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import TodayDoses from "@/app/(app)/routine/TodayDoses";
+import { regimenDoseDaypart, type RegimenDoseDay, type RegimenDoseOccurrence } from "@/lib/regimenDose";
+import { localDateString } from "@/lib/regimenSchedule";
 import { groupRoutineItems, type RoutineItem } from "@/lib/routine";
 
 export default function TodayRoutineAgenda() {
   const [items, setItems] = useState<RoutineItem[]>([]);
+  const [day, setDay] = useState<RegimenDoseDay | null>(null);
   const [loading, setLoading] = useState(true);
-  const [unavailable, setUnavailable] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const date = localDateString();
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const [routineResponse, dosesResponse] = await Promise.all([
+        fetch("/api/stacks/combined", { cache: "no-store" }),
+        fetch(`/api/routine/doses?date=${encodeURIComponent(date)}`, { cache: "no-store" }),
+      ]);
+      const [routineBody, dosesBody] = await Promise.all([
+        routineResponse.json().catch(() => null),
+        dosesResponse.json().catch(() => null),
+      ]);
+      if (!routineResponse.ok || !routineBody?.ok || !dosesResponse.ok || !dosesBody?.ok) {
+        throw new Error("routine_unavailable");
+      }
+      setItems(routineBody.items ?? []);
+      setDay(dosesBody.day);
+    } catch {
+      setError("We could not load today's routine. Your records are unchanged.");
+    } finally {
+      setLoading(false);
+    }
+  }, [date]);
 
   useEffect(() => {
-    let cancelled = false;
-    fetch("/api/stacks/combined", { cache: "no-store" })
-      .then(async (response) => {
-        const body = await response.json().catch(() => null);
-        if (!response.ok || !body?.ok) throw new Error("routine_unavailable");
-        if (!cancelled) setItems(body.items ?? []);
-      })
-      .catch(() => {
-        if (!cancelled) setUnavailable(true);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => { cancelled = true; };
-  }, []);
+    void load();
+  }, [load]);
 
   const scheduleReviewItems = useMemo(
     () => groupRoutineItems(items).current.filter((item) => !item.schedule),
     [items],
   );
+  const occurrences = day?.occurrences ?? [];
+  const completed = occurrences.filter((occurrence) => occurrence.status).length;
+  const remaining = occurrences.filter((occurrence) => !occurrence.status);
+  const next = nextOccurrence(remaining);
+  const progress = occurrences.length ? Math.round((completed / occurrences.length) * 100) : 0;
+  const dayparts = daypartProgress(occurrences);
+
+  async function recordNext(status: "taken" | "skipped") {
+    if (!next) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/routine/doses", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          regimen_item_id: next.regimenItemId,
+          date,
+          slot_key: next.slotKey,
+          status,
+        }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error("dose_record_failed");
+      await load();
+    } catch {
+      setError("We could not record that item. Please try again or use Routine.");
+    } finally {
+      setBusy(false);
+    }
+  }
 
   if (loading) {
     return (
-      <section className="flex min-h-32 items-center justify-center rounded-2xl border border-slate-200 bg-white p-5 text-slate-600 shadow-sm" aria-label="Loading today's routine">
-        <Loader2 className="mr-2 h-5 w-5 animate-spin text-[#087F72]" aria-hidden="true" /> Loading today&apos;s routine
+      <section className="flex min-h-32 items-center justify-center rounded-2xl border border-slate-200 bg-white p-5 text-slate-600 shadow-sm" aria-label="Loading today's rhythm">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin text-[#087F72]" aria-hidden="true" /> Personalizing today&apos;s rhythm
       </section>
     );
   }
 
-  if (unavailable) {
+  if (error && !day) {
     return (
       <section className="flex items-start rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-950 shadow-sm" role="alert">
-        <AlertTriangle className="mr-2 mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" /> We could not load today&apos;s routine. Your records are unchanged. Open Routine to try again.
+        <AlertTriangle className="mr-2 mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" /> {error} Open Routine to try again.
       </section>
     );
   }
 
   return (
-    <TodayDoses
-      refreshToken={0}
-      scheduleReviewItems={scheduleReviewItems}
-      variant="today"
-    />
+    <section className="overflow-hidden rounded-3xl border border-[#BCE3DA] bg-white shadow-sm" aria-labelledby="daily-rhythm-title">
+      <div className="bg-gradient-to-r from-[#F4FAF8] to-[#F8F5FB] p-5 sm:p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="flex items-center text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]"><Sparkles className="mr-2 h-4 w-4" aria-hidden="true" /> Personalized nudge</p>
+            <h2 id="daily-rhythm-title" className="mt-1 text-2xl font-bold text-[#041B2D]">Your daily rhythm</h2>
+          </div>
+          <div className="shrink-0 rounded-full bg-white px-3 py-2 text-sm font-bold text-[#06695F] shadow-sm">
+            {occurrences.length ? `${completed} of ${occurrences.length}` : "Clear"}
+          </div>
+        </div>
+
+        {occurrences.length ? <>
+          <div className="mt-5 h-2.5 overflow-hidden rounded-full bg-white" role="progressbar" aria-label="Today's routine progress" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}>
+            <div className="h-full rounded-full bg-gradient-to-r from-[#08A88A] to-[#7C3AED] transition-all" style={{ width: `${progress}%` }} />
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {dayparts.map((part) => (
+              <span key={part.label} className={`rounded-full px-3 py-1.5 text-xs font-bold ${part.complete ? "bg-emerald-100 text-emerald-800" : "bg-white text-slate-700"}`}>
+                {part.complete ? <Check className="mr-1 inline h-3.5 w-3.5" aria-hidden="true" /> : null}{part.label} {part.completed}/{part.total}
+              </span>
+            ))}
+          </div>
+        </> : null}
+      </div>
+
+      <div className="p-5 sm:p-6">
+        {error ? <p className="mb-4 rounded-xl bg-rose-50 p-3 text-sm font-semibold text-rose-800" role="alert">{error}</p> : null}
+
+        {!occurrences.length ? (
+          <div className="flex items-start gap-3">
+            <Trophy className="mt-0.5 h-6 w-6 shrink-0 text-[#087F72]" aria-hidden="true" />
+            <div><p className="font-bold text-[#041B2D]">Your scheduled routine is clear today.</p><p className="mt-1 text-sm leading-6 text-slate-600">Put your attention toward the focused practice above. Small wins still count.</p></div>
+          </div>
+        ) : next ? (
+          <div className="grid gap-5 sm:grid-cols-[1fr_auto] sm:items-center">
+            <div>
+              <p className="text-sm font-bold text-[#087F72]">{coachMessage(completed, occurrences.length)}</p>
+              <p className="mt-2 flex items-center text-sm font-semibold text-slate-600"><Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> Next up at {next.timeLabel}</p>
+              <h3 className="mt-1 text-xl font-bold text-[#041B2D]">{next.itemName}</h3>
+              <p className="mt-1 text-sm text-slate-600">{next.dose || "Dose not recorded"}</p>
+            </div>
+            <div className="flex flex-wrap gap-2 sm:max-w-56">
+              <button type="button" disabled={busy} onClick={() => void recordNext("taken")} className="inline-flex min-h-12 flex-1 items-center justify-center rounded-xl bg-[#087F72] px-5 py-3 font-bold text-white hover:bg-[#06695F] disabled:opacity-60">
+                {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Check className="mr-2 h-4 w-4" aria-hidden="true" />} Mark taken
+              </button>
+              <button type="button" disabled={busy} onClick={() => void recordNext("skipped")} className="min-h-11 px-3 py-2 text-sm font-semibold text-slate-600 hover:text-[#041B2D] disabled:opacity-60">Skip</button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start gap-3">
+            <Trophy className="mt-0.5 h-6 w-6 shrink-0 text-amber-600" aria-hidden="true" />
+            <div><p className="font-bold text-[#041B2D]">Routine complete. Promise kept.</p><p className="mt-1 text-sm leading-6 text-slate-600">You handled today&apos;s scheduled items. Let that win free your attention for the rest of your day.</p></div>
+          </div>
+        )}
+
+        <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          {scheduleReviewItems.length ? (
+            <Link href={`/routine#edit-routine-item-${encodeURIComponent(scheduleReviewItems[0].id)}`} className="inline-flex items-center text-sm font-semibold text-amber-800 hover:underline">
+              <AlertTriangle className="mr-2 h-4 w-4" aria-hidden="true" /> {scheduleReviewItems.length} item{scheduleReviewItems.length === 1 ? " needs" : "s need"} a schedule
+            </Link>
+          ) : <p className="text-xs leading-5 text-slate-500">This tracks the schedule you entered. Follow your existing instructions.</p>}
+          <Link href="/routine" className="inline-flex min-h-11 items-center text-sm font-bold text-[#087F72] hover:underline">Open full Routine <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" /></Link>
+        </div>
+      </div>
+    </section>
   );
+}
+
+function nextOccurrence(remaining: RegimenDoseOccurrence[], now = new Date()): RegimenDoseOccurrence | null {
+  if (!remaining.length) return null;
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  return remaining.find((occurrence) => timeMinutes(occurrence.time) >= currentMinutes) ?? remaining[0];
+}
+
+function timeMinutes(time: string): number {
+  const [hour, minute] = time.split(":").map(Number);
+  return hour * 60 + minute;
+}
+
+function daypartProgress(occurrences: RegimenDoseOccurrence[]) {
+  return (["Morning", "Afternoon", "Evening"] as const).flatMap((label) => {
+    const items = occurrences.filter((occurrence) => regimenDoseDaypart(occurrence.time) === label);
+    if (!items.length) return [];
+    const completed = items.filter((occurrence) => occurrence.status).length;
+    return [{ label, completed, total: items.length, complete: completed === items.length }];
+  });
+}
+
+function coachMessage(completed: number, total: number): string {
+  if (!completed) return "One clear action is enough to start momentum.";
+  if (completed >= Math.ceil(total / 2)) return "You are over halfway there. Keep the rhythm easy.";
+  return "Good start. Your next small win is ready.";
 }


### PR DESCRIPTION
## Follow-up to PR97

PR97 was merged before the post-merge usability review. This follow-up corrects the Today experience without changing the full Routine workflow.

## What changed

- Replaces the replicated checklist on Today with a compact **Daily Rhythm** card.
- Selects one next scheduled item based on time and completion state.
- Allows the next item to be marked taken or skipped directly.
- Shows lightweight progress and Morning, Afternoon, and Evening momentum.
- Adapts the nudge as the member begins, progresses, or completes the day.
- Keeps full checklists, batch actions, as-needed items, history, editing, and clinician printing in Routine.
- Keeps exact deep links for items missing a schedule.

## Why

Today should feel engaging and intelligently personalized, not like a second Routine page. The intended hierarchy is:

1. One identity-based weekly practice.
2. One personalized next routine action.
3. One optional check-in.
4. Detailed management only when the member opens Routine.

## AI direction

This PR uses transparent, contextual logic and does not mislabel it as generative AI. A future evidence-safe AI coach should use real weekly patterns, explain why a suggestion appeared, and avoid the stale adherence assumptions in the older AI-insights path.

## Validation

- `npm.cmd run qa:pr97`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr96`
- `npm.cmd run typecheck`
- `git diff --check`

## Deployment notes

- No Supabase migration.
- No new environment variables.
- Stripe behavior unchanged.