### PR TITLE
PR103: Add Blueprint Delta Intelligence

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintDeltaPanel.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintDeltaPanel.tsx
@@ -1,0 +1,232 @@
+import Link from "next/link";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  CircleMinus,
+  CirclePlus,
+  FileClock,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react";
+
+import type {
+  BlueprintDelta,
+  BlueprintDeltaKind,
+  BlueprintRecommendationDelta,
+} from "@/lib/blueprintDelta";
+
+export default function BlueprintDeltaPanel({ delta, stale }: { delta: BlueprintDelta; stale: boolean }) {
+  const material = delta.recommendations.filter((item) => item.kind !== "unchanged");
+  const stable = delta.recommendations.filter((item) => item.kind === "unchanged");
+
+  return (
+    <section className="mt-8 overflow-hidden rounded-2xl border border-[#9DCFC3] bg-white shadow-sm" aria-labelledby="blueprint-delta-title">
+      <div className="border-b border-[#CFE8E2] bg-[#F0FAF7] p-5 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Blueprint change intelligence</p>
+            <h2 id="blueprint-delta-title" className="mt-1 text-2xl font-bold text-[#041B2D]">Since your last Blueprint</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+              Compared with {formatDate(delta.previousCreatedAt)}. This summary reads the two saved reports and does not guess why your health information changed.
+            </p>
+            {delta.generationReason === "member-refresh" ? (
+              <p className="mt-1 text-sm font-semibold text-slate-700">The current version was created from a member-requested refresh.</p>
+            ) : null}
+          </div>
+          <Link
+            href={`/blueprints/${encodeURIComponent(delta.previousStackId)}`}
+            className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-xl border border-[#9DCFC3] bg-white px-4 py-2 text-sm font-bold text-[#087F72] hover:bg-[#EAFBF8]"
+          >
+            <FileClock className="mr-2 h-4 w-4" aria-hidden="true" />
+            Open prior version
+          </Link>
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Recommendation change counts">
+          <DeltaCount label="New" count={delta.counts.added} tone="emerald" />
+          <DeltaCount label="Updated" count={delta.counts.changed} tone="blue" />
+          <DeltaCount label="No longer listed" count={delta.counts.removed} tone="slate" />
+          <DeltaCount label="Stable" count={delta.counts.unchanged} tone="slate" />
+        </div>
+      </div>
+
+      {stale ? (
+        <div className="border-b border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-950 sm:px-6">
+          Your saved health information has changed again since this report was created. Refresh the Blueprint before using this comparison for current decisions.
+        </div>
+      ) : null}
+
+      <div className="p-5 sm:p-6">
+        <SafetyDelta delta={delta} />
+
+        <div className="mt-6">
+          <h3 className="text-lg font-bold text-[#041B2D]">Changes to review</h3>
+          <p className="mt-1 text-sm leading-6 text-slate-600">
+            New and updated options still require your decision. Items that disappeared are shown for transparency only.
+          </p>
+          {material.length ? (
+            <ul className="mt-4 space-y-3">
+              {material.map((item) => <DeltaCard key={item.key} item={item} previousStackId={delta.previousStackId} />)}
+            </ul>
+          ) : (
+            <p className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-700">
+              No recommendations were added, removed, or materially updated in this version.
+            </p>
+          )}
+        </div>
+
+        {stable.length ? (
+          <details className="mt-5 rounded-xl border border-slate-200 bg-slate-50">
+            <summary className="cursor-pointer px-4 py-3 text-sm font-bold text-[#041B2D]">
+              {stable.length} stable {stable.length === 1 ? "recommendation" : "recommendations"}
+            </summary>
+            <ul className="border-t border-slate-200 px-4 py-2">
+              {stable.map((item) => (
+                <li key={item.key} className="flex flex-col gap-2 border-b border-slate-200 py-3 last:border-0 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="font-semibold text-[#041B2D]">{item.name}</p>
+                    <p className="mt-1 text-sm text-slate-600">{item.explanation}</p>
+                  </div>
+                  <a href="#recommendation-report" className="shrink-0 text-sm font-bold text-[#087F72] hover:underline">Review detail</a>
+                </li>
+              ))}
+            </ul>
+          </details>
+        ) : null}
+
+        <p className="mt-5 text-xs leading-5 text-slate-500">
+          Full report language, evidence, and PDFs remain available in each dated Blueprint. Safety status comes from LVE360&apos;s deterministic report review, not from generated change-summary language.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function SafetyDelta({ delta }: { delta: BlueprintDelta }) {
+  const needsReview = delta.safety.needsReview;
+  return (
+    <div className={`rounded-xl border p-4 ${needsReview ? "border-amber-200 bg-amber-50" : "border-emerald-200 bg-emerald-50"}`}>
+      <div className="flex items-start gap-3">
+        {needsReview
+          ? <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" aria-hidden="true" />
+          : <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-700" aria-hidden="true" />}
+        <div className="flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className={`font-bold ${needsReview ? "text-amber-950" : "text-emerald-950"}`}>Safety review</h3>
+            <span className={`rounded-full px-2 py-0.5 text-xs font-bold ${delta.safety.changed ? "bg-blue-100 text-blue-900" : "bg-white/80 text-slate-700"}`}>
+              {delta.safety.changed ? "Status changed" : "Status stable"}
+            </span>
+          </div>
+          <p className={`mt-1 text-sm leading-6 ${needsReview ? "text-amber-900" : "text-emerald-900"}`}>{delta.safety.explanation}</p>
+          <a href="#safety-notes" className={`mt-2 inline-flex min-h-10 items-center text-sm font-bold hover:underline ${needsReview ? "text-amber-900" : "text-emerald-900"}`}>
+            {needsReview ? "Review current safety notes" : "Read current safety notes"}
+            <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DeltaCard({ item, previousStackId }: { item: BlueprintRecommendationDelta; previousStackId: string }) {
+  const style = deltaStyle(item.kind);
+  const Icon = style.icon;
+  const actionHref = item.kind === "removed" ? `/blueprints/${encodeURIComponent(previousStackId)}#recommendation-report` : item.actionHref;
+  const details = item.kind === "changed" ? changedDetails(item) : currentDetails(item);
+
+  return (
+    <li className={`rounded-xl border p-4 ${style.card}`}>
+      <div className="flex items-start gap-3">
+        <Icon className={`mt-0.5 h-5 w-5 shrink-0 ${style.iconClass}`} aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="font-bold text-[#041B2D]">{item.name}</h4>
+            <span className={`rounded-full px-2 py-0.5 text-xs font-bold ${style.badge}`}>{style.label}</span>
+            {item.attention === "clinician_review" ? (
+              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-900">Clinician review</span>
+            ) : null}
+          </div>
+          <p className="mt-2 text-sm leading-6 text-slate-700">{item.explanation}</p>
+          {details.length ? (
+            <dl className="mt-3 grid gap-2 rounded-lg bg-white/80 p-3 text-sm sm:grid-cols-2">
+              {details.map((detail) => (
+                <div key={detail.label}>
+                  <dt className="text-xs font-bold uppercase tracking-[0.08em] text-slate-500">{detail.label}</dt>
+                  <dd className="mt-0.5 text-slate-700">{detail.value}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+            {actionHref.startsWith("/") ? (
+              <Link href={actionHref} className="inline-flex min-h-10 items-center text-sm font-bold text-[#087F72] hover:underline">
+                {item.actionLabel}<ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+              </Link>
+            ) : (
+              <a href={actionHref} className="inline-flex min-h-10 items-center text-sm font-bold text-[#087F72] hover:underline">
+                {item.actionLabel}<ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+              </a>
+            )}
+            {item.kind !== "removed" ? <a href="#report-evidence-references" className="inline-flex min-h-10 items-center text-sm font-semibold text-slate-600 hover:text-[#087F72] hover:underline">See evidence</a> : null}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function currentDetails(item: BlueprintRecommendationDelta): Array<{ label: string; value: string }> {
+  if (!item.current || item.kind === "removed") return [];
+  return [
+    item.current.status ? { label: "Current status", value: item.current.status } : null,
+    item.current.dose ? { label: "Starting guidance", value: item.current.dose } : null,
+    item.current.timing ? { label: "Timing", value: item.current.timing } : null,
+  ].filter((detail): detail is { label: string; value: string } => Boolean(detail));
+}
+
+function changedDetails(item: BlueprintRecommendationDelta): Array<{ label: string; value: string }> {
+  if (!item.previous || !item.current) return [];
+  const fields = item.changedFields.filter((field) => field !== "name");
+  return fields.flatMap((field) => {
+    const label = field === "dose"
+      ? "Starting guidance"
+      : field === "timing"
+        ? "Timing"
+        : field === "rationale"
+          ? "Report rationale"
+          : "Review status";
+    return [
+      { label: `Previous ${label.toLowerCase()}`, value: item.previous?.[field] || "Not recorded" },
+      { label: `Current ${label.toLowerCase()}`, value: item.current?.[field] || "Not recorded" },
+    ];
+  });
+}
+
+function DeltaCount({ label, count, tone }: { label: string; count: number; tone: "emerald" | "blue" | "slate" }) {
+  const tones = {
+    emerald: "border-emerald-200 bg-emerald-50 text-emerald-950",
+    blue: "border-blue-200 bg-blue-50 text-blue-950",
+    slate: "border-slate-200 bg-white text-slate-800",
+  };
+  return (
+    <div className={`rounded-xl border px-3 py-3 ${tones[tone]}`}>
+      <p className="text-2xl font-bold">{count}</p>
+      <p className="mt-0.5 text-xs font-semibold">{label}</p>
+    </div>
+  );
+}
+
+function deltaStyle(kind: BlueprintDeltaKind) {
+  if (kind === "added") return { label: "New", card: "border-emerald-200 bg-emerald-50/60", badge: "bg-emerald-100 text-emerald-900", icon: CirclePlus, iconClass: "text-emerald-700" };
+  if (kind === "changed") return { label: "Updated", card: "border-blue-200 bg-blue-50/60", badge: "bg-blue-100 text-blue-900", icon: RefreshCw, iconClass: "text-blue-700" };
+  if (kind === "removed") return { label: "No longer listed", card: "border-slate-200 bg-slate-50", badge: "bg-slate-200 text-slate-700", icon: CircleMinus, iconClass: "text-slate-500" };
+  return { label: "Stable", card: "border-slate-200 bg-slate-50", badge: "bg-slate-200 text-slate-700", icon: CheckCircle2, iconClass: "text-slate-500" };
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "the prior saved version";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "the prior saved version";
+  return date.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" });
+}

--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -22,6 +22,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import type { BlueprintDelta } from "@/lib/blueprintDelta";
 import type { MemberSupplement } from "@/lib/blueprintWorkspace";
 import { doseIntegrityIssue } from "@/lib/doseIntegrity";
 import { trackProductEvent } from "@/lib/productAnalyticsClient";
@@ -30,6 +31,8 @@ import type {
   MemberRecommendationDecision,
   RecommendationDecisionRecord,
 } from "@/lib/recommendationDecision";
+
+import BlueprintDeltaPanel from "./BlueprintDeltaPanel";
 
 type StackSummary = {
   id: string;
@@ -70,6 +73,7 @@ type Props = {
   versioningReady: boolean;
   isLatest: boolean;
   history: VersionSummary[];
+  delta: BlueprintDelta | null;
 };
 
 export default function BlueprintWorkspaceClient({
@@ -82,6 +86,7 @@ export default function BlueprintWorkspaceClient({
   versioningReady,
   isLatest,
   history,
+  delta,
 }: Props) {
   const router = useRouter();
   const [supplements, setSupplements] = useState(initialSupplements);
@@ -363,6 +368,8 @@ export default function BlueprintWorkspaceClient({
       {message ? <p role="status" className="mt-5 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-900">{message}</p> : null}
       {error ? <p role="alert" className="mt-5 rounded-xl bg-red-50 px-4 py-3 text-sm font-medium text-red-800">{error}</p> : null}
 
+      {delta ? <BlueprintDeltaPanel delta={delta} stale={stale} /> : null}
+
       <section className="mt-8 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6" aria-labelledby="blueprint-next-steps-title">
         <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#087F72]">Your decision map</p>
         <h2 id="blueprint-next-steps-title" className="mt-1 text-2xl font-bold text-[#041B2D]">What needs your attention</h2>
@@ -461,7 +468,7 @@ export default function BlueprintWorkspaceClient({
         </main>
 
         <aside className="space-y-6">
-          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <section id="version-history" className="scroll-mt-24 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
             <div className="flex items-center gap-2">
               <History className="h-5 w-5 text-[#087F72]" aria-hidden="true" />
               <h2 className="font-bold text-[#041B2D]">Version history</h2>

--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { requireTier } from "@/app/_auth/requireTier";
+import { buildBlueprintDelta } from "@/lib/blueprintDelta";
 import { parseBlueprintReport } from "@/lib/blueprintReport";
 import {
   blueprintMarkdownFromStack,
@@ -86,6 +87,20 @@ export default async function BlueprintPage({ params }: PageProps) {
     ? !stack.input_snapshot_hash || stack.input_snapshot_hash !== currentInputHash
     : false;
   const latestId = history?.[0]?.id ?? stack.id;
+  const currentVersionIndex = (history ?? []).findIndex((version) => version.id === stack.id);
+  const previousStack = (history ?? []).find((version) => version.id === stack.supersedes_stack_id)
+    ?? (currentVersionIndex >= 0 ? history?.[currentVersionIndex + 1] : null)
+    ?? null;
+  const delta = previousStack
+    ? buildBlueprintDelta({
+        previousStackId: previousStack.id,
+        previousCreatedAt: previousStack.created_at,
+        currentCreatedAt: stack.created_at,
+        generationReason: stack.generation_reason,
+        previousMarkdown: blueprintMarkdownFromStack(previousStack),
+        currentMarkdown: markdown,
+      })
+    : null;
 
   return (
     <BlueprintWorkspaceClient
@@ -112,6 +127,7 @@ export default async function BlueprintPage({ params }: PageProps) {
         safetyStatus: deriveBlueprintSafetyStatus(blueprintMarkdownFromStack(version)),
         generationReason: version.generation_reason,
       }))}
+      delta={delta}
     />
   );
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "qa:pr100": "node --experimental-strip-types src/_tests_/pr100TodayBrief.assert.ts && node src/_tests_/pr100Page.assert.mjs",
     "qa:pr101": "node src/_tests_/pr101Page.assert.mjs",
     "qa:pr102": "node --experimental-strip-types src/_tests_/pr102RoutineCopilot.assert.ts && node src/_tests_/pr102Page.assert.mjs",
+    "qa:pr103": "node --experimental-strip-types src/_tests_/pr103BlueprintDelta.assert.ts && node src/_tests_/pr103Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr103BlueprintDelta.assert.ts
+++ b/src/_tests_/pr103BlueprintDelta.assert.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+
+import { buildBlueprintDelta, extractBlueprintRecommendationSnapshots } from "../lib/blueprintDelta.ts";
+
+function report({ recommendations, dosing, safety }: { recommendations: string; dosing: string; safety: string }) {
+  return [
+    "## Contraindications & Med Interactions",
+    "",
+    safety,
+    "",
+    "## Your Blueprint Recommendations",
+    "",
+    "| Rank | Supplement | Status | Why It Matters |",
+    "| --- | --- | --- | --- |",
+    recommendations,
+    "",
+    "## Dosing & Notes",
+    "",
+    dosing,
+  ].join("\n");
+}
+
+const previousMarkdown = report({
+  safety: "- No material flags identified from the information provided.",
+  recommendations: [
+    "| 1 | Vitamin B12 | New - consider | Supports normal energy metabolism. |",
+    "| 2 | Magnesium Glycinate | New - consider | Supports a consistent evening routine. |",
+    "| 3 | CoQ10 | Clinician review | Review alongside the current medication list. |",
+  ].join("\n"),
+  dosing: [
+    "- Vitamin B12: 500 mcg daily. Morning.",
+    "- Magnesium Glycinate: 200 mg daily. Evening.",
+  ].join("\n"),
+});
+
+const currentMarkdown = report({
+  safety: "- Clinician review: Review the current medication and supplement combination before making a change.",
+  recommendations: [
+    "| 1 | Methylcobalamin | New - consider | Supports normal energy metabolism. |",
+    "| 2 | Magnesium Bisglycinate | New - consider | Supports a consistent evening routine. |",
+    "| 3 | Omega-3 | Clinician review | Discuss alongside the current medication list. |",
+  ].join("\n"),
+  dosing: [
+    "- Methylcobalamin: 1,000 mcg daily. Morning.",
+    "- Magnesium Bisglycinate: 200 mg daily. Evening.",
+  ].join("\n"),
+});
+
+const snapshots = extractBlueprintRecommendationSnapshots(currentMarkdown);
+assert.equal(snapshots.length, 3, "Only explicit recommendation-table entries should be compared.");
+assert.equal(snapshots.filter((item) => item.key === "vitamin-b12").length, 1);
+assert.equal(snapshots.filter((item) => item.key === "magnesium-glycinate").length, 1);
+
+const delta = buildBlueprintDelta({
+  previousStackId: "stack-previous",
+  previousCreatedAt: "2026-08-01T12:00:00.000Z",
+  currentCreatedAt: "2026-08-11T12:00:00.000Z",
+  generationReason: "member-refresh",
+  previousMarkdown,
+  currentMarkdown,
+});
+
+assert.deepEqual(delta.counts, { added: 1, changed: 1, removed: 1, unchanged: 1 });
+
+const b12 = delta.recommendations.find((item) => item.key === "vitamin-b12");
+assert.equal(b12?.kind, "changed", "A canonical B12 alias must not be falsely described as new.");
+assert.ok(b12?.changedFields.includes("dose"));
+
+const magnesium = delta.recommendations.find((item) => item.key === "magnesium-glycinate");
+assert.equal(magnesium?.kind, "unchanged", "A canonical magnesium alias with the same guidance must remain stable.");
+
+const omega = delta.recommendations.find((item) => item.key === "omega-3");
+assert.equal(omega?.kind, "added");
+assert.equal(omega?.attention, "clinician_review");
+assert.equal(omega?.actionHref, "#recommendation-report");
+
+const removed = delta.recommendations.find((item) => item.key === "coq10");
+assert.equal(removed?.kind, "removed");
+assert.equal(removed?.attention, "informational");
+assert.match(removed?.explanation ?? "", /not an instruction to stop/i);
+
+assert.equal(delta.safety.previousStatus, "safe");
+assert.equal(delta.safety.currentStatus, "warning");
+assert.equal(delta.safety.changed, true);
+assert.equal(delta.safety.needsReview, true);
+
+console.log("PR103 Blueprint Delta behavior assertions passed.");

--- a/src/_tests_/pr103BlueprintDelta.assert.ts
+++ b/src/_tests_/pr103BlueprintDelta.assert.ts
@@ -51,6 +51,25 @@ assert.equal(snapshots.length, 3, "Only explicit recommendation-table entries sh
 assert.equal(snapshots.filter((item) => item.key === "vitamin-b12").length, 1);
 assert.equal(snapshots.filter((item) => item.key === "magnesium-glycinate").length, 1);
 
+const currentOptimizeMarkdown = [
+  "## Current Stack",
+  "",
+  "| Supplement | Purpose | Dose | Timing |",
+  "| --- | --- | --- | --- |",
+  "| Omega-3 | Cardiovascular wellness | 1000 mg | Evening |",
+  "",
+  "## Your Blueprint Recommendations",
+  "",
+  "| Rank | Supplement | Status | Why It Matters |",
+  "| --- | --- | --- | --- |",
+  "| 1 | Omega-3 | Current - optimize | Supports cardiovascular wellness. |",
+].join("\n");
+assert.equal(
+  extractBlueprintRecommendationSnapshots(currentOptimizeMarkdown).find((item) => item.key === "omega-3")?.status,
+  "Current - optimize",
+  "Current, optimize rows are still explicit Blueprint recommendations and must be compared.",
+);
+
 const delta = buildBlueprintDelta({
   previousStackId: "stack-previous",
   previousCreatedAt: "2026-08-01T12:00:00.000Z",

--- a/src/_tests_/pr103BlueprintDelta.assert.ts
+++ b/src/_tests_/pr103BlueprintDelta.assert.ts
@@ -70,6 +70,19 @@ assert.equal(
   "Current, optimize rows are still explicit Blueprint recommendations and must be compared.",
 );
 
+const currentOptimizeDelta = buildBlueprintDelta({
+  previousStackId: "stack-before-current-item",
+  previousCreatedAt: "2026-08-01T12:00:00.000Z",
+  currentCreatedAt: "2026-08-11T12:00:00.000Z",
+  generationReason: "member-refresh",
+  previousMarkdown: "## Your Blueprint Recommendations\n\nNo recommendations recorded.",
+  currentMarkdown: currentOptimizeMarkdown,
+});
+const currentOmega = currentOptimizeDelta.recommendations.find((item) => item.key === "omega-3");
+assert.equal(currentOmega?.attention, "informational");
+assert.equal(currentOmega?.actionHref, "/routine");
+assert.equal(currentOmega?.actionLabel, "Open in Routine");
+
 const delta = buildBlueprintDelta({
   previousStackId: "stack-previous",
   previousCreatedAt: "2026-08-01T12:00:00.000Z",

--- a/src/_tests_/pr103Page.assert.mjs
+++ b/src/_tests_/pr103Page.assert.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+const page = read("app/(app)/blueprints/[stackId]/page.tsx");
+const workspace = read("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx");
+const panel = read("app/(app)/blueprints/[stackId]/BlueprintDeltaPanel.tsx");
+const delta = read("src/lib/blueprintDelta.ts");
+
+assert.match(page, /supersedes_stack_id/, "The exact predecessor should be preferred for a refresh comparison.");
+assert.match(page, /buildBlueprintDelta/, "Blueprint comparison must be assembled on the server.");
+assert.match(workspace, /BlueprintDeltaPanel/, "The current Blueprint workspace must render its change summary.");
+assert.match(panel, /Since your last Blueprint/, "The summary must explain its comparison frame.");
+assert.match(panel, /does not guess why your health information changed/, "The summary must disclose its causal boundary.");
+assert.match(panel, /Open prior version/, "Members must be able to inspect the earlier source report.");
+assert.match(panel, /See evidence/, "Material current recommendations must link to evidence.");
+assert.match(panel, /Safety status comes from LVE360&apos;s deterministic report review/, "Safety authority must be explicit.");
+assert.match(delta, /deriveBlueprintSafetyStatus/, "Safety changes must use the deterministic safety parser.");
+assert.doesNotMatch(delta, /openai|generateText|generateObject/i, "Recommendation classification must not be delegated to a model.");
+assert.match(delta, /not an instruction to stop a medication, supplement, or hormone/, "Removed ideas must not become stop instructions.");
+
+console.log("PR103 page and safety-boundary assertions passed.");

--- a/src/lib/blueprintDelta.ts
+++ b/src/lib/blueprintDelta.ts
@@ -1,0 +1,234 @@
+import { deriveBlueprintSafetyStatus, type BlueprintSafetyStatus } from "./blueprintSafetyStatus.ts";
+import { healthItemIdentityKey } from "./healthItemIdentity.ts";
+import { parseMarkdownToItems } from "./parseMarkdownToItems.ts";
+
+export type BlueprintDeltaKind = "added" | "changed" | "removed" | "unchanged";
+export type BlueprintDeltaAttention = "decision" | "clinician_review" | "informational";
+
+export type BlueprintRecommendationSnapshot = {
+  key: string;
+  name: string;
+  status: string | null;
+  dose: string | null;
+  timing: string | null;
+  rationale: string | null;
+};
+
+export type BlueprintRecommendationDelta = {
+  key: string;
+  name: string;
+  kind: BlueprintDeltaKind;
+  attention: BlueprintDeltaAttention;
+  changedFields: Array<"name" | "status" | "dose" | "timing" | "rationale">;
+  previous: BlueprintRecommendationSnapshot | null;
+  current: BlueprintRecommendationSnapshot | null;
+  explanation: string;
+  actionHref: string;
+  actionLabel: string;
+};
+
+export type BlueprintDelta = {
+  previousStackId: string;
+  previousCreatedAt: string | null;
+  currentCreatedAt: string | null;
+  generationReason: string | null;
+  recommendations: BlueprintRecommendationDelta[];
+  counts: Record<BlueprintDeltaKind, number>;
+  safety: {
+    previousStatus: BlueprintSafetyStatus;
+    currentStatus: BlueprintSafetyStatus;
+    changed: boolean;
+    needsReview: boolean;
+    explanation: string;
+  };
+};
+
+type BuildBlueprintDeltaInput = {
+  previousStackId: string;
+  previousCreatedAt: string | null;
+  currentCreatedAt: string | null;
+  generationReason: string | null;
+  previousMarkdown: string;
+  currentMarkdown: string;
+};
+
+const REPORT_STATUS_PREFIX = /^Blueprint status:\s*/i;
+
+function cleanValue(value: string | null | undefined): string | null {
+  const cleaned = String(value ?? "")
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned || null;
+}
+
+function comparisonValue(value: string | null): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[.*_`#]/g, " ")
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function reportStatus(notes: string | null | undefined): string | null {
+  return cleanValue(String(notes ?? "").replace(REPORT_STATUS_PREFIX, ""));
+}
+
+export function extractBlueprintRecommendationSnapshots(markdown: string): BlueprintRecommendationSnapshot[] {
+  const snapshots = parseMarkdownToItems(markdown)
+    .filter((item) => item.is_current === false && REPORT_STATUS_PREFIX.test(item.notes ?? ""))
+    .map((item) => ({
+      key: healthItemIdentityKey(item.name),
+      name: cleanValue(item.name) ?? "Recommendation",
+      status: reportStatus(item.notes),
+      dose: cleanValue(item.dose),
+      timing: cleanValue(item.timing_text || item.timing),
+      rationale: cleanValue(item.rationale),
+    }))
+    .filter((item) => Boolean(item.key));
+
+  const byKey = new Map<string, BlueprintRecommendationSnapshot>();
+  for (const snapshot of snapshots) {
+    if (!byKey.has(snapshot.key)) byKey.set(snapshot.key, snapshot);
+  }
+  return [...byKey.values()];
+}
+
+function attentionFor(
+  kind: BlueprintDeltaKind,
+  current: BlueprintRecommendationSnapshot | null,
+): BlueprintDeltaAttention {
+  if (kind === "removed" || kind === "unchanged") return "informational";
+  if (/clinician review/i.test(current?.status ?? "")) return "clinician_review";
+  return "decision";
+}
+
+function changedFields(
+  previous: BlueprintRecommendationSnapshot,
+  current: BlueprintRecommendationSnapshot,
+): BlueprintRecommendationDelta["changedFields"] {
+  const fields: BlueprintRecommendationDelta["changedFields"] = [];
+  if (comparisonValue(previous.name) !== comparisonValue(current.name)) fields.push("name");
+  if (comparisonValue(previous.status) !== comparisonValue(current.status)) fields.push("status");
+  if (comparisonValue(previous.dose) !== comparisonValue(current.dose)) fields.push("dose");
+  if (comparisonValue(previous.timing) !== comparisonValue(current.timing)) fields.push("timing");
+  if (comparisonValue(previous.rationale) !== comparisonValue(current.rationale)) fields.push("rationale");
+  return fields;
+}
+
+function fieldList(fields: BlueprintRecommendationDelta["changedFields"]): string {
+  const labels = fields.map((field) => {
+    if (field === "dose") return "starting guidance";
+    if (field === "timing") return "timing guidance";
+    if (field === "rationale") return "report rationale";
+    if (field === "status") return "review status";
+    return "display name";
+  });
+  if (labels.length <= 1) return labels[0] ?? "report guidance";
+  return `${labels.slice(0, -1).join(", ")} and ${labels.at(-1)}`;
+}
+
+function explanationFor(
+  kind: BlueprintDeltaKind,
+  previous: BlueprintRecommendationSnapshot | null,
+  current: BlueprintRecommendationSnapshot | null,
+  fields: BlueprintRecommendationDelta["changedFields"],
+): string {
+  if (kind === "added") {
+    return current?.rationale
+      ? `This option is new in the current report. The recorded rationale is: ${current.rationale}`
+      : "This option is new in the current report. No additional rationale was recorded.";
+  }
+  if (kind === "removed") {
+    return "This option is no longer listed as a recommendation. That is a report change, not an instruction to stop a medication, supplement, or hormone.";
+  }
+  if (kind === "changed") {
+    return `The current report changed the ${fieldList(fields)}.${current?.rationale ? ` Current rationale: ${current.rationale}` : ""}`;
+  }
+  return "The recommendation and its recorded guidance are unchanged from the prior Blueprint.";
+}
+
+function actionFor(
+  kind: BlueprintDeltaKind,
+  attention: BlueprintDeltaAttention,
+): Pick<BlueprintRecommendationDelta, "actionHref" | "actionLabel"> {
+  if (kind === "removed") return { actionHref: "#version-history", actionLabel: "Open prior Blueprint" };
+  if (kind === "unchanged") return { actionHref: "#recommendation-report", actionLabel: "Review report detail" };
+  if (attention === "clinician_review") return { actionHref: "#recommendation-report", actionLabel: "Review before discussing" };
+  return { actionHref: "#recommendation-decisions", actionLabel: "Make a decision" };
+}
+
+function safetyExplanation(previousStatus: BlueprintSafetyStatus, currentStatus: BlueprintSafetyStatus): string {
+  if (currentStatus === "error") {
+    return "The current report does not contain a readable safety section. Treat its safety status as unavailable until the report is reviewed.";
+  }
+  if (previousStatus !== currentStatus && currentStatus === "safe") {
+    return "The current deterministic safety review no longer identifies a material concern in the report. Review the current notes before acting on any recommendation.";
+  }
+  if (previousStatus !== currentStatus) {
+    return "The current deterministic safety review now contains notes that need attention. Open the safety section for the recorded findings.";
+  }
+  if (currentStatus === "warning") {
+    return "The safety-review status is unchanged and the current report still contains notes that need attention.";
+  }
+  return "The deterministic safety-review status is unchanged, with no material concern identified in either report.";
+}
+
+export function buildBlueprintDelta(input: BuildBlueprintDeltaInput): BlueprintDelta {
+  const previous = extractBlueprintRecommendationSnapshots(input.previousMarkdown);
+  const current = extractBlueprintRecommendationSnapshots(input.currentMarkdown);
+  const previousByKey = new Map(previous.map((item) => [item.key, item]));
+  const currentByKey = new Map(current.map((item) => [item.key, item]));
+  const keys = [...new Set([...currentByKey.keys(), ...previousByKey.keys()])];
+
+  const recommendations = keys.map((key): BlueprintRecommendationDelta => {
+    const previousItem = previousByKey.get(key) ?? null;
+    const currentItem = currentByKey.get(key) ?? null;
+    const fields = previousItem && currentItem ? changedFields(previousItem, currentItem) : [];
+    const kind: BlueprintDeltaKind = !previousItem
+      ? "added"
+      : !currentItem
+        ? "removed"
+        : fields.length
+          ? "changed"
+          : "unchanged";
+    const attention = attentionFor(kind, currentItem);
+    return {
+      key,
+      name: currentItem?.name ?? previousItem?.name ?? "Recommendation",
+      kind,
+      attention,
+      changedFields: fields,
+      previous: previousItem,
+      current: currentItem,
+      explanation: explanationFor(kind, previousItem, currentItem, fields),
+      ...actionFor(kind, attention),
+    };
+  }).sort((left, right) => {
+    const order: Record<BlueprintDeltaKind, number> = { added: 0, changed: 1, removed: 2, unchanged: 3 };
+    return order[left.kind] - order[right.kind] || left.name.localeCompare(right.name);
+  });
+
+  const previousStatus = deriveBlueprintSafetyStatus(input.previousMarkdown);
+  const currentStatus = deriveBlueprintSafetyStatus(input.currentMarkdown);
+
+  return {
+    previousStackId: input.previousStackId,
+    previousCreatedAt: input.previousCreatedAt,
+    currentCreatedAt: input.currentCreatedAt,
+    generationReason: input.generationReason,
+    recommendations,
+    counts: recommendations.reduce<Record<BlueprintDeltaKind, number>>(
+      (counts, item) => ({ ...counts, [item.kind]: counts[item.kind] + 1 }),
+      { added: 0, changed: 0, removed: 0, unchanged: 0 },
+    ),
+    safety: {
+      previousStatus,
+      currentStatus,
+      changed: previousStatus !== currentStatus,
+      needsReview: currentStatus !== "safe",
+      explanation: safetyExplanation(previousStatus, currentStatus),
+    },
+  };
+}

--- a/src/lib/blueprintDelta.ts
+++ b/src/lib/blueprintDelta.ts
@@ -105,6 +105,7 @@ function attentionFor(
 ): BlueprintDeltaAttention {
   if (kind === "removed" || kind === "unchanged") return "informational";
   if (/clinician review/i.test(current?.status ?? "")) return "clinician_review";
+  if (/^current\b/i.test(current?.status ?? "")) return "informational";
   return "decision";
 }
 
@@ -156,10 +157,12 @@ function explanationFor(
 function actionFor(
   kind: BlueprintDeltaKind,
   attention: BlueprintDeltaAttention,
+  current: BlueprintRecommendationSnapshot | null,
 ): Pick<BlueprintRecommendationDelta, "actionHref" | "actionLabel"> {
   if (kind === "removed") return { actionHref: "#version-history", actionLabel: "Open prior Blueprint" };
   if (kind === "unchanged") return { actionHref: "#recommendation-report", actionLabel: "Review report detail" };
   if (attention === "clinician_review") return { actionHref: "#recommendation-report", actionLabel: "Review before discussing" };
+  if (/^current\b/i.test(current?.status ?? "")) return { actionHref: "/routine", actionLabel: "Open in Routine" };
   return { actionHref: "#recommendation-decisions", actionLabel: "Make a decision" };
 }
 
@@ -207,7 +210,7 @@ export function buildBlueprintDelta(input: BuildBlueprintDeltaInput): BlueprintD
       previous: previousItem,
       current: currentItem,
       explanation: explanationFor(kind, previousItem, currentItem, fields),
-      ...actionFor(kind, attention),
+      ...actionFor(kind, attention, currentItem),
     };
   }).sort((left, right) => {
     const order: Record<BlueprintDeltaKind, number> = { added: 0, changed: 1, removed: 2, unchanged: 3 };

--- a/src/lib/blueprintDelta.ts
+++ b/src/lib/blueprintDelta.ts
@@ -77,7 +77,11 @@ function reportStatus(notes: string | null | undefined): string | null {
 
 export function extractBlueprintRecommendationSnapshots(markdown: string): BlueprintRecommendationSnapshot[] {
   const snapshots = parseMarkdownToItems(markdown)
-    .filter((item) => item.is_current === false && REPORT_STATUS_PREFIX.test(item.notes ?? ""))
+    // A recommendation-table row may also appear in Current Stack and will
+    // therefore be marked current by the shared report parser. The explicit
+    // Blueprint status prefix is the authoritative signal that the row came
+    // from the recommendations table.
+    .filter((item) => REPORT_STATUS_PREFIX.test(item.notes ?? ""))
     .map((item) => ({
       key: healthItemIdentityKey(item.name),
       name: cleanValue(item.name) ?? "Recommendation",


### PR DESCRIPTION
## Purpose

Make refreshed Blueprints understandable by showing members exactly what changed from the prior saved version.

## What changed

- Compare the current Blueprint with its exact predecessor, with chronological fallback for legacy versions.
- Group recommendations as new, updated, no longer listed, or stable.
- Normalize equivalent ingredient names so B12 and magnesium aliases are not falsely labeled as new.
- Show bounded report rationale and previous/current guidance without guessing why health inputs changed.
- Keep deterministic safety-review status authoritative and visually separate from recommendation changes.
- Link changes to the decision layer, current safety notes, evidence, or the prior Blueprint.
- Preserve the full report, PDFs, version history, and existing recommendation decisions.

## Safety boundaries

- No model decides whether a recommendation or safety finding changed.
- Removed recommendations are explicitly not presented as instructions to stop medications, supplements, or hormones.
- Safety status continues to come from the existing deterministic report parser.
- The comparison discloses that it does not infer causality.

## Verification

Passed:
- `npm.cmd run qa:pr103`
- `npm.cmd run typecheck`
- `npm.cmd run qa:blueprint-safety`
- `npm.cmd run qa:pr93`
- `git diff --check`

Environment-limited:
- `npm.cmd run build` compiled successfully and completed type validation, then local page generation stopped at `/login` because this checkout lacks usable public Supabase environment values.
- `npm.cmd run qa:blueprints` reaches a stale pre-PR103 assertion that still expects the retired “Start this weekly practice” Blueprint control.

## Risks and rollback

Risk is limited to comparison presentation on versioned Blueprint pages. No schema, refresh-generation, regimen, decision, or safety-engine behavior changes. Roll back commit `193ee66` to remove the feature.

## Preview QA

Use an authenticated member with at least two Blueprint versions. Confirm the current page shows accurate counts, readable change cards, direct links, a separately labeled safety result, and a collapsed stable group.