### PR TITLE
PR101: Add grounded AI weekly review synthesis

### DIFF
--- a/app/api/account/export/route.ts
+++ b/app/api/account/export/route.ts
@@ -34,6 +34,7 @@ export async function GET() {
     { label: "check_ins", table: "logs", column: "user_id", value: user.id },
     { label: "ai_summaries", table: "ai_summaries", column: "user_id", value: user.id },
     { label: "ai_generation_ledger", table: "ai_generation_ledger", column: "user_id", value: user.id },
+    { label: "ai_weekly_syntheses", table: "ai_weekly_syntheses", column: "user_id", value: user.id },
     { label: "weekly_experiments", table: "weekly_experiments", column: "user_id", value: user.id },
     { label: "weekly_reviews", table: "weekly_experiment_reviews", column: "user_id", value: user.id },
     { label: "practice_completions", table: "daily_practice_completions", column: "user_id", value: user.id },

--- a/app/api/journey/route.ts
+++ b/app/api/journey/route.ts
@@ -7,6 +7,7 @@ import type {
   JourneyCompletion,
   JourneyExperiment,
   JourneyReview,
+  JourneySynthesis,
 } from "@/lib/journey";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
@@ -43,7 +44,7 @@ export async function GET() {
 
     const admin = getSupabaseAdmin();
     const blueprintPromise = getCurrentBlueprintContext(auth.user.id);
-    const [{ data: experiments, error: experimentError }, { data: reviews, error: reviewError }, { data: checkIns, error: checkInError }] = await Promise.all([
+    const [{ data: experiments, error: experimentError }, { data: reviews, error: reviewError }, { data: checkIns, error: checkInError }, { data: syntheses, error: synthesisError }] = await Promise.all([
       admin
         .from("weekly_experiments")
         .select("id, source_stack_id, source_action_id, identity_direction, action_label, cue, frequency_per_week, minimum_version, status, week_start, activated_at, completed_at")
@@ -62,9 +63,16 @@ export async function GET() {
         .eq("user_id", auth.user.id)
         .order("log_date", { ascending: true })
         .limit(90),
+      admin
+        .from("ai_weekly_syntheses")
+        .select("id,experiment_id,observation,hypothesis,evidence,confidence,response_state,created_at")
+        .eq("user_id", auth.user.id)
+        .in("generation_status", ["succeeded", "failed", "skipped"])
+        .order("created_at", { ascending: false })
+        .limit(52),
     ]);
-    if (experimentError || reviewError || checkInError) {
-      throw experimentError ?? reviewError ?? checkInError;
+    if (experimentError || reviewError || checkInError || synthesisError) {
+      throw experimentError ?? reviewError ?? checkInError ?? synthesisError;
     }
 
     const experimentRows = (experiments ?? []) as JourneyExperiment[];
@@ -94,6 +102,7 @@ export async function GET() {
       reviews: (reviews ?? []) as JourneyReview[],
       completions,
       check_ins: (checkIns ?? []) as JourneyCheckIn[],
+      syntheses: (syntheses ?? []) as JourneySynthesis[],
       blueprint,
       experiment_blueprints: experimentBlueprints,
     });

--- a/app/api/weekly-review/route.ts
+++ b/app/api/weekly-review/route.ts
@@ -3,7 +3,8 @@ import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 
 import type { WeeklyExperiment } from "@/lib/activation";
-import { isReviewDecision, isReviewDue, validateNextPlan } from "@/lib/weeklyReview";
+import { isReviewDecision, isReviewDue, validateNextPlan, type NextWeekPlan } from "@/lib/weeklyReview";
+import { synthesisResponseState, type WeeklySynthesisContent } from "@/lib/weeklySynthesis";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
 
@@ -117,6 +118,10 @@ export async function POST(req: NextRequest) {
       if (/already_completed/i.test(error.message)) return NextResponse.json({ ok: false, error: "review_already_completed" }, { status: 409 });
       throw error;
     }
+    const synthesisId = typeof body?.synthesis_id === "string" ? body.synthesis_id : null;
+    if (synthesisId) {
+      await recordSynthesisResponse(auth.user.id, synthesisId, decision, nextPlan, typeof data === "string" ? data : null);
+    }
     await recordProductEventSafely({
       event_name: "weekly_review_completed",
       source: "weekly_review",
@@ -129,6 +134,39 @@ export async function POST(req: NextRequest) {
     console.error("[weekly-review] save failed", error);
     return NextResponse.json({ ok: false, error: "review_unavailable" }, { status: 500 });
   }
+}
+
+async function recordSynthesisResponse(
+  userId: string,
+  synthesisId: string,
+  decision: Parameters<typeof synthesisResponseState>[1],
+  plan: NextWeekPlan | null,
+  nextExperimentId: string | null,
+) {
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin.from("ai_weekly_syntheses")
+    .select("suggested_decision,suggested_action_label,suggested_cue,suggested_frequency_per_week,suggested_minimum_version")
+    .eq("id", synthesisId).eq("user_id", userId).maybeSingle();
+  if (error || !data) {
+    console.warn("[weekly-review] synthesis response not recorded", error?.message ?? "not_found");
+    return;
+  }
+  const suggestedPlan = data.suggested_decision === "pause" ? null : {
+    action_label: data.suggested_action_label ?? "",
+    cue: data.suggested_cue ?? "",
+    frequency_per_week: data.suggested_frequency_per_week ?? 1,
+    minimum_version: data.suggested_minimum_version ?? "",
+  };
+  const state = synthesisResponseState({
+    suggestedDecision: data.suggested_decision as WeeklySynthesisContent["suggestedDecision"],
+    suggestedPlan,
+  }, decision, plan);
+  const { error: updateError } = await admin.from("ai_weekly_syntheses").update({
+    response_state: state,
+    next_experiment_id: nextExperimentId,
+    updated_at: new Date().toISOString(),
+  }).eq("id", synthesisId).eq("user_id", userId);
+  if (updateError) console.warn("[weekly-review] synthesis response update failed", updateError.message);
 }
 
 function todayUtc(): string {

--- a/app/api/weekly-review/synthesis/route.ts
+++ b/app/api/weekly-review/synthesis/route.ts
@@ -1,0 +1,70 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+import type { WeeklyExperiment } from "@/lib/activation";
+import { getOrCreateWeeklySynthesis } from "@/lib/ai/weeklySynthesisData";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { isReviewDue } from "@/lib/weeklyReview";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.id) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    const admin = getSupabaseAdmin();
+    const { data: profile } = await admin.from("users").select("tier").eq("id", user.id).maybeSingle();
+    if (profile?.tier !== "premium" && profile?.tier !== "trial") {
+      return NextResponse.json({ ok: false, error: "premium_required" }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => null) as Record<string, unknown> | null;
+    const experimentId = typeof body?.experiment_id === "string" ? body.experiment_id : "";
+    const difficulty = Number(body?.difficulty);
+    const valueRating = Number(body?.value_rating);
+    if (!experimentId || !Number.isInteger(difficulty) || difficulty < 1 || difficulty > 5 || !Number.isInteger(valueRating) || valueRating < 1 || valueRating > 5) {
+      return NextResponse.json({ ok: false, error: "invalid_synthesis_request" }, { status: 400 });
+    }
+
+    const { data: experiment, error: experimentError } = await admin.from("weekly_experiments")
+      .select("*").eq("id", experimentId).eq("user_id", user.id).eq("status", "active").maybeSingle();
+    if (experimentError) throw experimentError;
+    if (!experiment) return NextResponse.json({ ok: false, error: "experiment_not_found" }, { status: 404 });
+    const typedExperiment = experiment as WeeklyExperiment;
+    if (!isReviewDue(typedExperiment.week_start, new Date().toISOString().slice(0, 10))) {
+      return NextResponse.json({ ok: false, error: "review_not_due" }, { status: 409 });
+    }
+    const weekEnd = addDays(typedExperiment.week_start, 6);
+    const [{ data: completionRows, error: completionError }, { data: checkIns, error: checkInError }] = await Promise.all([
+      admin.from("daily_practice_completions").select("completion_date").eq("user_id", user.id).eq("experiment_id", experimentId)
+        .gte("completion_date", typedExperiment.week_start).lte("completion_date", weekEnd).order("completion_date"),
+      admin.from("logs").select("log_date,sleep,energy").eq("user_id", user.id)
+        .gte("log_date", typedExperiment.week_start).lte("log_date", weekEnd).order("log_date"),
+    ]);
+    if (completionError || checkInError) throw completionError ?? checkInError;
+    const completedDates = (completionRows ?? []).map((row) => row.completion_date as string);
+    const synthesis = await getOrCreateWeeklySynthesis(user.id, {
+      experiment: typedExperiment,
+      completedDates,
+      completedCount: completedDates.length,
+      target: typedExperiment.frequency_per_week ?? 1,
+      difficulty,
+      valueRating,
+      checkIns: (checkIns ?? []).map((row) => ({ date: row.log_date, sleep: row.sleep, energy: row.energy })),
+    });
+    return NextResponse.json({ ok: true, synthesis });
+  } catch (error) {
+    console.error("[weekly-synthesis] load failed", error);
+    return NextResponse.json({ ok: false, error: "weekly_synthesis_unavailable" }, { status: 500 });
+  }
+}
+
+function addDays(date: string, days: number) {
+  const value = new Date(`${date}T12:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "qa:pr97": "node src/_tests_/pr97UnifiedDailyAgenda.assert.mjs",
     "qa:pr99": "node src/_tests_/pr99AiGateway.assert.mjs",
     "qa:pr100": "node --experimental-strip-types src/_tests_/pr100TodayBrief.assert.ts && node src/_tests_/pr100Page.assert.mjs",
+    "qa:pr101": "node src/_tests_/pr101Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr101Page.assert.mjs
+++ b/src/_tests_/pr101Page.assert.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+
+const review = read("src/components/review/WeeklyReviewClient.tsx");
+const reviewRoute = read("app/api/weekly-review/route.ts");
+const synthesisRoute = read("app/api/weekly-review/synthesis/route.ts");
+const data = read("src/lib/ai/weeklySynthesisData.ts");
+const logic = read("src/lib/weeklySynthesis.ts");
+const journey = read("src/components/journey/JourneyDashboard.tsx");
+const today = read("src/components/dashboard/AiTodayBrief.tsx");
+const migration = read("supabase/migrations/20260811034153_pr101_ai_weekly_syntheses.sql");
+
+assert.match(today, /Hide for 3 hours/, "The snooze label must state its actual behavior.");
+assert.match(review, /Get a grounded suggestion/, "AI assistance must be member initiated.");
+assert.match(review, /Evidence used/, "The suggestion must cite the member data it used.");
+assert.match(review, /Use this suggestion/, "Members must be able to accept the suggestion.");
+assert.match(review, /edit every field below or choose a different option/i, "Members must be able to edit or reject it.");
+assert.match(synthesisRoute, /premium_required/, "The synthesis must remain a paid feature.");
+assert.match(data, /isLowDataWeek/, "Low-data weeks must avoid an unnecessary model call.");
+assert.match(data, /code === "23505"/, "Concurrent requests must reuse one cached synthesis.");
+assert.match(logic, /valueRating <= 2[\s\S]*return "swap"/, "Low usefulness must suggest testing a different practice.");
+assert.match(logic, /difficulty >= 4[\s\S]*return "shrink"/, "High friction must suggest a smaller practice.");
+assert.match(logic, /isLowDataWeek[\s\S]*completedCount < 2/, "Sparse weeks must be labeled as low data.");
+assert.match(logic, /decision !== synthesis\.suggestedDecision[\s\S]*"rejected"/, "A different member choice must be recorded as rejection.");
+assert.match(logic, /samePlan[\s\S]*"accepted"[\s\S]*"edited"/, "Accepted and edited suggestions must be distinguishable.");
+assert.match(reviewRoute, /synthesisResponseState/, "The final member decision must be recorded.");
+assert.match(journey, /Working hypothesis/, "Journey must distinguish hypotheses from observations.");
+assert.match(migration, /revoke all on table public\.ai_weekly_syntheses from public, anon, authenticated/, "The table must stay server-only.");
+assert.match(migration, /-- Rollback:/, "The migration must include rollback notes.");
+
+console.log("PR101 weekly synthesis page and storage assertions passed");

--- a/src/components/dashboard/AiTodayBrief.tsx
+++ b/src/components/dashboard/AiTodayBrief.tsx
@@ -148,7 +148,7 @@ export default function AiTodayBrief({
             Open Routine
           </Link>
           <button type="button" onClick={() => void handleQuietAction("remind_later")} disabled={Boolean(busy)} className="inline-flex min-h-11 items-center px-3 py-2 text-sm font-semibold text-slate-600 hover:text-[#041B2D] disabled:opacity-60">
-            <Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> Remind later
+            <Clock3 className="mr-2 h-4 w-4" aria-hidden="true" /> Hide for 3 hours
           </button>
         </div>
 

--- a/src/components/journey/JourneyDashboard.tsx
+++ b/src/components/journey/JourneyDashboard.tsx
@@ -25,6 +25,7 @@ import {
   type JourneyExperiment,
   type JourneyResponse,
   type JourneyReview,
+  type JourneySynthesis,
 } from "@/lib/journey";
 import { blueprintSafetyLabel, type CurrentBlueprintContext, type ExperimentBlueprintContext } from "@/lib/blueprintContext";
 
@@ -206,6 +207,7 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
           reviews={completedReviews}
           experiments={data.experiments}
           experimentBlueprints={data.experiment_blueprints}
+          syntheses={data.syntheses}
         />
       </div>
     </div>
@@ -477,7 +479,8 @@ function WinsTimeline({ reviews, completionTotal }: { reviews: JourneyReview[]; 
   );
 }
 
-function LearningLoop({ reviews, experiments, experimentBlueprints }: { reviews: JourneyReview[]; experiments: JourneyExperiment[]; experimentBlueprints: Record<string, ExperimentBlueprintContext> }) {
+function LearningLoop({ reviews, experiments, experimentBlueprints, syntheses }: { reviews: JourneyReview[]; experiments: JourneyExperiment[]; experimentBlueprints: Record<string, ExperimentBlueprintContext>; syntheses: JourneySynthesis[] }) {
+  const synthesisByExperiment = new Map(syntheses.map((item) => [item.experiment_id, item]));
   return (
     <section aria-labelledby="review-history-title" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="flex items-center gap-2"><Compass className="h-5 w-5 text-[#087F72]" aria-hidden="true" /><h2 id="review-history-title" className="text-xl font-bold text-[#041B2D]">Your learning loop</h2></div>
@@ -486,11 +489,13 @@ function LearningLoop({ reviews, experiments, experimentBlueprints }: { reviews:
           const experiment = experiments.find((item) => item.id === review.experiment_id);
           const nextExperiment = experiments.find((item) => item.id === review.next_experiment_id) ?? null;
           const context = experiment ? experimentBlueprints[experiment.id] ?? null : null;
+          const synthesis = synthesisByExperiment.get(review.experiment_id) ?? null;
           return <li key={review.experiment_id} className="rounded-2xl bg-slate-50 p-4">
             <dl className="space-y-3 text-sm leading-6">
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Tried</dt><dd className="font-semibold text-[#041B2D]">{experiment?.action_label || "Weekly practice"}</dd></div>
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Why it mattered</dt><dd className="text-slate-600">{context?.priority_label || `${domainLabel(experiment?.identity_direction ?? null)} was your chosen focus.`}</dd></div>
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Noticed</dt><dd className="text-slate-600">You reported usefulness {review.value_rating}/5 and difficulty {review.difficulty}/5 after {review.completion_count} of {review.target_count} planned reps.</dd></div>
+              {synthesis ? <><div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Recorded observation</dt><dd className="text-slate-600">{synthesis.observation}</dd></div><div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Working hypothesis</dt><dd className="text-slate-600">{synthesis.hypothesis} <span className="font-semibold">This is a {synthesis.confidence}-confidence idea to test, not proof.</span></dd></div></> : null}
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Chose next</dt><dd className="text-slate-600">{review.decision ? DECISION_LABELS[review.decision] : "Reviewed"}{nextExperiment?.action_label ? `: ${nextExperiment.action_label}` : "."}</dd></div>
             </dl>
           </li>;

--- a/src/components/review/WeeklyReviewClient.tsx
+++ b/src/components/review/WeeklyReviewClient.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, ArrowRight, Check, Loader2, Pause, RefreshCw, Repeat2, TrendingUp } from "lucide-react";
+import { ArrowLeft, ArrowRight, Check, Loader2, Pause, RefreshCw, Repeat2, Sparkles, TrendingUp } from "lucide-react";
 
 import type { WeeklyExperiment } from "@/lib/activation";
 import { suggestedNextPlan, type NextWeekPlan, type ReviewDecision } from "@/lib/weeklyReview";
+import type { WeeklySynthesis } from "@/lib/weeklySynthesis";
 
 type ReviewResponse = {
   ok: boolean;
@@ -32,6 +33,8 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
   const [nextPlan, setNextPlan] = useState<NextWeekPlan | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [synthesisLoading, setSynthesisLoading] = useState(false);
+  const [synthesis, setSynthesis] = useState<WeeklySynthesis | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -60,6 +63,32 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
     setNextPlan(experiment ? suggestedNextPlan(experiment, value) : null);
   }
 
+  async function requestSuggestion() {
+    if (!difficulty || !valueRating) return;
+    setSynthesisLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/weekly-review/synthesis", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ experiment_id: experimentId, difficulty, value_rating: valueRating }),
+      });
+      const json = await response.json().catch(() => null) as { ok?: boolean; synthesis?: WeeklySynthesis; error?: string } | null;
+      if (!response.ok || !json?.ok || !json.synthesis) throw new Error(reviewError(json?.error));
+      setSynthesis(json.synthesis);
+    } catch (suggestionError) {
+      setError(suggestionError instanceof Error ? suggestionError.message : "The suggestion is unavailable right now.");
+    } finally {
+      setSynthesisLoading(false);
+    }
+  }
+
+  function useSuggestion() {
+    if (!synthesis) return;
+    setDecision(synthesis.suggestedDecision);
+    setNextPlan(synthesis.suggestedPlan);
+  }
+
   async function finishReview() {
     if (!ready || !decision) return;
     setSaving(true);
@@ -68,7 +97,7 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
       const response = await fetch("/api/weekly-review", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ experiment_id: experimentId, difficulty, value_rating: valueRating, decision, next_plan: nextPlan }),
+        body: JSON.stringify({ experiment_id: experimentId, difficulty, value_rating: valueRating, decision, next_plan: nextPlan, synthesis_id: synthesis?.id ?? null }),
       });
       const json = await response.json().catch(() => null) as ReviewResponse | null;
       if (!response.ok || !json?.ok) throw new Error(reviewError(json?.error));
@@ -96,8 +125,17 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
         <p className="mt-2 text-sm text-white/70">Every completed repetition counts, including the minimum version.</p>
       </section>
 
-      <Rating title="How difficult was this practice to repeat?" low="Very easy" high="Very hard" value={difficulty} onChange={setDifficulty} />
-      <Rating title="How useful did this practice feel?" low="Not useful" high="Very useful" value={valueRating} onChange={setValueRating} />
+      <Rating title="How difficult was this practice to repeat?" low="Very easy" high="Very hard" value={difficulty} onChange={(value) => { setDifficulty(value); setSynthesis(null); }} />
+      <Rating title="How useful did this practice feel?" low="Not useful" high="Very useful" value={valueRating} onChange={(value) => { setValueRating(value); setSynthesis(null); }} />
+
+      {difficulty && valueRating ? (
+        synthesis ? <SynthesisCard synthesis={synthesis} onUse={useSuggestion} /> : (
+          <section className="mt-8 rounded-3xl border border-[#BCE3DA] bg-[#F4FAF8] p-6">
+            <div className="flex items-start gap-3"><Sparkles className="mt-1 h-5 w-5 shrink-0 text-[#087F72]" aria-hidden="true" /><div><h2 className="text-xl font-bold text-[#041B2D]">Want a grounded suggestion?</h2><p className="mt-2 text-sm leading-6 text-slate-600">LVE360 can reflect your recorded repetitions and ratings, then suggest one adjustable experiment for next week.</p></div></div>
+            <button type="button" onClick={() => void requestSuggestion()} disabled={synthesisLoading} className="mt-5 inline-flex min-h-11 items-center rounded-xl border border-[#087F72] bg-white px-4 py-2 text-sm font-bold text-[#087F72] hover:bg-[#EAFBF8] disabled:opacity-60">{synthesisLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Sparkles className="mr-2 h-4 w-4" />} Get a grounded suggestion</button>
+          </section>
+        )
+      ) : null}
 
       <section className="mt-10">
         <h2 className="text-2xl font-bold text-[#041B2D]">What should happen next?</h2>
@@ -123,6 +161,23 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
         {saving ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : <Check className="mr-2 h-5 w-5" />} Finish review <ArrowRight className="ml-2 h-4 w-4" />
       </button>
     </ReviewShell>
+  );
+}
+
+function SynthesisCard({ synthesis, onUse }: { synthesis: WeeklySynthesis; onUse: () => void }) {
+  const decisionLabel = decisions.find((item) => item.value === synthesis.suggestedDecision)?.title ?? "Try the suggestion";
+  return (
+    <section className="mt-8 rounded-3xl border border-[#9DCFC3] bg-[#EAFBF8] p-6 sm:p-8">
+      <div className="flex items-center gap-2"><Sparkles className="h-5 w-5 text-[#087F72]" aria-hidden="true" /><p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">LVE360 weekly reflection</p></div>
+      <div className="mt-5 grid gap-5 sm:grid-cols-2">
+        <div><h3 className="font-bold text-[#041B2D]">What the record shows</h3><p className="mt-2 text-sm leading-6 text-slate-700">{synthesis.observation}</p></div>
+        <div><h3 className="font-bold text-[#041B2D]">A hypothesis to test</h3><p className="mt-2 text-sm leading-6 text-slate-700">{synthesis.hypothesis}</p><p className="mt-2 text-xs font-semibold text-slate-500">{synthesis.confidence === "low" ? "Low confidence. More repetitions may change this view." : "Moderate confidence. This is still not proof of cause and effect."}</p></div>
+      </div>
+      <div className="mt-5 rounded-2xl bg-white p-4"><h3 className="text-sm font-bold text-[#041B2D]">Evidence used</h3><ul className="mt-2 space-y-1 text-sm text-slate-600">{synthesis.evidence.map((item) => <li key={item.label}><span className="font-semibold text-slate-700">{item.label}:</span> {item.value}</li>)}</ul></div>
+      <div className="mt-5"><p className="text-sm font-bold text-[#041B2D]">Suggested next step: {decisionLabel}</p>{synthesis.suggestedPlan ? <p className="mt-1 text-sm text-slate-600">{synthesis.suggestedPlan.action_label}, {synthesis.suggestedPlan.frequency_per_week} times next week.</p> : <p className="mt-1 text-sm text-slate-600">Pause this practice and choose your next focus when ready.</p>}</div>
+      <button type="button" onClick={onUse} className="mt-5 inline-flex min-h-11 items-center rounded-xl bg-[#087F72] px-4 py-2 text-sm font-bold text-white hover:bg-[#06695F]"><Check className="mr-2 h-4 w-4" /> Use this suggestion</button>
+      <p className="mt-3 text-xs leading-5 text-slate-500">You can edit every field below or choose a different option. Your choice always controls the next week.</p>
+    </section>
   );
 }
 
@@ -160,5 +215,6 @@ function reviewError(error?: string): string {
   if (error === "review_not_due") return "Your weekly review opens on the final day of this focused week.";
   if (error === "review_already_completed") return "This week has already been reviewed.";
   if (error === "invalid_next_plan") return "Check your next practice, cue, target, and minimum version.";
+  if (error === "weekly_synthesis_unavailable") return "The grounded suggestion is unavailable right now. You can still complete the review yourself.";
   return "Your weekly review is unavailable right now. Please try again.";
 }

--- a/src/lib/ai/modelConfig.ts
+++ b/src/lib/ai/modelConfig.ts
@@ -9,6 +9,7 @@ export type AiTask =
   | "blueprint_repair"
   | "blueprint_repair_main"
   | "today_brief"
+  | "weekly_review_synthesis"
   | "weekly_insight";
 
 export type AiTaskProfile = {
@@ -53,6 +54,11 @@ const TASK_PROFILES: Record<AiTask, AiTaskProfile> = {
   today_brief: {
     capability: "mini",
     promptVersion: "today-brief-v2",
+    reasoningEffort: "low",
+  },
+  weekly_review_synthesis: {
+    capability: "mini",
+    promptVersion: "weekly-review-synthesis-v1",
     reasoningEffort: "low",
   },
   weekly_insight: {

--- a/src/lib/ai/weeklySynthesisData.ts
+++ b/src/lib/ai/weeklySynthesisData.ts
@@ -1,0 +1,166 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import { generateAI } from "@/lib/ai/gateway";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import {
+  deterministicWeeklySynthesis,
+  isLowDataWeek,
+  parseGeneratedWeeklySynthesis,
+  WEEKLY_SYNTHESIS_PROMPT_VERSION,
+  type WeeklySynthesis,
+  type WeeklySynthesisContext,
+  type WeeklySynthesisContent,
+} from "@/lib/weeklySynthesis";
+
+type WeeklySynthesisRow = {
+  id: string;
+  source: "ai" | "fallback";
+  generation_status: WeeklySynthesis["generationStatus"];
+  observation: string;
+  hypothesis: string;
+  evidence: WeeklySynthesis["evidence"];
+  confidence: WeeklySynthesis["confidence"];
+  suggested_decision: WeeklySynthesis["suggestedDecision"];
+  suggested_action_label: string | null;
+  suggested_cue: string | null;
+  suggested_frequency_per_week: number | null;
+  suggested_minimum_version: string | null;
+  response_state: WeeklySynthesis["responseState"];
+};
+
+function stableHash(value: unknown) {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function rowToSynthesis(row: WeeklySynthesisRow): WeeklySynthesis {
+  const hasPlan = row.suggested_decision !== "pause"
+    && row.suggested_action_label
+    && row.suggested_cue
+    && row.suggested_frequency_per_week
+    && row.suggested_minimum_version;
+  return {
+    id: row.id,
+    source: row.source,
+    generationStatus: row.generation_status,
+    observation: row.observation,
+    hypothesis: row.hypothesis,
+    evidence: Array.isArray(row.evidence) ? row.evidence : [],
+    confidence: row.confidence,
+    suggestedDecision: row.suggested_decision,
+    suggestedPlan: hasPlan ? {
+      action_label: row.suggested_action_label as string,
+      cue: row.suggested_cue as string,
+      frequency_per_week: row.suggested_frequency_per_week as number,
+      minimum_version: row.suggested_minimum_version as string,
+    } : null,
+    responseState: row.response_state,
+  };
+}
+
+function rowValues(userId: string, experimentId: string, contextHash: string, content: WeeklySynthesisContent) {
+  return {
+    user_id: userId,
+    experiment_id: experimentId,
+    context_hash: contextHash,
+    prompt_version: WEEKLY_SYNTHESIS_PROMPT_VERSION,
+    source: "fallback",
+    generation_status: "pending",
+    observation: content.observation,
+    hypothesis: content.hypothesis,
+    evidence: content.evidence,
+    confidence: content.confidence,
+    suggested_decision: content.suggestedDecision,
+    suggested_action_label: content.suggestedPlan?.action_label ?? null,
+    suggested_cue: content.suggestedPlan?.cue ?? null,
+    suggested_frequency_per_week: content.suggestedPlan?.frequency_per_week ?? null,
+    suggested_minimum_version: content.suggestedPlan?.minimum_version ?? null,
+  };
+}
+
+function generatedPrompt(context: WeeklySynthesisContext) {
+  return [
+    {
+      role: "system" as const,
+      content: [
+        "You write a short weekly lifestyle-practice reflection for LVE360.",
+        "Use only the supplied recorded behavior and member ratings.",
+        "Return only valid JSON with exactly two string fields: observation and hypothesis.",
+        "The observation must state recorded facts neutrally.",
+        "The hypothesis must be framed as a possibility to test, never as cause and effect.",
+        "Do not mention supplements, medications, diagnoses, treatment, tests, doses, or new health facts.",
+        "Do not shame the member or use failed, lazy, behind, should have, or similar language.",
+      ].join(" "),
+    },
+    {
+      role: "user" as const,
+      content: JSON.stringify({
+        practice: context.experiment.action_label,
+        cue: context.experiment.cue,
+        minimum_version: context.experiment.minimum_version,
+        planned_repetitions: context.target,
+        completed_repetitions: context.completedCount,
+        difficulty_rating: context.difficulty,
+        usefulness_rating: context.valueRating,
+        check_ins_recorded: context.checkIns.length,
+      }),
+    },
+  ];
+}
+
+export async function getOrCreateWeeklySynthesis(userId: string, context: WeeklySynthesisContext): Promise<WeeklySynthesis> {
+  const admin = getSupabaseAdmin();
+  const contextHash = stableHash({ promptVersion: WEEKLY_SYNTHESIS_PROMPT_VERSION, context });
+  const loadExisting = () => admin.from("ai_weekly_syntheses").select("*")
+    .eq("user_id", userId).eq("experiment_id", context.experiment.id).eq("context_hash", contextHash);
+  const { data: existing, error: existingError } = await loadExisting().maybeSingle();
+  if (existingError) throw existingError;
+  if (existing) return rowToSynthesis(existing as WeeklySynthesisRow);
+
+  const fallback = deterministicWeeklySynthesis(context);
+  const values = rowValues(userId, context.experiment.id, contextHash, fallback);
+  const { data: claimed, error: claimError } = await admin.from("ai_weekly_syntheses").insert(values).select("*").single();
+  if (claimError?.code === "23505") {
+    const { data: raced, error } = await loadExisting().single();
+    if (error) throw error;
+    return rowToSynthesis(raced as WeeklySynthesisRow);
+  }
+  if (claimError || !claimed) throw claimError ?? new Error("weekly_synthesis_claim_failed");
+
+  if (isLowDataWeek(context)) {
+    const { data, error } = await admin.from("ai_weekly_syntheses")
+      .update({ generation_status: "skipped", updated_at: new Date().toISOString() })
+      .eq("id", claimed.id).select("*").single();
+    if (error) throw error;
+    return rowToSynthesis(data as WeeklySynthesisRow);
+  }
+
+  try {
+    const response = await generateAI({
+      task: "weekly_review_synthesis",
+      userId,
+      messages: generatedPrompt(context),
+      maxTokens: 180,
+      timeoutMs: 20_000,
+      temperature: 0.2,
+    });
+    const generated = parseGeneratedWeeklySynthesis(response.text, context);
+    const content = generated ?? fallback;
+    const { data, error } = await admin.from("ai_weekly_syntheses").update({
+      ...rowValues(userId, context.experiment.id, contextHash, content),
+      source: generated ? "ai" : "fallback",
+      generation_status: generated ? "succeeded" : "failed",
+      updated_at: new Date().toISOString(),
+    }).eq("id", claimed.id).select("*").single();
+    if (error) throw error;
+    return rowToSynthesis(data as WeeklySynthesisRow);
+  } catch (error) {
+    console.warn("[weekly-synthesis] generation unavailable; using saved fallback", error);
+    const { data, error: updateError } = await admin.from("ai_weekly_syntheses")
+      .update({ generation_status: "failed", updated_at: new Date().toISOString() })
+      .eq("id", claimed.id).select("*").single();
+    if (updateError) throw updateError;
+    return rowToSynthesis(data as WeeklySynthesisRow);
+  }
+}

--- a/src/lib/journey.ts
+++ b/src/lib/journey.ts
@@ -46,12 +46,24 @@ export type JourneyCheckIn = {
   energy: number | null;
 };
 
+export type JourneySynthesis = {
+  id: string;
+  experiment_id: string;
+  observation: string;
+  hypothesis: string;
+  evidence: Array<{ label: string; value: string }>;
+  confidence: "low" | "moderate";
+  response_state: "none" | "accepted" | "edited" | "rejected";
+  created_at: string;
+};
+
 export type JourneyResponse = {
   ok: boolean;
   experiments: JourneyExperiment[];
   reviews: JourneyReview[];
   completions: JourneyCompletion[];
   check_ins: JourneyCheckIn[];
+  syntheses: JourneySynthesis[];
   blueprint: import("@/lib/blueprintContext").CurrentBlueprintContext | null;
   experiment_blueprints: Record<string, import("@/lib/blueprintContext").ExperimentBlueprintContext>;
   error?: string;

--- a/src/lib/weeklyReview.ts
+++ b/src/lib/weeklyReview.ts
@@ -25,7 +25,10 @@ export function isReviewDecision(value: unknown): value is ReviewDecision {
   return typeof value === "string" && REVIEW_DECISIONS.includes(value as ReviewDecision);
 }
 
-export function suggestedNextPlan(experiment: WeeklyExperiment, decision: ReviewDecision): NextWeekPlan | null {
+export function suggestedNextPlan(
+  experiment: Pick<WeeklyExperiment, "action_label" | "cue" | "frequency_per_week" | "minimum_version">,
+  decision: ReviewDecision,
+): NextWeekPlan | null {
   if (decision === "pause") return null;
   const frequency = experiment.frequency_per_week ?? 1;
   return {

--- a/src/lib/weeklySynthesis.ts
+++ b/src/lib/weeklySynthesis.ts
@@ -1,0 +1,157 @@
+import { z } from "zod";
+
+import { STARTER_ACTIONS, type IdentityDirection, type WeeklyExperiment } from "./activation";
+import { suggestedNextPlan, type NextWeekPlan, type ReviewDecision } from "./weeklyReview";
+
+export const WEEKLY_SYNTHESIS_PROMPT_VERSION = "weekly-review-synthesis-v1";
+
+export type WeeklySynthesisEvidence = {
+  label: string;
+  value: string;
+};
+
+export type WeeklySynthesisContext = {
+  experiment: Pick<WeeklyExperiment, "id" | "identity_direction" | "action_label" | "cue" | "frequency_per_week" | "minimum_version" | "week_start">;
+  completedDates: string[];
+  completedCount: number;
+  target: number;
+  difficulty: number;
+  valueRating: number;
+  checkIns: Array<{ date: string; sleep: number | null; energy: number | null }>;
+};
+
+export type WeeklySynthesisContent = {
+  observation: string;
+  hypothesis: string;
+  evidence: WeeklySynthesisEvidence[];
+  confidence: "low" | "moderate";
+  suggestedDecision: ReviewDecision;
+  suggestedPlan: NextWeekPlan | null;
+};
+
+export type WeeklySynthesis = WeeklySynthesisContent & {
+  id: string;
+  source: "ai" | "fallback";
+  generationStatus: "pending" | "succeeded" | "failed" | "skipped";
+  responseState: "none" | "accepted" | "edited" | "rejected";
+};
+
+const GeneratedSynthesisSchema = z.object({
+  observation: z.string().trim().min(12).max(220),
+  hypothesis: z.string().trim().min(12).max(280),
+}).strict();
+
+const INTERVENTION_PATTERN = /\b(?:b[- ]?12|supplement|vitamin|mineral|magnesium|creatine|omega[- ]?3|fish oil|medication|medicine|drug|dose|dosage|prescription|clinician|physician|doctor|pharmacist|blood test|lab(?:oratory)?|mg|mcg|iu|tablet|capsule)\b/i;
+const MEDICAL_CLAIM_PATTERN = /\b(?:diagnos|treat|cure|prevent|reverse|manage)\w*\s+(?:a\s+|an\s+|your\s+)?(?:disease|condition|disorder|syndrome|symptom)/i;
+const DISCOURAGING_PATTERN = /\b(?:failed|failure|lazy|behind|should have|haven't|have not)\b/i;
+
+function safeGeneratedText(value: string) {
+  return !INTERVENTION_PATTERN.test(value)
+    && !MEDICAL_CLAIM_PATTERN.test(value)
+    && !DISCOURAGING_PATTERN.test(value);
+}
+
+function average(values: number[]) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+export function isLowDataWeek(context: WeeklySynthesisContext) {
+  return context.completedCount < 2 && context.checkIns.length < 2;
+}
+
+export function recommendedReviewDecision(context: WeeklySynthesisContext): ReviewDecision {
+  const completionRatio = context.target > 0 ? context.completedCount / context.target : 0;
+  if (context.valueRating <= 2) return "swap";
+  if (context.difficulty >= 4 || completionRatio < 0.6) return "shrink";
+  if (completionRatio >= 1 && context.valueRating >= 4 && context.difficulty <= 2) return "advance";
+  return "keep";
+}
+
+export function recommendedNextPlan(context: WeeklySynthesisContext, decision: ReviewDecision): NextWeekPlan | null {
+  if (decision !== "swap") return suggestedNextPlan(context.experiment, decision);
+
+  const domain = context.experiment.identity_direction ?? "overall_health";
+  const options = STARTER_ACTIONS[domain as IdentityDirection] ?? STARTER_ACTIONS.overall_health;
+  const current = context.experiment.action_label?.trim().toLowerCase() ?? "";
+  const replacement = options.find((option) => option.toLowerCase() !== current) ?? options[0];
+  return {
+    action_label: replacement,
+    cue: context.experiment.cue ?? "After a routine I already do",
+    frequency_per_week: Math.max(1, Math.min(3, context.target)),
+    minimum_version: context.experiment.minimum_version ?? "Take the first small step",
+  };
+}
+
+export function weeklySynthesisEvidence(context: WeeklySynthesisContext): WeeklySynthesisEvidence[] {
+  const evidence: WeeklySynthesisEvidence[] = [
+    { label: "Practice repetitions", value: `${context.completedCount} of ${context.target} planned` },
+    { label: "Difficulty reflection", value: `${context.difficulty} of 5` },
+    { label: "Usefulness reflection", value: `${context.valueRating} of 5` },
+  ];
+  if (context.checkIns.length) {
+    evidence.push({ label: "Daily check-ins", value: `${context.checkIns.length} recorded` });
+    const sleep = average(context.checkIns.flatMap((item) => typeof item.sleep === "number" ? [item.sleep] : []));
+    const energy = average(context.checkIns.flatMap((item) => typeof item.energy === "number" ? [item.energy] : []));
+    if (sleep != null) evidence.push({ label: "Average sleep check-in", value: `${sleep.toFixed(1)} of 5` });
+    if (energy != null) evidence.push({ label: "Average energy check-in", value: `${energy.toFixed(1)} of 10` });
+  }
+  return evidence;
+}
+
+export function deterministicWeeklySynthesis(context: WeeklySynthesisContext): WeeklySynthesisContent {
+  const decision = recommendedReviewDecision(context);
+  const early = isLowDataWeek(context);
+  const observation = early
+    ? `This is an early signal from ${context.completedCount} recorded practice ${context.completedCount === 1 ? "repetition" : "repetitions"} and ${context.checkIns.length} daily ${context.checkIns.length === 1 ? "check-in" : "check-ins"}.`
+    : `You completed ${context.completedCount} of ${context.target} planned repetitions and rated the practice ${context.valueRating} of 5 for usefulness and ${context.difficulty} of 5 for difficulty.`;
+  const hypotheses: Record<ReviewDecision, string> = {
+    keep: "The current version may be a workable fit. Repeating it for another week would test whether that fit is consistent.",
+    shrink: "The practice may still be worthwhile, but its current size, timing, or setup may be creating friction. A smaller version would test that idea.",
+    swap: "The practice may not feel useful enough to earn another week. A different small action in the same life area may be more informative.",
+    pause: "A pause may create room to decide what deserves attention next.",
+    advance: "The practice felt useful and repeatable this week. A very small increase would test whether it can grow without becoming burdensome.",
+  };
+  return {
+    observation,
+    hypothesis: hypotheses[decision],
+    evidence: weeklySynthesisEvidence(context),
+    confidence: early ? "low" : "moderate",
+    suggestedDecision: decision,
+    suggestedPlan: recommendedNextPlan(context, decision),
+  };
+}
+
+export function parseGeneratedWeeklySynthesis(raw: string, context: WeeklySynthesisContext): WeeklySynthesisContent | null {
+  const candidate = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+  const result = GeneratedSynthesisSchema.safeParse(parsed);
+  if (!result.success || !safeGeneratedText(result.data.observation) || !safeGeneratedText(result.data.hypothesis)) return null;
+  const fallback = deterministicWeeklySynthesis(context);
+  return {
+    ...fallback,
+    observation: result.data.observation,
+    hypothesis: result.data.hypothesis,
+  };
+}
+
+function samePlan(left: NextWeekPlan | null, right: NextWeekPlan | null) {
+  if (!left || !right) return left === right;
+  return left.action_label.trim() === right.action_label.trim()
+    && left.cue.trim() === right.cue.trim()
+    && left.frequency_per_week === right.frequency_per_week
+    && left.minimum_version.trim() === right.minimum_version.trim();
+}
+
+export function synthesisResponseState(
+  synthesis: Pick<WeeklySynthesisContent, "suggestedDecision" | "suggestedPlan">,
+  decision: ReviewDecision,
+  plan: NextWeekPlan | null,
+): "accepted" | "edited" | "rejected" {
+  if (decision !== synthesis.suggestedDecision) return "rejected";
+  return samePlan(plan, synthesis.suggestedPlan) ? "accepted" : "edited";
+}

--- a/supabase/migrations/20260811034153_pr101_ai_weekly_syntheses.sql
+++ b/supabase/migrations/20260811034153_pr101_ai_weekly_syntheses.sql
@@ -1,0 +1,42 @@
+-- PR101: Cache evidence-grounded weekly AI reflections and member responses.
+-- Server-only access is intentional. The browser reaches this data through paid,
+-- authenticated application routes that verify row ownership.
+
+create table if not exists public.ai_weekly_syntheses (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  experiment_id uuid not null references public.weekly_experiments(id) on delete cascade,
+  context_hash text not null check (length(context_hash) = 64),
+  prompt_version text not null check (length(prompt_version) between 3 and 80),
+  source text not null check (source in ('ai', 'fallback')),
+  generation_status text not null check (generation_status in ('pending', 'succeeded', 'failed', 'skipped')),
+  observation text not null check (length(observation) between 1 and 500),
+  hypothesis text not null check (length(hypothesis) between 1 and 500),
+  evidence jsonb not null default '[]'::jsonb check (jsonb_typeof(evidence) = 'array'),
+  confidence text not null check (confidence in ('low', 'moderate')),
+  suggested_decision text not null check (suggested_decision in ('keep', 'shrink', 'swap', 'pause', 'advance')),
+  suggested_action_label text,
+  suggested_cue text,
+  suggested_frequency_per_week integer check (suggested_frequency_per_week between 1 and 7),
+  suggested_minimum_version text,
+  response_state text not null default 'none' check (response_state in ('none', 'accepted', 'edited', 'rejected')),
+  next_experiment_id uuid references public.weekly_experiments(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, experiment_id, context_hash)
+);
+
+create index if not exists ai_weekly_syntheses_user_updated_idx
+  on public.ai_weekly_syntheses (user_id, updated_at desc);
+create index if not exists ai_weekly_syntheses_experiment_idx
+  on public.ai_weekly_syntheses (experiment_id);
+
+alter table public.ai_weekly_syntheses enable row level security;
+revoke all on table public.ai_weekly_syntheses from public, anon, authenticated;
+grant select, insert, update on table public.ai_weekly_syntheses to service_role;
+
+comment on table public.ai_weekly_syntheses is
+  'Server-only cached weekly reflections. Observations are separated from non-causal hypotheses.';
+
+-- Rollback:
+-- drop table if exists public.ai_weekly_syntheses;


### PR DESCRIPTION
Summary
- Relabels the Today snooze action as Hide for 3 hours so the wording matches its behavior.
- Adds an optional, evidence-grounded AI reflection to the existing weekly review.
- Keeps the member in control with editable accept, change, or reject paths.
- Carries saved observations and clearly labeled hypotheses into Journey.
- Caches synthesis results, skips model calls for low-data weeks, and routes generation through the cost-conscious mini capability.

Safety and privacy
- AI can write only the observation and hypothesis. Deterministic product logic controls evidence, confidence, decision, and next-week plan.
- Generated text rejects medication, supplement, diagnostic, treatment, dose, testing, and shaming language.
- The new Supabase table is server-only with RLS enabled and no direct anon or authenticated grants.
- Account export includes saved weekly syntheses.

Verification
- npm.cmd run qa:pr101
- npm.cmd run qa:pr100
- npm.cmd run qa:journey
- npm.cmd run qa:pr80
- npm.cmd run qa:pr96
- npm.cmd run typecheck
- git diff --check
- Supabase migration applied and verified for RLS and grants

Preview QA
- Confirm the Vercel build passes.
- Complete a due weekly review with and without the AI suggestion.
- Verify accept, edit, and alternate-choice behavior.
- Confirm the completed observation and hypothesis appear in Journey.