### PR TITLE
PR102 — Build the Routine Copilot

### DIFF
--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -24,6 +24,7 @@ import {
 import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 
+import RoutineCopilotPanel from "@/components/routine/RoutineCopilotPanel";
 import {
   groupRoutineItems,
   isClinicianReviewProposal,
@@ -57,6 +58,7 @@ type ToastState = { message: string; undo?: () => Promise<void> } | null;
 type RoutineView = "today" | "medications" | "hormones" | "supplements";
 type RoutineEditPatch = {
   dose?: string | null;
+  timing?: string | null;
   doseConfirmed?: boolean;
   schedule?: RoutineItem["schedule"];
   instructionAuthority?: RegimenInstructionAuthority;
@@ -148,6 +150,7 @@ export default function RoutineClient({
     setBusyId(item.id);
     const previous = {
       dose: item.dose,
+      timing: item.timing,
       doseConfirmed: Boolean(doseIntegrityIssue(item.name, item.dose)),
       schedule: item.schedule ?? null,
       instructionAuthority: item.instruction_authority ?? undefined,
@@ -666,6 +669,7 @@ function IdeasSection({
 function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineItem; saving: boolean; onClose: () => void; onSave: (item: RoutineItem, patch: RoutineEditPatch) => void }) {
   const prescribedItem = item.item_kind === "medication" || item.item_kind === "hormone";
   const [dose, setDose] = useState(item.dose ?? "");
+  const [timing, setTiming] = useState(item.timing ?? "");
   const [brand, setBrand] = useState(item.brand ?? "");
   const [reorderUrl, setReorderUrl] = useState(item.reorder_url ?? "");
   const [schedule, setSchedule] = useState<ScheduleDraft>(() => scheduleDraft(item.schedule));
@@ -688,6 +692,18 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
           ? "Use this only to record a change you received from your clinician, pharmacist, or current prescription label. LVE360 is not changing or recommending your prescription."
           : "Record what you currently do. This does not create a medical instruction or replace a product label."}
       </p>
+      <RoutineCopilotPanel
+        kind={item.item_kind}
+        existingName={item.name}
+        onApply={(proposal) => {
+          if (proposal.dose) {
+            setDose(proposal.dose);
+            setDoseConfirmed(false);
+          }
+          if (proposal.timing) setTiming(proposal.timing);
+          if (proposal.schedule) setSchedule(scheduleDraft(proposal.schedule));
+        }}
+      />
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">{prescribedItem ? "Prescribed dose at each scheduled time" : "Amount at each scheduled time"}<input autoFocus value={dose} onChange={(event) => { setDose(event.target.value); setDoseConfirmed(false); }} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={item.item_kind === "hormone" ? "For example, 80 mg" : "For example, 2 capsules"} /></label>
       {item.schedule && item.schedule.times.length > 1 ? <p className="mt-2 text-sm leading-6 text-slate-600">This amount is shown for every scheduled time. If the amount is a full-day total, enter the amount you take at one scheduled time instead.</p> : null}
       {doseIssue ? (
@@ -706,7 +722,7 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
           {!reorderUrlReady ? <p className="text-sm font-semibold text-rose-700 sm:col-span-2">Use a complete secure link that begins with https://.</p> : null}
         </div>
       ) : null}
-      {!item.schedule && item.timing ? <p className="mt-4 rounded-xl bg-slate-50 p-3 text-sm text-slate-700"><span className="font-bold">Current written schedule:</span> {item.timing}. Choose a structured cadence below to use the daily checklist.</p> : null}
+      <label className="mt-5 block text-sm font-bold text-[#041B2D]">Written schedule <span className="font-normal text-slate-500">(copied from your current instructions)</span><input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, once weekly on Sunday" /></label>
       <ScheduleEditor value={schedule} onChange={setSchedule} />
       {sourceRequired ? (
         <label className="mt-5 block text-sm font-bold text-[#041B2D]">
@@ -721,6 +737,7 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
         <button type="button" onClick={onClose} disabled={saving} className="min-h-12 rounded-xl border border-slate-300 px-4 py-3 font-bold text-slate-700">Cancel</button>
         <button type="button" disabled={saving || !scheduleReady || !reorderUrlReady || Boolean(doseIssue && !doseConfirmed) || (sourceRequired && !instructionAuthority)} onClick={() => onSave(item, {
           dose: dose.trim() || null,
+          timing: timing.trim() || null,
           ...(doseIssue ? { doseConfirmed } : {}),
           ...(!prescribedItem ? { brand: brand.trim() || null, reorderUrl: reorderUrl.trim() || null } : {}),
           ...(hasStructuredSchedule ? { schedule: scheduleDraftPayload(schedule) } : {}),
@@ -776,6 +793,15 @@ function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-950">
         Record only what you currently take based on your clinician, pharmacist, or prescription label. This does not ask LVE360 to recommend a {label} or dose.
       </div>
+      <RoutineCopilotPanel
+        kind={kind}
+        onApply={(proposal) => {
+          if (proposal.name) setName(proposal.name);
+          if (proposal.dose) setDose(proposal.dose);
+          if (proposal.timing) setTiming(proposal.timing);
+          if (proposal.schedule) setSchedule(scheduleDraft(proposal.schedule));
+        }}
+      />
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">{kind === "hormone" ? "Hormone name" : "Medication name"}<input autoFocus value={name} onChange={(event) => setName(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, testosterone cypionate" : "For example, Zepbound"} /></label>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Prescribed dose<input value={dose} onChange={(event) => setDose(event.target.value)} maxLength={120} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, 80 mg" : "For example, 10 mg / 0.5 mL"} /></label>
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Schedule<input value={timing} onChange={(event) => setTiming(event.target.value)} maxLength={160} className="mt-2 min-h-12 w-full rounded-xl border border-slate-300 px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder={kind === "hormone" ? "For example, Monday and Thursday evenings" : "For example, once weekly on Sunday"} /></label>

--- a/app/(app)/routine/print/page.tsx
+++ b/app/(app)/routine/print/page.tsx
@@ -4,7 +4,7 @@ import { requireTier } from "@/app/_auth/requireTier";
 import { groupRoutineItems, ROUTINE_SECTION_LABELS, ROUTINE_SECTION_ORDER, routineInstructionAuthorityLabel, routineScheduleLabel } from "@/lib/routine";
 import { getRoutineData } from "@/lib/routineData";
 import { doseIntegrityIssue } from "@/lib/doseIntegrity";
-import { clinicianRoutineChanges, clinicianRoutineQuestions } from "@/lib/clinicianRoutineSummary";
+import { clinicianRoutineQuestions } from "@/lib/clinicianRoutineSummary";
 
 import PrintButton from "./PrintButton";
 
@@ -16,7 +16,6 @@ export default async function RoutinePrintPage() {
   const data = await getRoutineData(user.id);
   const grouped = groupRoutineItems(data.items);
   const generatedAt = new Date();
-  const changes = clinicianRoutineChanges(grouped.current);
   const questions = clinicianRoutineQuestions(grouped.current);
 
   return (
@@ -38,17 +37,7 @@ export default async function RoutinePrintPage() {
         </p>
       </header>
 
-      <section className="mt-6 break-inside-avoid rounded-xl border border-slate-300 p-4 print:rounded-none" aria-labelledby="member-change-summary">
-        <h2 id="member-change-summary" className="text-lg font-bold text-[#041B2D]">Member-recorded changes</h2>
-        <p className="mt-1 text-sm leading-6 text-slate-600">These statements describe how the member’s LVE360 record was created or updated. They do not verify a clinical change.</p>
-        {changes.length ? (
-          <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-slate-700">
-            {changes.map((change) => <li key={`${change.itemId}-${change.description}`}><strong>{change.itemName}:</strong> {change.description}</li>)}
-          </ol>
-        ) : <p className="mt-3 text-sm text-slate-700">No member-added or member-updated items are identified in the current record.</p>}
-      </section>
-
-      <section className="mt-5 break-inside-avoid rounded-xl border border-amber-300 bg-amber-50 p-4 print:rounded-none" aria-labelledby="organized-review-questions">
+      <section className="mt-6 break-inside-avoid rounded-xl border border-amber-300 bg-amber-50 p-4 print:rounded-none" aria-labelledby="organized-review-questions">
         <h2 id="organized-review-questions" className="text-lg font-bold text-[#041B2D]">LVE360-organized questions for review</h2>
         <p className="mt-1 text-sm leading-6 text-amber-950">These questions are generated from missing or potentially unclear member-entered fields. They are not treatment or dosing recommendations.</p>
         {questions.length ? (

--- a/app/(app)/routine/print/page.tsx
+++ b/app/(app)/routine/print/page.tsx
@@ -4,6 +4,7 @@ import { requireTier } from "@/app/_auth/requireTier";
 import { groupRoutineItems, ROUTINE_SECTION_LABELS, ROUTINE_SECTION_ORDER, routineInstructionAuthorityLabel, routineScheduleLabel } from "@/lib/routine";
 import { getRoutineData } from "@/lib/routineData";
 import { doseIntegrityIssue } from "@/lib/doseIntegrity";
+import { clinicianRoutineChanges, clinicianRoutineQuestions } from "@/lib/clinicianRoutineSummary";
 
 import PrintButton from "./PrintButton";
 
@@ -15,6 +16,8 @@ export default async function RoutinePrintPage() {
   const data = await getRoutineData(user.id);
   const grouped = groupRoutineItems(data.items);
   const generatedAt = new Date();
+  const changes = clinicianRoutineChanges(grouped.current);
+  const questions = clinicianRoutineQuestions(grouped.current);
 
   return (
     <article className="mx-auto max-w-4xl rounded-2xl bg-white p-5 shadow-sm print:max-w-none print:rounded-none print:p-0 print:shadow-none sm:p-8">
@@ -34,6 +37,26 @@ export default async function RoutinePrintPage() {
           This list reflects information recorded by the member. It is provided to support review and reconciliation. LVE360 does not prescribe, change, or verify medication, hormone, or supplement instructions.
         </p>
       </header>
+
+      <section className="mt-6 break-inside-avoid rounded-xl border border-slate-300 p-4 print:rounded-none" aria-labelledby="member-change-summary">
+        <h2 id="member-change-summary" className="text-lg font-bold text-[#041B2D]">Member-recorded changes</h2>
+        <p className="mt-1 text-sm leading-6 text-slate-600">These statements describe how the member’s LVE360 record was created or updated. They do not verify a clinical change.</p>
+        {changes.length ? (
+          <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-slate-700">
+            {changes.map((change) => <li key={`${change.itemId}-${change.description}`}><strong>{change.itemName}:</strong> {change.description}</li>)}
+          </ol>
+        ) : <p className="mt-3 text-sm text-slate-700">No member-added or member-updated items are identified in the current record.</p>}
+      </section>
+
+      <section className="mt-5 break-inside-avoid rounded-xl border border-amber-300 bg-amber-50 p-4 print:rounded-none" aria-labelledby="organized-review-questions">
+        <h2 id="organized-review-questions" className="text-lg font-bold text-[#041B2D]">LVE360-organized questions for review</h2>
+        <p className="mt-1 text-sm leading-6 text-amber-950">These questions are generated from missing or potentially unclear member-entered fields. They are not treatment or dosing recommendations.</p>
+        {questions.length ? (
+          <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-amber-950">
+            {questions.map((question) => <li key={`${question.itemId}-${question.question}`}><strong>{question.itemName}:</strong> {question.question}</li>)}
+          </ol>
+        ) : <p className="mt-3 text-sm text-amber-950">No clarification questions were generated from the recorded fields.</p>}
+      </section>
 
       <div className="mt-6 space-y-7">
         {ROUTINE_SECTION_ORDER.map((kind) => {

--- a/app/api/routine/copilot/route.ts
+++ b/app/api/routine/copilot/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+import { organizeRoutineInstructions } from "@/lib/ai/routineCopilotData";
+import { getCurrentRegimen } from "@/lib/currentRegimen";
+import { requirePaidApi } from "@/lib/serverEntitlements";
+import { addRoutineScheduleContext, type RoutineCopilotKind } from "@/lib/routineCopilot";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const KINDS: RoutineCopilotKind[] = ["medication", "hormone", "supplement", "endocrine_active_supplement"];
+
+export async function POST(req: Request) {
+  const entitlement = await requirePaidApi();
+  if (!entitlement.ok) return entitlement.response;
+
+  try {
+    const body = await req.json().catch(() => null);
+    const sourceText = typeof body?.sourceText === "string" ? body.sourceText.replace(/\s+/g, " ").trim() : "";
+    const kind = body?.kind as RoutineCopilotKind;
+    const existingName = typeof body?.existingName === "string" ? body.existingName.trim().slice(0, 120) : null;
+    if (!KINDS.includes(kind) || sourceText.length < 3 || sourceText.length > 1200) {
+      return NextResponse.json({ ok: false, error: "invalid_routine_instructions" }, { status: 400 });
+    }
+
+    const [proposal, currentItems] = await Promise.all([
+      organizeRoutineInstructions({ userId: entitlement.user.id, sourceText, kind, existingName }),
+      getCurrentRegimen(entitlement.user.id),
+    ]);
+    return NextResponse.json({ ok: true, proposal: addRoutineScheduleContext(proposal, currentItems, existingName) });
+  } catch (error) {
+    console.error("[routine-copilot] request failed", error);
+    return NextResponse.json({ ok: false, error: "routine_copilot_unavailable" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "qa:pr99": "node src/_tests_/pr99AiGateway.assert.mjs",
     "qa:pr100": "node --experimental-strip-types src/_tests_/pr100TodayBrief.assert.ts && node src/_tests_/pr100Page.assert.mjs",
     "qa:pr101": "node src/_tests_/pr101Page.assert.mjs",
+    "qa:pr102": "node --experimental-strip-types src/_tests_/pr102RoutineCopilot.assert.ts && node src/_tests_/pr102Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr102Page.assert.mjs
+++ b/src/_tests_/pr102Page.assert.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+const route = read("app/api/routine/copilot/route.ts");
+const panel = read("src/components/routine/RoutineCopilotPanel.tsx");
+const client = read("app/(app)/routine/RoutineClient.tsx");
+const modelConfig = read("src/lib/ai/modelConfig.ts");
+const printPage = read("app/(app)/routine/print/page.tsx");
+
+assert.match(route, /requirePaidApi/, "Routine Copilot must remain paid-gated.");
+assert.doesNotMatch(route, /\.insert\(|\.update\(|\.upsert\(/, "Routine Copilot proposals must not write regimen data.");
+assert.match(panel, /Apply to form/, "The proposal must require explicit form application.");
+assert.match(panel, /still not saved|Nothing is saved/, "The UI must distinguish proposal application from persistence.");
+assert.match(client, /RoutineCopilotPanel/, "Add and edit flows must expose the organizer.");
+assert.match(client, /Save record/, "The existing save confirmation must remain in place.");
+assert.match(client, /Add reported \{label\}/, "The existing add confirmation must remain in place.");
+assert.match(modelConfig, /routine_label_parser[\s\S]*capability: "mini"/, "The parser must use the cost-conscious mini capability.");
+assert.match(printPage, /Member-recorded changes/, "The printout must label member-entered facts.");
+assert.match(printPage, /LVE360-organized questions for review/, "The printout must distinguish organized questions from facts.");
+assert.match(printPage, /not treatment or dosing recommendations/, "The clinician questions must state their boundary.");
+
+console.log("PR102 page and boundary assertions passed.");

--- a/src/_tests_/pr102Page.assert.mjs
+++ b/src/_tests_/pr102Page.assert.mjs
@@ -16,7 +16,8 @@ assert.match(client, /RoutineCopilotPanel/, "Add and edit flows must expose the 
 assert.match(client, /Save record/, "The existing save confirmation must remain in place.");
 assert.match(client, /Add reported \{label\}/, "The existing add confirmation must remain in place.");
 assert.match(modelConfig, /routine_label_parser[\s\S]*capability: "mini"/, "The parser must use the cost-conscious mini capability.");
-assert.match(printPage, /Member-recorded changes/, "The printout must label member-entered facts.");
+assert.doesNotMatch(printPage, /Member-recorded changes/, "The printout must not spend space on repetitive change provenance.");
+assert.match(printPage, /LVE360 member record/, "The printout must still identify the regimen as a member record.");
 assert.match(printPage, /LVE360-organized questions for review/, "The printout must distinguish organized questions from facts.");
 assert.match(printPage, /not treatment or dosing recommendations/, "The clinician questions must state their boundary.");
 

--- a/src/_tests_/pr102RoutineCopilot.assert.ts
+++ b/src/_tests_/pr102RoutineCopilot.assert.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+
+import { clinicianRoutineChanges, clinicianRoutineQuestions } from "../lib/clinicianRoutineSummary.ts";
+import { addRoutineScheduleContext, buildRoutineCopilotProposal } from "../lib/routineCopilot.ts";
+import type { RoutineItem } from "../lib/routine.ts";
+
+const weekly = buildRoutineCopilotProposal({
+  sourceText: "Zepbound 10 mg / 0.5 mL once weekly on Sunday at 8:00 AM",
+  kind: "medication",
+  extraction: {
+    name_quote: "Zepbound",
+    dose_quote: "10 mg / 0.5 mL",
+    schedule_quote: "once weekly on Sunday at 8:00 AM",
+  },
+});
+assert.equal(weekly.name, "Zepbound");
+assert.equal(weekly.dose, "10 mg / 0.5 mL");
+assert.deepEqual(weekly.schedule, {
+  cadence: "weekly",
+  times: ["08:00"],
+  weekdays: [0],
+  interval_days: null,
+  anchor_date: null,
+});
+assert.deepEqual(weekly.missingFields, []);
+
+const vague = buildRoutineCopilotProposal({
+  sourceText: "Magnesium glycinate 2 capsules in the evening",
+  kind: "supplement",
+  extraction: {
+    name_quote: "Magnesium glycinate",
+    dose_quote: "2 capsules",
+    schedule_quote: "in the evening",
+  },
+});
+assert.equal(vague.schedule, null);
+assert.match(vague.questions.join(" "), /exact clock time/i);
+
+const everyFewDays = buildRoutineCopilotProposal({
+  sourceText: "Take 1 tablet every 2 days at 7 AM",
+  kind: "medication",
+  extraction: { dose_quote: "1 tablet", schedule_quote: "every 2 days at 7 AM" },
+});
+assert.equal(everyFewDays.schedule, null);
+assert.match(everyFewDays.questions.join(" "), /starting date/i);
+
+const protectedAgainstInvention = buildRoutineCopilotProposal({
+  sourceText: "Take 5 mg daily at 9 PM",
+  kind: "medication",
+  extraction: { name_quote: "Invented drug", dose_quote: "20 mg", schedule_quote: "daily at 8 AM" },
+});
+assert.equal(protectedAgainstInvention.name, null);
+assert.equal(protectedAgainstInvention.dose, "5 mg");
+assert.equal(protectedAgainstInvention.timing, "Take 5 mg daily at 9 PM");
+assert.equal(protectedAgainstInvention.schedule?.times[0], "21:00");
+
+const contextual = addRoutineScheduleContext(weekly, [{
+  name: "Existing item",
+  schedule: { cadence: "daily", times: ["08:00"], weekdays: [], interval_days: null, anchor_date: null },
+}]);
+assert.match(contextual.explanation, /organization note, not an interaction or safety assessment/i);
+
+const baseItem: RoutineItem = {
+  id: "item-1",
+  stack_id: null,
+  name: "Recorded medication",
+  brand: null,
+  reorder_url: null,
+  image_url: null,
+  product_source: "member",
+  product_sku: null,
+  purpose: null,
+  dose: null,
+  timing: null,
+  notes: null,
+  item_kind: "medication",
+  instruction_source: "member_update",
+  instruction_authority: null,
+  schedule: null,
+  active: true,
+  is_current: true,
+  source_type: "regimen",
+  link_amazon: null,
+  link_fullscript: null,
+  refill_days_left: null,
+  last_refilled_at: null,
+};
+assert.match(clinicianRoutineChanges([baseItem])[0].description, /Member reports updating/i);
+const questions = clinicianRoutineQuestions([baseItem]).map((item) => item.question).join(" ");
+assert.match(questions, /amount and unit/i);
+assert.match(questions, /cadence/i);
+assert.match(questions, /instruction came from/i);
+
+console.log("PR102 Routine Copilot behavior assertions passed.");

--- a/src/_tests_/pr102RoutineCopilot.assert.ts
+++ b/src/_tests_/pr102RoutineCopilot.assert.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { clinicianRoutineChanges, clinicianRoutineQuestions } from "../lib/clinicianRoutineSummary.ts";
+import { clinicianRoutineQuestions } from "../lib/clinicianRoutineSummary.ts";
 import { addRoutineScheduleContext, buildRoutineCopilotProposal } from "../lib/routineCopilot.ts";
 import type { RoutineItem } from "../lib/routine.ts";
 
@@ -85,7 +85,6 @@ const baseItem: RoutineItem = {
   refill_days_left: null,
   last_refilled_at: null,
 };
-assert.match(clinicianRoutineChanges([baseItem])[0].description, /Member reports updating/i);
 const questions = clinicianRoutineQuestions([baseItem]).map((item) => item.question).join(" ");
 assert.match(questions, /amount and unit/i);
 assert.match(questions, /cadence/i);

--- a/src/components/routine/RoutineCopilotPanel.tsx
+++ b/src/components/routine/RoutineCopilotPanel.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { AlertTriangle, Check, Loader2, Sparkles } from "lucide-react";
+import { useState } from "react";
+
+import { regimenScheduleLabel } from "@/lib/regimenSchedule";
+import type { RoutineCopilotKind, RoutineCopilotProposal } from "@/lib/routineCopilot";
+
+export default function RoutineCopilotPanel({
+  kind,
+  existingName,
+  onApply,
+}: {
+  kind: RoutineCopilotKind;
+  existingName?: string | null;
+  onApply: (proposal: RoutineCopilotProposal) => void;
+}) {
+  const [sourceText, setSourceText] = useState("");
+  const [proposal, setProposal] = useState<RoutineCopilotProposal | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [applied, setApplied] = useState(false);
+
+  async function organize() {
+    setBusy(true);
+    setError(null);
+    setApplied(false);
+    try {
+      const response = await fetch("/api/routine/copilot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceText, kind, existingName }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok || !body?.proposal) throw new Error(body?.error ?? "routine_copilot_unavailable");
+      setProposal(body.proposal as RoutineCopilotProposal);
+    } catch {
+      setProposal(null);
+      setError("We could not organize that text. Nothing in the form or your saved routine changed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function apply() {
+    if (!proposal) return;
+    onApply(proposal);
+    setApplied(true);
+  }
+
+  return (
+    <section className="mt-5 rounded-2xl border border-[#9DCFC3] bg-[#F2FBF9] p-4" aria-labelledby="routine-copilot-title">
+      <div className="flex items-start gap-3">
+        <span className="rounded-xl bg-white p-2 text-[#087F72]"><Sparkles className="h-5 w-5" aria-hidden="true" /></span>
+        <div>
+          <h3 id="routine-copilot-title" className="font-bold text-[#041B2D]">Organize label or schedule text</h3>
+          <p className="mt-1 text-sm leading-6 text-slate-600">Paste exactly what your current label or instructions say. LVE360 will organize the wording for your review without choosing or changing any instruction.</p>
+        </div>
+      </div>
+      <label className="mt-4 block text-sm font-bold text-[#041B2D]">
+        Label or instruction text
+        <textarea value={sourceText} onChange={(event) => { setSourceText(event.target.value); setProposal(null); setApplied(false); }} rows={3} maxLength={1200} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal outline-none focus:border-[#087F72] focus:ring-2 focus:ring-[#087F72]/20" placeholder="For example, take 10 mg once weekly on Sunday at 8:00 AM" />
+      </label>
+      <button type="button" disabled={busy || sourceText.trim().length < 3} onClick={() => void organize()} className="mt-3 inline-flex min-h-12 items-center justify-center rounded-xl border border-[#087F72] bg-white px-4 py-3 font-bold text-[#06695F] hover:bg-[#EAFBF8] disabled:opacity-60">
+        {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : <Sparkles className="mr-2 h-4 w-4" aria-hidden="true" />}
+        Organize these instructions
+      </button>
+      {error ? <p className="mt-3 rounded-xl bg-rose-50 p-3 text-sm font-semibold text-rose-800">{error}</p> : null}
+      {proposal ? (
+        <div className="mt-4 rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs font-bold uppercase tracking-[0.15em] text-[#087F72]">Proposed organization</p>
+          <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+            <div><dt className="font-bold text-[#041B2D]">Name copied from text</dt><dd className="mt-0.5 text-slate-700">{proposal.name ?? existingName ?? "Not found"}</dd></div>
+            <div><dt className="font-bold text-[#041B2D]">Amount copied from text</dt><dd className="mt-0.5 text-slate-700">{proposal.dose ?? "Not found"}</dd></div>
+            <div className="sm:col-span-2"><dt className="font-bold text-[#041B2D]">Checklist schedule</dt><dd className="mt-0.5 text-slate-700">{proposal.schedule ? regimenScheduleLabel(proposal.schedule) : "Not ready"}</dd></div>
+          </dl>
+          <p className="mt-3 text-sm leading-6 text-slate-600">{proposal.explanation}</p>
+          {proposal.questions.length ? (
+            <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+              <p className="flex items-center font-bold"><AlertTriangle className="mr-2 h-4 w-4" aria-hidden="true" /> Check before saving</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">{proposal.questions.map((question) => <li key={question}>{question}</li>)}</ul>
+            </div>
+          ) : null}
+          <button type="button" onClick={apply} className="mt-4 inline-flex min-h-12 items-center justify-center rounded-xl bg-[#087F72] px-4 py-3 font-bold text-white hover:bg-[#06695F]">
+            <Check className="mr-2 h-4 w-4" aria-hidden="true" /> Apply to form
+          </button>
+          <p className="mt-2 text-xs leading-5 text-slate-500">{applied ? "Applied for your review. It is still not saved." : "Nothing is saved until you apply this proposal and use the form’s Save or Add button."}</p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/lib/ai/modelConfig.ts
+++ b/src/lib/ai/modelConfig.ts
@@ -9,6 +9,7 @@ export type AiTask =
   | "blueprint_repair"
   | "blueprint_repair_main"
   | "today_brief"
+  | "routine_label_parser"
   | "weekly_review_synthesis"
   | "weekly_insight";
 
@@ -54,6 +55,11 @@ const TASK_PROFILES: Record<AiTask, AiTaskProfile> = {
   today_brief: {
     capability: "mini",
     promptVersion: "today-brief-v2",
+    reasoningEffort: "low",
+  },
+  routine_label_parser: {
+    capability: "mini",
+    promptVersion: "routine-label-parser-v1",
     reasoningEffort: "low",
   },
   weekly_review_synthesis: {

--- a/src/lib/ai/routineCopilotData.ts
+++ b/src/lib/ai/routineCopilotData.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import { generateAI } from "@/lib/ai/gateway";
+import {
+  buildRoutineCopilotProposal,
+  type RoutineCopilotExtraction,
+  type RoutineCopilotKind,
+  type RoutineCopilotProposal,
+} from "@/lib/routineCopilot";
+
+function parseJsonObject(text: string): RoutineCopilotExtraction | null {
+  const candidate = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+  try {
+    const value = JSON.parse(candidate);
+    return value && typeof value === "object" && !Array.isArray(value) ? value as RoutineCopilotExtraction : null;
+  } catch {
+    return null;
+  }
+}
+function prompt(sourceText: string, kind: RoutineCopilotKind, existingName?: string | null) {
+  return [
+    {
+      role: "system" as const,
+      content: [
+        "You extract member-entered regimen facts for LVE360. You do not recommend, correct, normalize, or infer any medication, hormone, supplement, dose, cadence, or time.",
+        "Return only valid JSON with exactly these nullable string fields: name_quote, dose_quote, schedule_quote.",
+        "Every non-null value must be an exact contiguous quote copied from the member text. Use null when the text does not explicitly contain the fact.",
+        "dose_quote is the amount and unit taken at one scheduled time, not a guessed daily total.",
+        "schedule_quote includes only explicit cadence, days, and timing wording. Never turn morning, evening, night, or bedtime into a clock time.",
+        "Do not provide health advice, safety conclusions, clinician decisions, or explanations.",
+      ].join(" "),
+    },
+    {
+      role: "user" as const,
+      content: JSON.stringify({ item_kind: kind, existing_item_name: existingName ?? null, member_text: sourceText }),
+    },
+  ];
+}
+
+export async function organizeRoutineInstructions({
+  userId,
+  sourceText,
+  kind,
+  existingName,
+}: {
+  userId: string;
+  sourceText: string;
+  kind: RoutineCopilotKind;
+  existingName?: string | null;
+}): Promise<RoutineCopilotProposal> {
+  try {
+    const response = await generateAI({
+      task: "routine_label_parser",
+      userId,
+      messages: prompt(sourceText, kind, existingName),
+      maxTokens: 180,
+      timeoutMs: 20_000,
+      temperature: 0,
+    });
+    return buildRoutineCopilotProposal({ sourceText, kind, existingName, extraction: parseJsonObject(response.text) });
+  } catch (error) {
+    console.warn("[routine-copilot] extraction unavailable; using deterministic organizer", error);
+    return buildRoutineCopilotProposal({ sourceText, kind, existingName });
+  }
+}

--- a/src/lib/clinicianRoutineSummary.ts
+++ b/src/lib/clinicianRoutineSummary.ts
@@ -1,0 +1,42 @@
+import { doseIntegrityIssue } from "./doseIntegrity.ts";
+import type { RoutineItem } from "./routine.ts";
+
+export type ClinicianRoutineChange = {
+  itemId: string;
+  itemName: string;
+  description: string;
+};
+
+export type ClinicianRoutineQuestion = {
+  itemId: string;
+  itemName: string;
+  question: string;
+};
+
+export function clinicianRoutineChanges(items: RoutineItem[]): ClinicianRoutineChange[] {
+  return items.flatMap((item) => {
+    if (item.instruction_source === "manual_add") {
+      return [{ itemId: item.id, itemName: item.name, description: "Member reports adding this item to their current record." }];
+    }
+    if (item.instruction_source === "member_update") {
+      return [{ itemId: item.id, itemName: item.name, description: "Member reports updating the dose, schedule, or product details in this record." }];
+    }
+    return [];
+  });
+}
+export function clinicianRoutineQuestions(items: RoutineItem[]): ClinicianRoutineQuestion[] {
+  return items.flatMap((item) => {
+    const questions: ClinicianRoutineQuestion[] = [];
+    const push = (question: string) => questions.push({ itemId: item.id, itemName: item.name, question });
+    const prescribed = item.item_kind === "medication" || item.item_kind === "hormone";
+    if (!item.dose?.trim()) push("Confirm the amount and unit taken at each scheduled time.");
+    if (!item.schedule) push("Confirm the cadence, applicable days, and exact checklist times.");
+    if (prescribed && !item.instruction_authority) push("Confirm where the current prescription instruction came from.");
+    const issue = doseIntegrityIssue(item.name, item.dose);
+    if (issue) push(`Review the member-entered amount and unit. ${issue.message}`);
+    if (item.schedule && item.schedule.times.length > 1 && item.dose?.trim()) {
+      push("Confirm that the recorded amount applies at each listed time rather than representing a full-day total.");
+    }
+    return questions;
+  });
+}

--- a/src/lib/clinicianRoutineSummary.ts
+++ b/src/lib/clinicianRoutineSummary.ts
@@ -1,29 +1,12 @@
 import { doseIntegrityIssue } from "./doseIntegrity.ts";
 import type { RoutineItem } from "./routine.ts";
 
-export type ClinicianRoutineChange = {
-  itemId: string;
-  itemName: string;
-  description: string;
-};
-
 export type ClinicianRoutineQuestion = {
   itemId: string;
   itemName: string;
   question: string;
 };
 
-export function clinicianRoutineChanges(items: RoutineItem[]): ClinicianRoutineChange[] {
-  return items.flatMap((item) => {
-    if (item.instruction_source === "manual_add") {
-      return [{ itemId: item.id, itemName: item.name, description: "Member reports adding this item to their current record." }];
-    }
-    if (item.instruction_source === "member_update") {
-      return [{ itemId: item.id, itemName: item.name, description: "Member reports updating the dose, schedule, or product details in this record." }];
-    }
-    return [];
-  });
-}
 export function clinicianRoutineQuestions(items: RoutineItem[]): ClinicianRoutineQuestion[] {
   return items.flatMap((item) => {
     const questions: ClinicianRoutineQuestion[] = [];

--- a/src/lib/routineCopilot.ts
+++ b/src/lib/routineCopilot.ts
@@ -1,0 +1,203 @@
+import { normalizeRegimenSchedule, regimenScheduleLabel, type RegimenSchedule } from "./regimenSchedule.ts";
+
+export type RoutineCopilotKind = "medication" | "hormone" | "supplement" | "endocrine_active_supplement";
+
+export type RoutineCopilotExtraction = {
+  name_quote?: unknown;
+  dose_quote?: unknown;
+  schedule_quote?: unknown;
+};
+
+export type RoutineCopilotProposal = {
+  name: string | null;
+  dose: string | null;
+  timing: string | null;
+  schedule: RegimenSchedule | null;
+  missingFields: string[];
+  questions: string[];
+  explanation: string;
+  source: "ai" | "fallback";
+};
+
+export type RoutineScheduleContextItem = {
+  name: string;
+  schedule?: RegimenSchedule | null;
+};
+
+const DAY_INDEX: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+function collapsed(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function verifiedQuote(sourceText: string, value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const quote = collapsed(value);
+  if (!quote || quote.length > 240) return null;
+  return collapsed(sourceText).toLocaleLowerCase().includes(quote.toLocaleLowerCase()) ? quote : null;
+}
+
+function fallbackDose(sourceText: string): string | null {
+  const match = sourceText.match(
+    /\b\d+(?:\.\d+)?\s*(?:mcg|μg|ug|mg|g|ml|mL|units?|iu|IU|tablets?|tabs?|capsules?|caps?|puffs?|drops?|packets?|scoops?)(?:\s*\/\s*\d+(?:\.\d+)?\s*(?:mcg|μg|ug|mg|g|ml|mL|units?|iu|IU))?/,
+  );
+  return match ? collapsed(match[0]) : null;
+}
+
+function fallbackScheduleQuote(sourceText: string): string | null {
+  const source = collapsed(sourceText);
+  if (!/\b(daily|every day|weekly|once (?:a|per) week|as needed|prn|morning|afternoon|evening|bedtime|monday|tuesday|wednesday|thursday|friday|saturday|sunday|every \d+ days?|\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?))\b/i.test(source)) {
+    return null;
+  }
+  return source;
+}
+
+function timeValues(text: string): string[] {
+  const found: string[] = [];
+  const pattern = /\b((?:[01]?\d|2[0-3]):[0-5]\d|(?:0?[1-9]|1[0-2])(?::[0-5]\d)?\s*(?:a\.?m\.?|p\.?m\.?))\b/gi;
+  for (const match of text.matchAll(pattern)) {
+    const raw = match[1].toLowerCase().replace(/\./g, "").replace(/\s+/g, "");
+    if (/^(?:[01]?\d|2[0-3]):[0-5]\d$/.test(raw)) {
+      const [hour, minute] = raw.split(":").map(Number);
+      found.push(`${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`);
+      continue;
+    }
+    const parsed = raw.match(/^(\d{1,2})(?::(\d{2}))?(am|pm)$/);
+    if (!parsed) continue;
+    let hour = Number(parsed[1]) % 12;
+    if (parsed[3] === "pm") hour += 12;
+    found.push(`${String(hour).padStart(2, "0")}:${parsed[2] ?? "00"}`);
+  }
+  return [...new Set(found)].sort();
+}
+
+function weekdayValues(text: string): number[] {
+  return Object.entries(DAY_INDEX)
+    .filter(([day]) => new RegExp(`\\b${day}(?:s)?\\b`, "i").test(text))
+    .map(([, index]) => index)
+    .sort();
+}
+
+export function deriveRoutineSchedule(text: string): RegimenSchedule | null {
+  const normalized = collapsed(text);
+  if (!normalized) return null;
+  if (/\b(as needed|prn)\b/i.test(normalized)) {
+    return normalizeRegimenSchedule({ cadence: "as_needed", times: [], weekdays: [], interval_days: null, anchor_date: null });
+  }
+
+  const times = timeValues(normalized);
+  if (!times.length) return null;
+  const weekdays = weekdayValues(normalized);
+
+  if (weekdays.length > 1) {
+    return normalizeRegimenSchedule({ cadence: "weekdays", times, weekdays, interval_days: null, anchor_date: null });
+  }
+  if (weekdays.length === 1 && /\b(weekly|once (?:a|per) week)\b/i.test(normalized)) {
+    return normalizeRegimenSchedule({ cadence: "weekly", times, weekdays, interval_days: null, anchor_date: null });
+  }
+  if (/\b(daily|every day|each day|once daily|twice daily|three times daily)\b/i.test(normalized)) {
+    return normalizeRegimenSchedule({ cadence: "daily", times, weekdays: [], interval_days: null, anchor_date: null });
+  }
+  return null;
+}
+
+function missingScheduleQuestion(timing: string | null): string {
+  if (!timing) return "What cadence, days, and exact times are written in your current instructions?";
+  if (/\bevery\s+(\d+)\s+days?\b/i.test(timing)) return "What starting date should anchor this every-few-days schedule?";
+  if (/\b(weekly|once (?:a|per) week)\b/i.test(timing) && !weekdayValues(timing).length) {
+    return "Which day of the week is written in your current instructions?";
+  }
+  if (/\b(morning|afternoon|evening|bedtime|night)\b/i.test(timing) && !timeValues(timing).length) {
+    return "What exact clock time do you want on the checklist? Keep following your current label or clinician instructions.";
+  }
+  return "Can you confirm the cadence, days, and exact times before adding this to the checklist?";
+}
+
+function scheduleExplanation(schedule: RegimenSchedule | null, timing: string | null) {
+  if (!schedule) {
+    return timing
+      ? "The written schedule is preserved, but the checklist still needs a supported cadence and exact time."
+      : "No schedule was organized. Your existing routine will remain unchanged until you confirm the missing details.";
+  }
+  if (schedule.cadence === "as_needed") return "This stays off the automatic checklist and can be recorded only when you choose to take it under your existing instructions.";
+  const occurrences = schedule.times.length;
+  return `${regimenScheduleLabel(schedule)}. This creates ${occurrences} checklist ${occurrences === 1 ? "time" : "times"} on each scheduled day.`;
+}
+
+export function buildRoutineCopilotProposal({
+  sourceText,
+  kind,
+  extraction,
+  existingName,
+}: {
+  sourceText: string;
+  kind: RoutineCopilotKind;
+  extraction?: RoutineCopilotExtraction | null;
+  existingName?: string | null;
+}): RoutineCopilotProposal {
+  const source = collapsed(sourceText).slice(0, 1200);
+  const aiName = verifiedQuote(source, extraction?.name_quote);
+  const aiDose = verifiedQuote(source, extraction?.dose_quote);
+  const aiTiming = verifiedQuote(source, extraction?.schedule_quote);
+  const dose = aiDose ?? fallbackDose(source);
+  const timing = aiTiming ?? fallbackScheduleQuote(source);
+  const schedule = deriveRoutineSchedule(timing ?? "");
+  const name = existingName?.trim() || aiName;
+  const missingFields: string[] = [];
+  const questions: string[] = [];
+
+  if (!name) {
+    missingFields.push("Item name");
+    questions.push(`What ${kind === "hormone" ? "hormone therapy" : kind} name is printed on the label?`);
+  }
+  if (!dose) {
+    missingFields.push("Amount at each scheduled time");
+    questions.push("What amount and unit are written for one scheduled time?");
+  }
+  if (!schedule) {
+    missingFields.push("Checklist schedule");
+    questions.push(missingScheduleQuestion(timing));
+  }
+
+  return {
+    name,
+    dose,
+    timing,
+    schedule,
+    missingFields,
+    questions: [...new Set(questions)],
+    explanation: scheduleExplanation(schedule, timing),
+    source: aiName || aiDose || aiTiming ? "ai" : "fallback",
+  };
+}
+
+export function addRoutineScheduleContext(
+  proposal: RoutineCopilotProposal,
+  items: RoutineScheduleContextItem[],
+  existingName?: string | null,
+): RoutineCopilotProposal {
+  if (!proposal.schedule || proposal.schedule.cadence === "as_needed") return proposal;
+  const proposedTimes = new Set(proposal.schedule.times);
+  const sameName = existingName?.trim().toLocaleLowerCase();
+  const shared = items.filter((item) => {
+    if (!item.schedule || item.name.trim().toLocaleLowerCase() === sameName) return false;
+    return item.schedule.times.some((time) => proposedTimes.has(time));
+  });
+  if (!shared.length) return proposal;
+
+  const names = shared.slice(0, 3).map((item) => item.name).join(", ");
+  const extra = shared.length > 3 ? ` and ${shared.length - 3} more` : "";
+  return {
+    ...proposal,
+    explanation: `${proposal.explanation} It shares a checklist time with ${names}${extra}, so that part of the routine may feel busier. This is an organization note, not an interaction or safety assessment.`,
+    questions: [...proposal.questions, "Do you want these items grouped at the same checklist time, based on the instructions you already follow?"],
+  };
+}


### PR DESCRIPTION
## What changed

- Adds a paid Routine Copilot inside medication, hormone, and existing supplement edit flows.
- Organizes exact member-entered label or schedule text into a proposed name, amount, and supported checklist schedule.
- Requires an explicit **Apply to form** action and preserves the existing **Save/Add** confirmation before any regimen write.
- Rejects AI-extracted text that is not an exact quote from the member's input and falls back to deterministic parsing when generation is unavailable.
- Flags missing days, exact times, starting dates, or amounts without inventing instructions.
- Adds neutral schedule-crowding context without making interaction or safety claims.
- Improves the clinician printout with concise LVE360-organized clarification questions placed directly before the regimen.
- Routes the task through the cost-conscious mini capability in the canonical AI gateway.

## Why

Members currently have to translate free-form label instructions into several structured fields by hand. PR102 reduces that friction while preserving LVE360's core safety boundary: AI may organize what the member entered, but it cannot choose doses, alter prescriptions, or save changes on the member's behalf.

The initial clinician printout also included a repetitive member-recorded changes section that consumed an entire page without helping a clinician make a decision. That section has been removed so the export leads with actionable clarification questions and the current regimen.

## Safety and privacy boundaries

- No regimen database write occurs in the Copilot endpoint.
- No dose, cadence, day, or clock time is inferred.
- Every AI-proposed phrase must exist verbatim in the member's source text.
- Existing regimen data remains unchanged on parsing or generation failure.
- The central AI ledger records operational metadata and a context hash, not the prompt or response text.
- No Supabase migration is required.

## Validation

- `npm.cmd run qa:pr102`
- `npm.cmd run qa:routine`
- `npm.cmd run qa:pr99`
- `npm.cmd run typecheck`
- `npm.cmd run build` with temporary local public Supabase placeholders because this checkout does not contain deployed environment secrets
