### PR TITLE
PR106 — Make Ask LVE360 a usable coaching workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@tailwindcss/postcss": "^4.1.13",
         "@types/node": "^20.12.7",
         "@types/react": "^18.2.66",
+        "@types/react-dom": "^18.2.22",
         "@types/recharts": "^1.8.29",
         "autoprefixer": "^10.4.21",
         "postcss": "8.5.25",
@@ -1761,6 +1762,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.22",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.22.tgz",
+      "integrity": "sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/recharts": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
     "@types/recharts": "^1.8.29",
     "autoprefixer": "^10.4.21",
     "postcss": "8.5.25",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "qa:pr103": "node --experimental-strip-types src/_tests_/pr103BlueprintDelta.assert.ts && node src/_tests_/pr103Page.assert.mjs",
     "qa:pr104": "node --experimental-strip-types src/_tests_/pr104ReminderBehavior.assert.ts && node src/_tests_/pr104Page.assert.mjs",
     "qa:pr105": "node --experimental-strip-types src/_tests_/pr105ContextualCoach.assert.ts && node src/_tests_/pr105Page.assert.mjs",
+    "qa:pr106": "node src/_tests_/pr106CoachWorkspace.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr106CoachWorkspace.assert.mjs
+++ b/src/_tests_/pr106CoachWorkspace.assert.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const coach = fs.readFileSync("src/components/coach/AskLve360Coach.tsx", "utf8");
+
+assert.match(coach, /max-w-6xl/, "The desktop coach must use a substantially larger workspace.");
+assert.match(coach, /sm:w-\[min\(92vw,72rem\)\]/, "The workspace must expand responsively without exceeding the viewport.");
+assert.match(coach, /min-h-0 flex-1 overflow-y-auto overscroll-contain/, "Only the conversation transcript should consume and scroll through flexible height.");
+assert.match(coach, /shrink-0 border-b/, "The coach header must remain visible while the transcript scrolls.");
+assert.match(coach, /shrink-0 border-t/, "The composer must remain visible while the transcript scrolls.");
+assert.match(coach, /max-w-5xl/, "Conversation content must retain a readable line length inside the larger workspace.");
+assert.match(coach, /launchButtonRef/, "The coach must retain a reference to its launcher for focus restoration.");
+assert.match(coach, /closeButtonRef\.current\?\.focus/, "Opening the coach must place keyboard focus inside the dialog.");
+assert.match(coach, /launchButtonRef\.current\?\.focus/, "Closing the coach must return keyboard focus to its launcher.");
+assert.match(coach, /document\.body\.style\.overflow = "hidden"/, "The dashboard behind an open coach must not scroll.");
+assert.match(coach, /transcriptRef\.current\?\.scrollTo/, "Opening and receiving an answer must surface the newest coaching turn.");
+assert.match(coach, /What I used/, "The larger workspace must preserve source inspection.");
+assert.match(coach, /cannot diagnose or change medications, hormones, supplements, reminders, or saved records/i, "The workspace redesign must preserve the safety boundary.");
+
+console.log("PR106 coaching workspace assertions passed.");

--- a/src/_tests_/pr106CoachWorkspace.assert.mjs
+++ b/src/_tests_/pr106CoachWorkspace.assert.mjs
@@ -14,6 +14,7 @@ assert.match(coach, /closeButtonRef\.current\?\.focus/, "Opening the coach must 
 assert.match(coach, /launchButtonRef\.current\?\.focus/, "Closing the coach must return keyboard focus to its launcher.");
 assert.match(coach, /document\.body\.style\.overflow = "hidden"/, "The dashboard behind an open coach must not scroll.");
 assert.match(coach, /transcriptRef\.current\?\.scrollTo/, "Opening and receiving an answer must surface the newest coaching turn.");
+assert.match(coach, /createPortal\([\s\S]*document\.body/, "The modal must escape the sticky, backdrop-filtered dashboard header's containing block.");
 assert.match(coach, /What I used/, "The larger workspace must preserve source inspection.");
 assert.match(coach, /cannot diagnose or change medications, hormones, supplements, reminders, or saved records/i, "The workspace redesign must preserve the safety boundary.");
 

--- a/src/components/coach/AskLve360Coach.tsx
+++ b/src/components/coach/AskLve360Coach.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, MessageCircle, Send, Sparkles, ThumbsDown, ThumbsUp, X } 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import {
   coachPageFromPath,
@@ -130,7 +131,7 @@ export default function AskLve360Coach() {
         <span className="sr-only lg:hidden">Ask LVE360</span>
       </button>
 
-      {open ? (
+      {open ? createPortal((
         <div className="fixed inset-0 z-[80] flex items-stretch justify-end bg-[#041B2D]/45 sm:p-4 lg:p-6" role="presentation" onMouseDown={(event) => {
           if (event.currentTarget === event.target) closeCoach();
         }}>
@@ -234,7 +235,7 @@ export default function AskLve360Coach() {
             </footer>
           </section>
         </div>
-      ) : null}
+      ), document.body) : null}
     </>
   );
 }

--- a/src/components/coach/AskLve360Coach.tsx
+++ b/src/components/coach/AskLve360Coach.tsx
@@ -3,7 +3,7 @@
 import { ExternalLink, MessageCircle, Send, Sparkles, ThumbsDown, ThumbsUp, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   coachPageFromPath,
@@ -29,15 +29,33 @@ export default function AskLve360Coach() {
   const [turns, setTurns] = useState<CoachTurn[]>([]);
   const [usage, setUsage] = useState<Usage | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const launchButtonRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const transcriptRef = useRef<HTMLDivElement>(null);
+
+  const closeCoach = useCallback(() => {
+    setOpen(false);
+    window.requestAnimationFrame(() => launchButtonRef.current?.focus());
+  }, []);
 
   useEffect(() => {
     if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const frame = window.requestAnimationFrame(() => {
+      transcriptRef.current?.scrollTo({ top: 0 });
+      closeButtonRef.current?.focus();
+    });
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") closeCoach();
     }
     document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [open]);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [closeCoach, open]);
 
   useEffect(() => {
     if (!open || loaded) return;
@@ -75,6 +93,7 @@ export default function AskLve360Coach() {
       setTurns((current) => [payload.turn as CoachTurn, ...current].slice(0, 8));
       setUsage(payload.usage ?? null);
       setQuestion("");
+      window.requestAnimationFrame(() => transcriptRef.current?.scrollTo({ top: 0, behavior: "smooth" }));
     } catch {
       setError("I could not answer that right now. Your saved information was not changed.");
     } finally {
@@ -100,6 +119,7 @@ export default function AskLve360Coach() {
   return (
     <>
       <button
+        ref={launchButtonRef}
         type="button"
         onClick={() => setOpen(true)}
         className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-[#087F72]/30 bg-[#EAFBF8] px-3 py-2 text-sm font-bold text-[#06695F] transition hover:border-[#087F72] hover:bg-[#DDF7F1] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72] focus-visible:ring-offset-2"
@@ -111,35 +131,39 @@ export default function AskLve360Coach() {
       </button>
 
       {open ? (
-        <div className="fixed inset-0 z-[80] flex justify-end bg-[#041B2D]/35" role="presentation" onMouseDown={(event) => {
-          if (event.currentTarget === event.target) setOpen(false);
+        <div className="fixed inset-0 z-[80] flex items-stretch justify-end bg-[#041B2D]/45 sm:p-4 lg:p-6" role="presentation" onMouseDown={(event) => {
+          if (event.currentTarget === event.target) closeCoach();
         }}>
           <section
             role="dialog"
             aria-modal="true"
             aria-labelledby="coach-title"
-            className="flex h-full w-full max-w-xl flex-col bg-[#F8FCFB] shadow-2xl"
+            className="flex h-full w-full min-w-0 max-w-6xl flex-col overflow-hidden bg-[#F8FCFB] shadow-2xl sm:h-[calc(100dvh-2rem)] sm:w-[min(92vw,72rem)] sm:rounded-[1.75rem] lg:h-[calc(100dvh-3rem)]"
           >
-            <header className="border-b border-[#9DCFC3] bg-white px-5 py-4 sm:px-6">
+            <header className="shrink-0 border-b border-[#9DCFC3] bg-white px-4 py-3 sm:px-6 sm:py-4">
               <div className="flex items-start justify-between gap-4">
-                <div>
+                <div className="min-w-0">
                   <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]"><MessageCircle className="h-4 w-4" aria-hidden="true" /> Contextual coaching</p>
                   <h2 id="coach-title" className="mt-1 text-2xl font-black text-[#041B2D]">Ask LVE360</h2>
                   <p className="mt-1 text-sm text-[#486170]">Grounded in the records you have saved in LVE360.</p>
                 </div>
-                <button type="button" onClick={() => setOpen(false)} className="rounded-lg p-2 text-[#486170] hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]" aria-label="Close Ask LVE360">
-                  <X className="h-5 w-5" aria-hidden="true" />
-                </button>
+                <div className="flex shrink-0 items-center gap-2">
+                  {remaining !== null ? <span className="hidden rounded-full bg-[#EAFBF8] px-3 py-1.5 text-xs font-bold text-[#06695F] sm:inline">{remaining} left this month</span> : null}
+                  <button ref={closeButtonRef} type="button" onClick={closeCoach} className="rounded-lg p-2 text-[#486170] hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#087F72]" aria-label="Close Ask LVE360">
+                    <X className="h-5 w-5" aria-hidden="true" />
+                  </button>
+                </div>
               </div>
-              {remaining !== null ? <p className="mt-3 text-xs font-semibold text-[#486170]">{remaining} coaching question{remaining === 1 ? "" : "s"} remaining this month</p> : null}
+              {remaining !== null ? <p className="mt-2 text-xs font-semibold text-[#486170] sm:hidden">{remaining} coaching question{remaining === 1 ? "" : "s"} remaining this month</p> : null}
             </header>
 
-            <div className="flex-1 overflow-y-auto px-5 py-5 sm:px-6">
-              {!turns.length && !loading ? (
-                <div className="rounded-2xl border border-[#9DCFC3] bg-white p-5">
+            <div ref={transcriptRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
+              <div className="mx-auto w-full max-w-5xl">
+                {!turns.length && !loading ? (
+                <div className="rounded-2xl border border-[#9DCFC3] bg-white p-5 sm:p-6">
                   <h3 className="font-black text-[#041B2D]">Start with what is in front of you</h3>
                   <p className="mt-2 text-sm leading-6 text-[#486170]">Ask about a Blueprint theme, your weekly practice, recorded progress, or how to prepare a question for a clinician.</p>
-                  <div className="mt-4 space-y-2">
+                  <div className="mt-4 grid gap-2 lg:grid-cols-2">
                     {prompts.map((prompt) => (
                       <button key={prompt} type="button" onClick={() => setQuestion(prompt)} className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-left text-sm font-semibold text-[#041B2D] hover:border-[#087F72] hover:bg-[#EAFBF8]">
                         {prompt}
@@ -149,13 +173,13 @@ export default function AskLve360Coach() {
                 </div>
               ) : null}
 
-              <div className="space-y-5" aria-live="polite">
+              <div className="space-y-6" aria-live="polite">
                 {loading && !turns.length ? <p className="text-sm text-[#486170]">Loading your coaching history…</p> : null}
                 {turns.map((turn) => (
                   <article key={turn.id} className="space-y-3">
-                    <div className="ml-8 rounded-2xl rounded-br-md bg-[#041B2D] px-4 py-3 text-sm leading-6 text-white">{turn.question}</div>
-                    <div className="mr-4 rounded-2xl rounded-bl-md border border-[#9DCFC3] bg-white p-4 shadow-sm">
-                      <p className="whitespace-pre-wrap text-sm leading-6 text-[#17384A]">{turn.answer}</p>
+                    <div className="ml-auto max-w-[88%] rounded-2xl rounded-br-md bg-[#041B2D] px-4 py-3 text-sm leading-6 text-white sm:max-w-[78%]">{turn.question}</div>
+                    <div className="mr-auto w-full rounded-2xl rounded-bl-md border border-[#9DCFC3] bg-white p-4 shadow-sm sm:p-5">
+                      <p className="whitespace-pre-wrap text-[15px] leading-7 text-[#17384A]">{turn.answer}</p>
                       {turn.source_refs?.length ? (
                         <details className="mt-4 border-t border-slate-100 pt-3">
                           <summary className="cursor-pointer text-xs font-bold uppercase tracking-[0.12em] text-[#087F72]">What I used</summary>
@@ -181,10 +205,11 @@ export default function AskLve360Coach() {
                 ))}
               </div>
               {error ? <p className="mt-4 rounded-xl bg-red-50 px-4 py-3 text-sm font-semibold text-red-800" role="alert">{error}</p> : null}
+              </div>
             </div>
 
-            <footer className="border-t border-[#9DCFC3] bg-white p-4 sm:px-6">
-              <form onSubmit={ask} className="flex gap-2">
+            <footer className="shrink-0 border-t border-[#9DCFC3] bg-white px-4 py-3 sm:px-6 lg:px-8">
+              <form onSubmit={ask} className="mx-auto flex w-full max-w-5xl items-end gap-2">
                 <label htmlFor="coach-question" className="sr-only">Ask LVE360 a question</label>
                 <textarea
                   id="coach-question"
@@ -198,14 +223,14 @@ export default function AskLve360Coach() {
                   }}
                   rows={2}
                   placeholder="Ask about your next small step…"
-                  className="min-h-12 flex-1 resize-none rounded-xl border border-slate-300 px-3 py-2 text-sm text-[#041B2D] focus:border-[#087F72] focus:outline-none focus:ring-2 focus:ring-[#087F72]/20"
+                  className="min-h-12 max-h-32 flex-1 resize-y rounded-xl border border-slate-300 px-3 py-2 text-sm text-[#041B2D] focus:border-[#087F72] focus:outline-none focus:ring-2 focus:ring-[#087F72]/20"
                   disabled={loading || remaining === 0}
                 />
-                <button type="submit" disabled={loading || question.trim().length < 4 || remaining === 0} className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-[#087F72] text-white hover:bg-[#06695F] disabled:cursor-not-allowed disabled:opacity-50" aria-label="Send question">
+                <button type="submit" disabled={loading || question.trim().length < 4 || remaining === 0} className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[#087F72] text-white hover:bg-[#06695F] disabled:cursor-not-allowed disabled:opacity-50" aria-label="Send question">
                   <Send className="h-5 w-5" aria-hidden="true" />
                 </button>
               </form>
-              <p className="mt-2 text-xs leading-5 text-[#60798A]">Educational wellness support only. Ask LVE360 cannot diagnose or change medications, hormones, supplements, reminders, or saved records. Review health decisions with a qualified professional.</p>
+              <p className="mx-auto mt-2 w-full max-w-5xl text-[11px] leading-4 text-[#60798A]">Educational wellness support only. Ask LVE360 cannot diagnose or change medications, hormones, supplements, reminders, or saved records. Review health decisions with a qualified professional.</p>
             </footer>
           </section>
         </div>


### PR DESCRIPTION
## Purpose

Make Ask LVE360 comfortable to read and use as a real coaching workspace. The PR105 drawer was too narrow, and its header and composer consumed enough vertical space that the transcript could become nearly unusable on shorter screens.

## Root cause

The original panel was capped at `max-w-xl`. Live Preview QA also revealed that it was mounted inside the sticky, backdrop-filtered dashboard header. That header established a containing block, so the supposedly full-height modal could collapse to the header's 64-pixel height on narrow screens.

## What changed

- expands the desktop coach into a responsive workspace using most of the available viewport
- renders the modal at the document root so the dashboard header cannot constrain it
- keeps mobile full-screen and touch-friendly
- makes only the transcript consume flexible height and scroll
- keeps the header, usage allowance, composer, and safety boundary visible
- constrains conversation content to a readable line length inside the wider panel
- improves answer typography and question-bubble sizing
- places empty-state prompts in two columns when space permits
- restores keyboard focus to the launcher after closing
- locks background dashboard scrolling while the modal is open
- surfaces the newest answer when the coach opens or receives a response

## Files changed

- `src/components/coach/AskLve360Coach.tsx`
- `src/_tests_/pr106CoachWorkspace.assert.mjs`
- `package.json`
- `package-lock.json`

## Verified

- `npm.cmd run qa:pr105`
- `npm.cmd run qa:pr106`
- `npm.cmd run typecheck`
- `git diff --check`
- GitHub build passed
- Vercel Preview deployment passed
- authenticated Preview at 1440×900:
  - 1152×852 workspace
  - 637-pixel transcript viewport
  - fixed header and composer
- authenticated Preview at 390×844:
  - true full-screen workspace
  - 561-pixel transcript viewport
  - no horizontal overflow
- transcript-only scrolling
- composer enablement and sizing
- close button and Escape dismissal
- focus enters the dialog and returns to the launcher
- background scroll locking
- no console errors or warnings

The local production build compiled successfully and completed type validation. It stopped during `/login` prerender because the protected public Supabase values are intentionally unavailable in this checkout; the complete GitHub and Vercel builds passed with configured environment values.

## Risks and rollback

This is a client-side layout and accessibility change only. It does not change the coaching API, model routing, usage limits, safety rules, saved history, or Supabase schema. Rollback is to revert PR106.