### PR TITLE
PR107 — Build Ask LVE360 Coaching Engine v2

### DIFF
--- a/app/api/coach/route.ts
+++ b/app/api/coach/route.ts
@@ -2,9 +2,10 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 
-import { buildCoachContext, generateCoachAnswer } from "@/lib/ai/contextualCoachData";
+import { buildCoachContext, generateCoachAnswer, type CoachDiagnostics } from "@/lib/ai/contextualCoachData";
 import {
   COACH_PROMPT_VERSION,
+  classifyCoachIntent,
   cleanCoachQuestion,
   coachBoundaryAnswer,
   coachPageFromPath,
@@ -94,15 +95,19 @@ export async function POST(req: NextRequest) {
     const question = cleanCoachQuestion(body?.question);
     if (!question) return NextResponse.json({ ok: false, error: "invalid_question" }, { status: 400 });
     const page = coachPageFromPath(body?.pathname);
+    const intent = classifyCoachIntent(question);
     const boundary = coachSafetyBoundary(question);
-    if (boundary) {
+    if (boundary || intent === "POTENTIAL_MEDICAL_RED_FLAG") {
       const turn = await saveTurn(auth.user.id, {
         page_context: page,
         question,
-        answer: coachBoundaryAnswer(boundary),
+        answer: coachBoundaryAnswer(boundary ?? "emergency"),
         response_source: "safety",
         generation_status: "blocked",
         source_refs: [],
+        intent,
+        quality_score: 100,
+        safety_rule_count: 1,
       });
       return NextResponse.json({ ok: true, turn, usage: await usage(auth.user.id) });
     }
@@ -116,11 +121,12 @@ export async function POST(req: NextRequest) {
         response_source: "budget",
         generation_status: "limited",
         source_refs: [],
+        intent,
       });
       return NextResponse.json({ ok: true, turn, usage: await usage(auth.user.id) });
     }
 
-    const context = await buildCoachContext(auth.user.id, page);
+    const context = await buildCoachContext(auth.user.id, page, question, intent);
     const { data: pending, error: pendingError } = await getSupabaseAdmin().from("ai_coaching_turns").insert({
       user_id: auth.user.id,
       page_context: page,
@@ -130,6 +136,8 @@ export async function POST(req: NextRequest) {
       generation_status: "pending",
       prompt_version: COACH_PROMPT_VERSION,
       source_refs: context.sources,
+      intent,
+      evidence_ids: context.evidenceOptions.map((option) => option.id),
     }).select("id").single();
     if (pendingError) throw pendingError;
 
@@ -137,6 +145,14 @@ export async function POST(req: NextRequest) {
     let sourceRefs: CoachSource[] = context.sources;
     let responseSource: CoachTurn["response_source"] = "fallback";
     let generationStatus: CoachTurn["generation_status"] = "failed";
+    let diagnostics: CoachDiagnostics = {
+      intent,
+      qualityScore: 0,
+      safetyRuleCount: context.preSafety?.findings.length ?? 0,
+      recommendationsRemoved: 0,
+      regenerationCount: 0,
+      evidenceIds: context.evidenceOptions.map((option) => option.id),
+    };
     try {
       const generated = await generateCoachAnswer(auth.user.id, question, context);
       if (generated) {
@@ -144,6 +160,7 @@ export async function POST(req: NextRequest) {
         sourceRefs = context.sources.filter((source) => generated.sourceIds.includes(source.id));
         responseSource = generated.responseSource;
         generationStatus = "succeeded";
+        diagnostics = generated.diagnostics;
       }
     } catch (error) {
       console.warn("[coach] generation unavailable; returning grounded fallback", error);
@@ -154,6 +171,12 @@ export async function POST(req: NextRequest) {
       source_refs: sourceRefs,
       response_source: responseSource,
       generation_status: generationStatus,
+      intent: diagnostics.intent,
+      quality_score: diagnostics.qualityScore,
+      safety_rule_count: diagnostics.safetyRuleCount,
+      recommendations_removed: diagnostics.recommendationsRemoved,
+      regeneration_count: diagnostics.regenerationCount,
+      evidence_ids: diagnostics.evidenceIds,
       updated_at: new Date().toISOString(),
     }).eq("id", pending.id).eq("user_id", auth.user.id)
       .select("id,page_context,question,answer,response_source,generation_status,source_refs,feedback,created_at").single();

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "qa:pr104": "node --experimental-strip-types src/_tests_/pr104ReminderBehavior.assert.ts && node src/_tests_/pr104Page.assert.mjs",
     "qa:pr105": "node --experimental-strip-types src/_tests_/pr105ContextualCoach.assert.ts && node src/_tests_/pr105Page.assert.mjs",
     "qa:pr106": "node src/_tests_/pr106CoachWorkspace.assert.mjs",
+    "qa:pr107": "node --experimental-strip-types src/_tests_/pr107CoachingEngine.assert.ts && node src/_tests_/pr107Architecture.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr105ContextualCoach.assert.ts
+++ b/src/_tests_/pr105ContextualCoach.assert.ts
@@ -18,16 +18,16 @@ assert.equal(cleanCoachQuestion("no"), null);
 
 assert.equal(coachSafetyBoundary("Do I have diabetes?"), "diagnosis");
 assert.equal(coachSafetyBoundary("Should I increase my medication dose?"), "regimen_change");
-assert.equal(coachSafetyBoundary("Should I take B12?"), "regimen_change");
+assert.equal(coachSafetyBoundary("Should I take B12?"), null);
 assert.equal(coachSafetyBoundary("Help me prepare questions about my medication."), null);
 assert.equal(coachSafetyBoundary("Do I have a weekly practice?"), null);
 assert.equal(coachSafetyBoundary("I have chest pain and can't breathe"), "emergency");
-assert.match(coachBoundaryAnswer("regimen_change"), /cannot tell you to start, stop, or change/i);
+assert.match(coachBoundaryAnswer("regimen_change"), /cannot direct a medication or hormone change/i);
 assert.match(coachBoundaryAnswer("diagnosis"), /cannot diagnose/i);
 assert.equal(isCoachAnswerSafe("You should increase your medication dose."), false);
 assert.equal(isCoachAnswerSafe("You should take a 10-minute walk after lunch."), true);
 assert.equal(isCoachAnswerSafe("You have diabetes."), false);
-assert.equal(isCoachAnswerSafe("This can help improve digestion and energy levels."), false);
+assert.equal(isCoachAnswerSafe("This can help improve digestion and energy levels."), true);
 assert.equal(isCoachAnswerSafe("This keeps the step tied to your weekly plan."), true);
 
 const parsed = parseCoachAnswer(

--- a/src/_tests_/pr105Page.assert.mjs
+++ b/src/_tests_/pr105Page.assert.mjs
@@ -12,16 +12,16 @@ const sourceMigration = fs.readFileSync("supabase/migrations/20260812030448_pr10
 
 assert.match(header, /AskLve360Coach/, "The paid dashboard must expose coaching globally.");
 assert.match(coach, /What I used/, "Every grounded answer must let the member inspect its sources.");
-assert.match(coach, /cannot diagnose or change medications, hormones, supplements, reminders, or saved records/i);
+assert.match(coach, /cannot diagnose or silently change saved records/i);
 assert.match(coach, /useful/);
 assert.match(coach, /not_useful/);
-assert.match(context, /Use only the supplied member facts/i);
-assert.match(context, /Do not add health benefits, mechanisms, or expected outcomes/i);
+assert.match(context, /Saved LVE360 records describe this member/i);
+assert.match(context, /Use the supplied curated evidence_options/i);
 assert.match(context, /deterministicTodayStep/, "Today's smallest-step prompt must prefer the active weekly practice deterministically.");
-assert.match(context, /deterministicRoutineOverview/, "The Routine overview must organize current records without inventing health effects.");
+assert.match(context, /deterministicPlanLookup/, "Routine lookups must organize current records without inventing health effects.");
 assert.match(context, /deterministicJourneyPattern/, "Common Journey questions must use transparent recorded averages rather than causal inference.");
 assert.match(context, /sleep_rating_out_of_5/, "Check-in scales must be explicit so ratings cannot be misread as hours.");
-assert.match(context, /PAGE_SOURCE_IDS/, "Each dashboard page must receive only relevant source context.");
+assert.match(context, /INTENT_SOURCE_IDS/, "Each intent must receive only relevant source context.");
 assert.match(context, /generateAI\(\{[\s\S]*task: "contextual_coach"/, "Coaching must use the canonical AI gateway.");
 assert.match(modelConfig, /contextual_coach:[\s\S]*capability: "mini"/, "Coaching must default to the cost-efficient model capability.");
 assert.match(api, /LVE_AI_COACH_MONTHLY_TURNS|coachBudget/);

--- a/src/_tests_/pr106CoachWorkspace.assert.mjs
+++ b/src/_tests_/pr106CoachWorkspace.assert.mjs
@@ -16,6 +16,6 @@ assert.match(coach, /document\.body\.style\.overflow = "hidden"/, "The dashboard
 assert.match(coach, /transcriptRef\.current\?\.scrollTo/, "Opening and receiving an answer must surface the newest coaching turn.");
 assert.match(coach, /createPortal\([\s\S]*document\.body/, "The modal must escape the sticky, backdrop-filtered dashboard header's containing block.");
 assert.match(coach, /What I used/, "The larger workspace must preserve source inspection.");
-assert.match(coach, /cannot diagnose or change medications, hormones, supplements, reminders, or saved records/i, "The workspace redesign must preserve the safety boundary.");
+assert.match(coach, /cannot diagnose or silently change saved records/i, "The workspace redesign must preserve the safety boundary without suppressing normal coaching.");
 
 console.log("PR106 coaching workspace assertions passed.");

--- a/src/_tests_/pr107Architecture.assert.mjs
+++ b/src/_tests_/pr107Architecture.assert.mjs
@@ -16,6 +16,7 @@ assert.match(data, /Recommendation is not mutation/i, "The prompt must separate 
 assert.match(data, /is already in your current Routine/, "A mutation request for an existing item must identify it instead of offering to add a duplicate.");
 assert.match(data, /requiresReviewBeforeStart/, "A non-current recommendation with a safety-review finding must not become a self-start instruction.");
 assert.match(data, /isCurrentRecommendation/, "An already-recorded recommendation must not become an instruction to add a duplicate.");
+assert.match(data, /explicitlyNamedEvidenceOption/, "A direct question about a named option must stay focused on that option.");
 assert.match(data, /Keep your saved Routine unchanged until that review is complete/, "Safety-review recommendations must hand off to a clinician or pharmacist before a new start.");
 assert.match(route, /classifyCoachIntent\(question\)/, "The API must classify intent before context assembly.");
 assert.match(route, /quality_score/, "The API must persist privacy-safe quality diagnostics.");

--- a/src/_tests_/pr107Architecture.assert.mjs
+++ b/src/_tests_/pr107Architecture.assert.mjs
@@ -15,6 +15,7 @@ assert.match(data, /already_in_stack/, "The prompt context must explicitly ident
 assert.match(data, /Recommendation is not mutation/i, "The prompt must separate recommendations from stored-record changes.");
 assert.match(data, /is already in your current Routine/, "A mutation request for an existing item must identify it instead of offering to add a duplicate.");
 assert.match(data, /requiresReviewBeforeStart/, "A non-current recommendation with a safety-review finding must not become a self-start instruction.");
+assert.match(data, /isCurrentRecommendation/, "An already-recorded recommendation must not become an instruction to add a duplicate.");
 assert.match(data, /Keep your saved Routine unchanged until that review is complete/, "Safety-review recommendations must hand off to a clinician or pharmacist before a new start.");
 assert.match(route, /classifyCoachIntent\(question\)/, "The API must classify intent before context assembly.");
 assert.match(route, /quality_score/, "The API must persist privacy-safe quality diagnostics.");

--- a/src/_tests_/pr107Architecture.assert.mjs
+++ b/src/_tests_/pr107Architecture.assert.mjs
@@ -13,6 +13,9 @@ assert.match(data, /assessCoachAnswerQuality/, "A deterministic quality gate mus
 assert.match(data, /fallbackStructured/, "A failed model or quality gate must have a useful evidence-bound repair path.");
 assert.match(data, /already_in_stack/, "The prompt context must explicitly identify existing Routine candidates.");
 assert.match(data, /Recommendation is not mutation/i, "The prompt must separate recommendations from stored-record changes.");
+assert.match(data, /is already in your current Routine/, "A mutation request for an existing item must identify it instead of offering to add a duplicate.");
+assert.match(data, /requiresReviewBeforeStart/, "A non-current recommendation with a safety-review finding must not become a self-start instruction.");
+assert.match(data, /Keep your saved Routine unchanged until that review is complete/, "Safety-review recommendations must hand off to a clinician or pharmacist before a new start.");
 assert.match(route, /classifyCoachIntent\(question\)/, "The API must classify intent before context assembly.");
 assert.match(route, /quality_score/, "The API must persist privacy-safe quality diagnostics.");
 assert.match(migration, /service-role only/i, "The additive migration must preserve server-only writes and existing RLS.");

--- a/src/_tests_/pr107Architecture.assert.mjs
+++ b/src/_tests_/pr107Architecture.assert.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const data = fs.readFileSync("src/lib/ai/contextualCoachData.ts", "utf8");
+const route = fs.readFileSync("app/api/coach/route.ts", "utf8");
+const coach = fs.readFileSync("src/components/coach/AskLve360Coach.tsx", "utf8");
+const migration = fs.readFileSync("supabase/migrations/20260813090000_pr107_coaching_diagnostics.sql", "utf8");
+
+assert.match(data, /classif(?:ied_intent|ied intent)/i, "The model must receive a deterministic intent.");
+assert.match(data, /curated evidence_options/i, "The prompt must distinguish LVE360 evidence from member records.");
+assert.match(data, /applySafetyChecks\(context\.safetyContext/, "Generated candidates must pass a deterministic post-generation safety check.");
+assert.match(data, /assessCoachAnswerQuality/, "A deterministic quality gate must run before display.");
+assert.match(data, /fallbackStructured/, "A failed model or quality gate must have a useful evidence-bound repair path.");
+assert.match(data, /already_in_stack/, "The prompt context must explicitly identify existing Routine candidates.");
+assert.match(data, /Recommendation is not mutation/i, "The prompt must separate recommendations from stored-record changes.");
+assert.match(route, /classifyCoachIntent\(question\)/, "The API must classify intent before context assembly.");
+assert.match(route, /quality_score/, "The API must persist privacy-safe quality diagnostics.");
+assert.match(migration, /service-role only/i, "The additive migration must preserve server-only writes and existing RLS.");
+assert.match(coach, /health record, evidence library, and safety rules/i, "The UI must describe all four product layers accurately.");
+
+console.log("PR107 coaching architecture assertions passed.");

--- a/src/_tests_/pr107CoachingEngine.assert.ts
+++ b/src/_tests_/pr107CoachingEngine.assert.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import {
+  assessCoachAnswerQuality,
+  classifyCoachIntent,
+  coachSafetyBoundary,
+  isCoachAnswerSafe,
+  parseStructuredCoachAnswer,
+  type StructuredCoachAnswer,
+} from "../lib/contextualCoach.ts";
+import { evaluateSafetyCandidates } from "../lib/safetyEngine.ts";
+
+const sleepAnswer = JSON.stringify({
+  intent: "GENERAL_EDUCATION",
+  direct_answer: "Magnesium, glycine, melatonin, and L-theanine are used for different sleep goals rather than as interchangeable sleep aids.",
+  options: [
+    { name: "Magnesium Glycinate", fit: "neutral", reason: "A possible fit when magnesium intake is low, although sleep evidence is mixed." },
+    { name: "Glycine", fit: "strong", reason: "An emerging option for sleep quality and next-day tiredness." },
+  ],
+  recommendation: null,
+  next_step: "Choose the sleep problem you want to solve before comparing the top two options.",
+  source_ids: ["evidence_magnesium_glycinate", "evidence_glycine", "invented"],
+});
+const parsed = parseStructuredCoachAnswer(
+  sleepAnswer,
+  "GENERAL_EDUCATION",
+  new Set(["evidence_magnesium_glycinate", "evidence_glycine"]),
+  new Set(["magnesium glycinate", "glycine"]),
+);
+assert.ok(parsed, "Scenario 1: general education must accept concrete, evidence-bound options.");
+assert.equal(parsed.options.length, 2);
+assert.deepEqual(parsed.sourceIds, ["evidence_magnesium_glycinate", "evidence_glycine"]);
+
+const personalized: StructuredCoachAnswer = {
+  intent: "PERSONALIZED_RECOMMENDATION",
+  directAnswer: "Your recent sleep scores and current Routine make one carefully chosen experiment more useful than a larger supplement list.",
+  options: [{ name: "Glycine", fit: "strong", reason: "It does not duplicate the supplied Routine and fits the stated sleep-quality goal." }],
+  recommendation: { candidate: "Glycine", reason: "It fits the recorded goal without duplicating the current stack.", trialPeriodDays: 14, metrics: ["sleep quality", "morning energy"] },
+  nextStep: "Try only one change and track sleep quality and morning energy for 14 days.",
+  sourceIds: ["current_routine", "recent_check_ins", "evidence_glycine"],
+};
+const personalizedQuality = assessCoachAnswerQuality({ answer: personalized, supplementQuestion: true, safetyChecked: true, usedMemberContext: true });
+assert.equal(personalizedQuality.passed, true, "Scenario 2: a personalized, safe, actionable answer should pass.");
+
+const duplicateEvaluation = evaluateSafetyCandidates(
+  {},
+  [{ name: "Magnesium Glycinate", is_current: false }, { name: "Magnesium Glycinate", is_current: true }],
+  { interactions: [{ ingredient: "Magnesium Glycinate" }], rules: [] },
+);
+assert.equal(duplicateEvaluation.candidates.length, 1, "Scenario 3: duplicate identities must collapse.");
+assert.equal(duplicateEvaluation.candidates[0].isCurrent, true, "Scenario 3: the existing Routine item must win deduplication.");
+
+const interactionEvaluation = evaluateSafetyCandidates(
+  { medications: ["Warfarin"] },
+  [{ name: "Omega-3", is_current: false }],
+  { interactions: [{ ingredient: "Omega-3", anticoagulants_bleeding_risk: true }], rules: [] },
+);
+assert.equal(interactionEvaluation.candidates[0].decision, "blocked", "Scenario 4: deterministic safety must veto a high-severity interaction.");
+
+const missingDataButUseful: StructuredCoachAnswer = {
+  intent: "PERSONALIZED_RECOMMENDATION",
+  directAnswer: "There are still useful general options to compare even though the saved record does not identify the exact sleep problem.",
+  options: [{ name: "Melatonin", fit: "neutral", reason: "It is more relevant to sleep timing than to every form of poor sleep." }],
+  recommendation: null,
+  nextStep: "Clarify whether the main issue is falling asleep, staying asleep, or sleep timing.",
+  sourceIds: ["evidence_melatonin"],
+};
+assert.equal(assessCoachAnswerQuality({ answer: missingDataButUseful, supplementQuestion: true, safetyChecked: true, usedMemberContext: false }).passed, true, "Scenario 5: missing user data must not force an abstention.");
+
+assert.equal(classifyCoachIntent("What supplements am I currently taking at night?"), "CURRENT_PLAN_LOOKUP", "Scenario 6: current-plan lookup must stay record-based.");
+assert.equal(classifyCoachIntent("Add glycine to my stack."), "REQUEST_TO_CHANGE_RECORD", "Scenario 7: mutation language must enter the controlled workflow.");
+assert.equal(coachSafetyBoundary("Add glycine to my stack."), null, "Scenario 7: discussing a supplement record request must not be mistaken for a prescribed-plan change.");
+assert.equal(classifyCoachIntent("I have chest pain and can't breathe"), "POTENTIAL_MEDICAL_RED_FLAG", "Scenario 8: a serious issue must stop normal coaching.");
+assert.equal(coachSafetyBoundary("I have chest pain and can't breathe"), "emergency");
+assert.equal(classifyCoachIntent("My tongue is swelling after taking this"), "POTENTIAL_MEDICAL_RED_FLAG");
+assert.equal(isCoachAnswerSafe("You should increase your prescribed thyroid medication."), false);
+assert.equal(isCoachAnswerSafe("Magnesium is absolutely safe and has no risk."), false);
+assert.equal(parseStructuredCoachAnswer(
+  JSON.stringify({
+    intent: "GENERAL_EDUCATION",
+    direct_answer: "A fabricated citation is https://example.com/fake-study.",
+    options: [], recommendation: null, next_step: "Use that invented source.", source_ids: [],
+  }),
+  "GENERAL_EDUCATION", new Set(), new Set(),
+), null, "Free-form or fabricated citations must be rejected rather than shown.");
+
+const recordOnlyFailure = assessCoachAnswerQuality({
+  answer: {
+    intent: "GENERAL_EDUCATION",
+    directAnswer: "Your Blueprint does not specify which supplements are good for sleep.",
+    options: [], recommendation: null,
+    nextStep: "Talk to a professional.", sourceIds: [],
+  },
+  supplementQuestion: true, safetyChecked: true, usedMemberContext: false,
+});
+assert.equal(recordOnlyFailure.passed, false, "The concrete production failure must be rejected by the quality gate.");
+
+console.log("PR107 coaching engine acceptance scenarios passed.");

--- a/src/components/coach/AskLve360Coach.tsx
+++ b/src/components/coach/AskLve360Coach.tsx
@@ -146,7 +146,7 @@ export default function AskLve360Coach() {
                 <div className="min-w-0">
                   <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-[#087F72]"><MessageCircle className="h-4 w-4" aria-hidden="true" /> Contextual coaching</p>
                   <h2 id="coach-title" className="mt-1 text-2xl font-black text-[#041B2D]">Ask LVE360</h2>
-                  <p className="mt-1 text-sm text-[#486170]">Grounded in the records you have saved in LVE360.</p>
+                  <p className="mt-1 text-sm text-[#486170]">Personalized using your LVE360 health record, evidence library, and safety rules.</p>
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                   {remaining !== null ? <span className="hidden rounded-full bg-[#EAFBF8] px-3 py-1.5 text-xs font-bold text-[#06695F] sm:inline">{remaining} left this month</span> : null}
@@ -185,14 +185,23 @@ export default function AskLve360Coach() {
                         <details className="mt-4 border-t border-slate-100 pt-3">
                           <summary className="cursor-pointer text-xs font-bold uppercase tracking-[0.12em] text-[#087F72]">What I used</summary>
                           <ul className="mt-3 space-y-2">
-                            {turn.source_refs.map((source) => (
-                              <li key={source.id} className="rounded-xl bg-[#F3F8F7] p-3 text-xs leading-5 text-[#486170]">
-                                <Link href={source.href} onClick={() => setOpen(false)} className="inline-flex items-center gap-1 font-bold text-[#06695F] hover:underline">
-                                  {source.label}<ExternalLink className="h-3 w-3" aria-hidden="true" />
-                                </Link>
-                                <p>{source.summary}</p>
-                              </li>
-                            ))}
+                            {turn.source_refs.map((source) => {
+                              const external = /^https?:\/\//i.test(source.href);
+                              return (
+                                <li key={source.id} className="rounded-xl bg-[#F3F8F7] p-3 text-xs leading-5 text-[#486170]">
+                                  <Link
+                                    href={source.href}
+                                    target={external ? "_blank" : undefined}
+                                    rel={external ? "noopener noreferrer" : undefined}
+                                    onClick={() => { if (!external) setOpen(false); }}
+                                    className="inline-flex items-center gap-1 font-bold text-[#06695F] hover:underline"
+                                  >
+                                    {source.label}<ExternalLink className="h-3 w-3" aria-hidden="true" />
+                                  </Link>
+                                  <p>{source.summary}</p>
+                                </li>
+                              );
+                            })}
                           </ul>
                         </details>
                       ) : null}
@@ -231,7 +240,7 @@ export default function AskLve360Coach() {
                   <Send className="h-5 w-5" aria-hidden="true" />
                 </button>
               </form>
-              <p className="mx-auto mt-2 w-full max-w-5xl text-[11px] leading-4 text-[#60798A]">Educational wellness support only. Ask LVE360 cannot diagnose or change medications, hormones, supplements, reminders, or saved records. Review health decisions with a qualified professional.</p>
+              <p className="mx-auto mt-2 w-full max-w-5xl text-[11px] leading-4 text-[#60798A]">Educational wellness coaching. Ask LVE360 can explain and compare options, but it cannot diagnose or silently change saved records. Medication and hormone changes require qualified professional guidance.</p>
             </footer>
           </section>
         </div>

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -321,6 +321,17 @@ function prompt(question: string, context: CoachContext, repair = false) {
 function deterministicRecordMutation(question: string, context: CoachContext) {
   if (context.intent !== "REQUEST_TO_CHANGE_RECORD") return null;
   const option = context.evidenceOptions[0];
+  const routine = Array.isArray(context.facts.routine) ? context.facts.routine as Array<Record<string, unknown>> : [];
+  const existing = option
+    ? routine.find((item) => healthItemIdentityKey(String(item.name ?? "")) === healthItemIdentityKey(option.name))
+    : null;
+  if (option && existing) {
+    return {
+      answer: `${option.name} is already in your current Routine${existing.dose ? ` at ${String(existing.dose)}` : ""}${existing.timing ? `, recorded for ${String(existing.timing)}` : ""}. I have not changed your saved records or added a duplicate. Use the controlled edit action on Routine if you need to review its exact form, dose, timing, or schedule.`,
+      sourceIds: context.sources.filter((source) => source.id === "current_routine" || source.id === option.id).map((source) => source.id),
+      responseSource: "deterministic" as const,
+    };
+  }
   const itemText = option ? ` Before adding ${option.name}, I can compare it with your current routine and run the LVE360 safety rules.` : " I can first explain the likely implications and review the relevant safety context.";
   return {
     answer: `I have not changed your saved records.${itemText} When you are ready, use the controlled add or edit action on Routine so you can review the exact name, dose, timing, and schedule before saving.`,
@@ -442,7 +453,22 @@ async function postValidate(context: CoachContext, answer: StructuredCoachAnswer
   const recommendation = answer.recommendation && options.some((option) => option.name === answer.recommendation?.candidate)
     ? answer.recommendation
     : null;
-  return { answer: { ...answer, options, recommendation }, safety, removed: answer.options.length - options.length };
+  const recommendationSafety = recommendation
+    ? decisions.get(healthItemIdentityKey(recommendation.candidate))
+    : null;
+  const requiresReviewBeforeStart = Boolean(recommendationSafety
+    && !recommendationSafety.isCurrent
+    && recommendationSafety.decision === "review");
+  const reviewedAnswer = requiresReviewBeforeStart && recommendation
+    ? {
+        ...answer,
+        directAnswer: `I would not start a new supplement from this answer alone. ${recommendation.candidate} is an evidence-informed option to discuss with a qualified professional, but LVE360 flagged a safety review before any new start.`,
+        options,
+        recommendation,
+        nextStep: `Review ${recommendation.candidate} and the safety note above with your clinician or pharmacist before starting it. Keep your saved Routine unchanged until that review is complete.`,
+      }
+    : { ...answer, options, recommendation };
+  return { answer: reviewedAnswer, safety, removed: answer.options.length - options.length };
 }
 
 function renderAnswer(answer: StructuredCoachAnswer, context: CoachContext, safety: AppliedSafetyResult | null) {

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -459,7 +459,16 @@ async function postValidate(context: CoachContext, answer: StructuredCoachAnswer
   const requiresReviewBeforeStart = Boolean(recommendationSafety
     && !recommendationSafety.isCurrent
     && recommendationSafety.decision === "review");
-  const reviewedAnswer = requiresReviewBeforeStart && recommendation
+  const isCurrentRecommendation = Boolean(recommendationSafety?.isCurrent);
+  const reviewedAnswer = isCurrentRecommendation && recommendation
+    ? {
+        ...answer,
+        directAnswer: `${recommendation.candidate} is already in your current Routine, so I would not add it again. The useful question is whether its recorded form, dose, and timing fit your sleep goal.`,
+        options,
+        recommendation,
+        nextStep: `Review the saved form, dose, and timing for ${recommendation.candidate}, then track the outcomes below without adding a duplicate.`,
+      }
+    : requiresReviewBeforeStart && recommendation
     ? {
         ...answer,
         directAnswer: `I would not start a new supplement from this answer alone. ${recommendation.candidate} is an evidence-informed option to discuss with a qualified professional, but LVE360 flagged a safety review before any new start.`,

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -2,26 +2,52 @@ import "server-only";
 
 import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
 import { generateAI } from "@/lib/ai/gateway";
+import { evidenceOptionByName, retrieveCoachEvidence, type CoachEvidenceOption } from "@/lib/coachEvidence";
+import {
+  assessCoachAnswerQuality,
+  parseStructuredCoachAnswer,
+  type CoachIntent,
+  type CoachPage,
+  type CoachQualityReport,
+  type CoachSource,
+  type StructuredCoachAnswer,
+} from "@/lib/contextualCoach";
 import { getCurrentBlueprintContext } from "@/lib/currentBlueprintContext";
 import { getCurrentRegimen } from "@/lib/currentRegimen";
-import type { CoachPage, CoachSource } from "@/lib/contextualCoach";
-import { parseCoachAnswer } from "@/lib/contextualCoach";
+import { healthItemIdentityKey } from "@/lib/healthItemIdentity";
+import { applySafetyChecks, type AppliedSafetyResult } from "@/lib/safetyCheck";
+import type { SafetyContext } from "@/lib/safetyEngine";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 export type CoachContext = {
   page: CoachPage;
+  intent: CoachIntent;
   sources: CoachSource[];
   facts: Record<string, unknown>;
+  evidenceOptions: CoachEvidenceOption[];
+  safetyContext: SafetyContext;
+  preSafety: AppliedSafetyResult | null;
 };
 
-const PAGE_SOURCE_IDS: Record<CoachPage, string[]> = {
-  today: ["weekly_practice", "current_blueprint", "recent_check_ins"],
-  routine: ["current_routine"],
-  blueprint: ["current_blueprint", "current_routine"],
-  journey: ["weekly_practice", "recent_check_ins"],
-  review: ["weekly_practice", "recent_check_ins", "current_blueprint"],
-  settings: ["current_blueprint", "current_routine", "weekly_practice", "recent_check_ins"],
-  other: ["current_blueprint", "current_routine", "weekly_practice", "recent_check_ins"],
+export type CoachDiagnostics = {
+  intent: CoachIntent;
+  qualityScore: number;
+  safetyRuleCount: number;
+  recommendationsRemoved: number;
+  regenerationCount: number;
+  evidenceIds: string[];
+};
+
+const INTENT_SOURCE_IDS: Record<CoachIntent, string[]> = {
+  GENERAL_EDUCATION: ["evidence", "current_routine", "health_profile", "recent_coaching"],
+  PERSONALIZED_RECOMMENDATION: ["evidence", "current_routine", "health_profile", "goals", "recent_check_ins", "current_blueprint", "recent_coaching"],
+  CURRENT_PLAN_LOOKUP: ["current_routine"],
+  OPTION_COMPARISON: ["evidence", "current_routine", "health_profile", "goals", "recent_check_ins", "recent_coaching"],
+  PLAN_EXPLANATION: ["current_blueprint", "current_routine", "goals", "recent_coaching"],
+  TIMING_OR_DOSING: ["evidence", "current_routine", "health_profile", "recent_coaching"],
+  PROGRESS_COACHING: ["weekly_practice", "recent_check_ins", "goals", "current_blueprint", "recent_coaching"],
+  REQUEST_TO_CHANGE_RECORD: ["current_routine", "evidence", "health_profile"],
+  POTENTIAL_MEDICAL_RED_FLAG: [],
 };
 
 const FACT_KEY_BY_SOURCE: Record<string, string> = {
@@ -29,35 +55,91 @@ const FACT_KEY_BY_SOURCE: Record<string, string> = {
   current_routine: "routine",
   weekly_practice: "weekly_practice",
   recent_check_ins: "recent_check_ins",
+  goals: "goals",
+  health_profile: "health_profile",
+  recent_coaching: "recent_coaching",
 };
-
-function scopeContext(page: CoachPage, sources: CoachSource[], facts: Record<string, unknown>): CoachContext {
-  const allowed = new Set(PAGE_SOURCE_IDS[page]);
-  const scopedSources = sources.filter((source) => allowed.has(source.id));
-  const scopedFacts = Object.fromEntries(scopedSources.flatMap((source) => {
-    const key = FACT_KEY_BY_SOURCE[source.id];
-    return key && key in facts ? [[key, facts[key]]] : [];
-  }));
-  return { page, sources: scopedSources, facts: scopedFacts };
-}
 
 function compact(value: string | null | undefined, length = 160) {
   return value?.replace(/\s+/g, " ").trim().slice(0, length) || null;
 }
 
-export async function buildCoachContext(userId: string, page: CoachPage): Promise<CoachContext> {
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function readableValues(value: unknown): string[] {
+  if (value == null) return [];
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).split(/[,;|\n]/).map((item) => item.replace(/\s+/g, " ").trim())
+      .filter((item) => item.length > 0 && !/^(?:none|no|n\/?a|not provided|unknown)$/i.test(item));
+  }
+  if (Array.isArray(value)) return [...new Set(value.flatMap(readableValues))];
+  const source = objectValue(value);
+  const named = source.name ?? source.label ?? source.text ?? source.value ?? source.answer
+    ?? source.condition_name ?? source.allergy_name ?? source.med_name;
+  if (named != null) return readableValues(named);
+  return [...new Set(Object.values(source).flatMap(readableValues))];
+}
+
+function calculateAge(dob: unknown) {
+  if (typeof dob !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(dob)) return null;
+  const born = new Date(`${dob}T00:00:00Z`);
+  if (Number.isNaN(born.getTime())) return null;
+  const now = new Date();
+  let age = now.getUTCFullYear() - born.getUTCFullYear();
+  const beforeBirthday = now.getUTCMonth() < born.getUTCMonth()
+    || (now.getUTCMonth() === born.getUTCMonth() && now.getUTCDate() < born.getUTCDate());
+  if (beforeBirthday) age -= 1;
+  return age >= 13 && age <= 120 ? age : null;
+}
+
+function scopeContext(context: CoachContext): CoachContext {
+  const allowed = new Set(INTENT_SOURCE_IDS[context.intent]);
+  const sources = context.sources.filter((source) => source.id.startsWith("evidence_") ? allowed.has("evidence") : allowed.has(source.id));
+  const facts = Object.fromEntries(sources.flatMap((source) => {
+    if (source.id.startsWith("evidence_")) return [];
+    const key = FACT_KEY_BY_SOURCE[source.id];
+    return key && key in context.facts ? [[key, context.facts[key]]] : [];
+  }));
+  if (allowed.has("evidence")) facts.evidence_options = context.facts.evidence_options;
+  return { ...context, sources, facts };
+}
+
+function supplementItems(regimen: Awaited<ReturnType<typeof getCurrentRegimen>>) {
+  return regimen.filter((item) => item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement");
+}
+
+function isCurrentSupplement(name: string, regimen: Awaited<ReturnType<typeof getCurrentRegimen>>) {
+  const identity = healthItemIdentityKey(name);
+  return supplementItems(regimen).some((item) => healthItemIdentityKey(item.name) === identity);
+}
+
+export async function buildCoachContext(userId: string, page: CoachPage, question: string, intent: CoachIntent): Promise<CoachContext> {
   const admin = getSupabaseAdmin();
-  const [blueprint, regimen, experimentResult, checkInsResult] = await Promise.all([
-    getCurrentBlueprintContext(userId),
-    getCurrentRegimen(userId),
-    admin.from("weekly_experiments")
+  const requested = new Set(INTENT_SOURCE_IDS[intent]);
+  const needsEvidence = requested.has("evidence");
+  const emptyResult = { data: null, error: null };
+  const [blueprint, regimen, experimentResult, checkInsResult, goalsResult, submissionResult, recentTurnsResult] = await Promise.all([
+    requested.has("current_blueprint") ? getCurrentBlueprintContext(userId) : Promise.resolve(null),
+    requested.has("current_routine") || needsEvidence ? getCurrentRegimen(userId) : Promise.resolve([]),
+    requested.has("weekly_practice") ? admin.from("weekly_experiments")
       .select("id,identity_direction,action_label,cue,frequency_per_week,minimum_version,week_start,status")
-      .eq("user_id", userId).eq("status", "active").order("updated_at", { ascending: false }).limit(1).maybeSingle(),
-    admin.from("logs").select("log_date,weight,sleep,energy")
-      .eq("user_id", userId).order("log_date", { ascending: false }).limit(7),
+      .eq("user_id", userId).eq("status", "active").order("updated_at", { ascending: false }).limit(1).maybeSingle() : Promise.resolve(emptyResult),
+    requested.has("recent_check_ins") ? admin.from("logs").select("log_date,weight,sleep,energy")
+      .eq("user_id", userId).order("log_date", { ascending: false }).limit(7) : Promise.resolve({ data: [], error: null }),
+    requested.has("goals") ? admin.from("goals").select("goals,custom_goal,target_weight,target_sleep,target_energy")
+      .eq("user_id", userId).maybeSingle() : Promise.resolve(emptyResult),
+    requested.has("health_profile") || needsEvidence ? admin.from("submissions")
+      .select("dob,sex,gender,conditions,allergies,pregnant,dosing_pref,brand_pref,engine_input_json,goals")
+      .eq("user_id", userId).order("created_at", { ascending: false }).limit(1).maybeSingle() : Promise.resolve(emptyResult),
+    requested.has("recent_coaching") ? admin.from("ai_coaching_turns")
+      .select("question,answer,created_at").eq("user_id", userId).neq("generation_status", "pending")
+      .order("created_at", { ascending: false }).limit(3) : Promise.resolve({ data: [], error: null }),
   ]);
-  if (experimentResult.error) throw experimentResult.error;
-  if (checkInsResult.error) throw checkInsResult.error;
+  for (const result of [experimentResult, checkInsResult, goalsResult, submissionResult, recentTurnsResult]) {
+    if (result.error) throw result.error;
+  }
 
   const sources: CoachSource[] = [];
   const facts: Record<string, unknown> = {};
@@ -77,13 +159,8 @@ export async function buildCoachContext(userId: string, page: CoachPage): Promis
     };
   }
   if (regimen.length) {
-    sources.push({
-      id: "current_routine",
-      label: "Current Routine",
-      summary: `${regimen.length} active medication, hormone, and supplement records.`,
-      href: "/routine",
-    });
-    facts.routine = regimen.slice(0, 30).map((item) => ({
+    sources.push({ id: "current_routine", label: "Current Routine", summary: `${regimen.length} active medication, hormone, and supplement records.`, href: "/routine" });
+    facts.routine = regimen.slice(0, 40).map((item) => ({
       kind: item.item_kind,
       name: compact(item.name, 100),
       dose: compact(item.dose, 80),
@@ -92,146 +169,398 @@ export async function buildCoachContext(userId: string, page: CoachPage): Promis
       instruction_authority: item.instruction_authority,
     }));
   }
+
   const experiment = experimentResult.data as Partial<WeeklyExperiment> | null;
   if (experiment?.id) {
-    const { count, error } = await admin.from("daily_practice_completions")
-      .select("id", { count: "exact", head: true })
-      .eq("user_id", userId).eq("experiment_id", experiment.id);
-    if (error) throw error;
-    sources.push({
-      id: "weekly_practice",
-      label: "Weekly Practice",
-      summary: `${count ?? 0} completions recorded toward this week's ${experiment.frequency_per_week ?? 0}-day target.`,
-      href: "/today",
-    });
+    const completionResult = await admin.from("daily_practice_completions")
+      .select("id", { count: "exact", head: true }).eq("user_id", userId).eq("experiment_id", experiment.id);
+    if (completionResult.error) throw completionResult.error;
+    sources.push({ id: "weekly_practice", label: "Weekly Practice", summary: `${completionResult.count ?? 0} completions recorded toward this week's ${experiment.frequency_per_week ?? 0}-day target.`, href: "/today" });
     facts.weekly_practice = {
       identity: identityLabel(experiment.identity_direction ?? null),
       action: compact(experiment.action_label),
       cue: compact(experiment.cue),
       minimum_version: compact(experiment.minimum_version),
       target: experiment.frequency_per_week,
-      completions: count ?? 0,
+      completions: completionResult.count ?? 0,
       week_start: experiment.week_start,
     };
   }
-  if ((checkInsResult.data ?? []).length) {
-    const checkIns = checkInsResult.data ?? [];
-    sources.push({
-      id: "recent_check_ins",
-      label: "Recent check-ins",
-      summary: `${checkIns.length} recent weight, sleep, or energy entries.`,
-      href: "/journey",
-    });
-    facts.recent_check_ins = checkIns.map((item) => ({
-      date: item.log_date,
-      weight: item.weight,
-      sleep_rating_out_of_5: item.sleep,
-      energy_rating_out_of_10: item.energy,
+
+  const checkIns = checkInsResult.data ?? [];
+  if (checkIns.length) {
+    sources.push({ id: "recent_check_ins", label: "Recent check-ins", summary: `${checkIns.length} recent weight, sleep, or energy entries.`, href: "/journey" });
+    facts.recent_check_ins = checkIns.map((item) => ({ date: item.log_date, weight: item.weight, sleep_rating_out_of_5: item.sleep, energy_rating_out_of_10: item.energy }));
+  }
+
+  const goals = goalsResult.data;
+  const goalNames = [...new Set([
+    ...readableValues(goals?.goals),
+    ...readableValues(goals?.custom_goal),
+  ])].slice(0, 8);
+  if (goalNames.length || goals?.target_weight != null || goals?.target_sleep != null || goals?.target_energy != null) {
+    sources.push({ id: "goals", label: "Goals", summary: `${goalNames.length} saved goal${goalNames.length === 1 ? "" : "s"} and dashboard targets.`, href: "/settings" });
+    facts.goals = {
+      names: goalNames,
+      target_weight: goals?.target_weight ?? null,
+      target_sleep_out_of_5: goals?.target_sleep ?? null,
+      target_energy_out_of_10: goals?.target_energy ?? null,
+    };
+  }
+
+  const submission = submissionResult.data;
+  const engine = objectValue(submission?.engine_input_json);
+  const client = objectValue(engine.client ?? engine);
+  const conditions = [...new Set(readableValues(client.conditions ?? submission?.conditions))].slice(0, 12);
+  const allergies = [...new Set(readableValues(client.allergies ?? submission?.allergies))].slice(0, 12);
+  const procedures = [...new Set(readableValues(client.procedures ?? client.upcoming_procedures ?? client.surgeries))].slice(0, 8);
+  const healthProfile = {
+    age: calculateAge(submission?.dob),
+    sex: compact(String(submission?.sex ?? submission?.gender ?? client.sex ?? client.gender ?? ""), 40),
+    conditions,
+    allergies,
+    procedures,
+    pregnant: client.pregnant ?? submission?.pregnant ?? null,
+    dosing_preference: compact(String(submission?.dosing_pref ?? client.dosing_pref ?? ""), 100),
+    brand_preference: compact(String(submission?.brand_pref ?? client.brand_pref ?? ""), 100),
+  };
+  if (Object.values(healthProfile).some((value) => Array.isArray(value) ? value.length > 0 : value != null && value !== "")) {
+    sources.push({ id: "health_profile", label: "Health profile", summary: "Saved age/life-stage, conditions, allergies, procedures, and preferences used only when relevant.", href: "/settings" });
+    facts.health_profile = healthProfile;
+  }
+
+  const recentTurns = recentTurnsResult.data ?? [];
+  if (recentTurns.length) {
+    sources.push({ id: "recent_coaching", label: "Recent coaching", summary: `${recentTurns.length} recent Ask LVE360 turn${recentTurns.length === 1 ? "" : "s"} used to understand follow-up wording.`, href: page === "other" ? "/today" : page === "blueprint" ? "/blueprints" : `/${page}` });
+    facts.recent_coaching = recentTurns.map((turn) => ({
+      question: compact(turn.question, 240),
+      answer: compact(turn.answer, 500),
     }));
   }
-  return scopeContext(page, sources, facts);
+
+  const followUpContext = /\b(?:this|that|it|the first|the second|that option|those)\b/i.test(question)
+    ? recentTurns.map((turn) => `${turn.question} ${turn.answer}`).join(" ").slice(0, 1200)
+    : "";
+  const evidenceOptions = retrieveCoachEvidence(`${question} ${followUpContext}`.trim());
+  const safetyContext: SafetyContext = {
+    medications: regimen.filter((item) => item.item_kind === "medication").map((item) => item.name),
+    conditions,
+    allergies,
+    procedures,
+    pregnant: typeof healthProfile.pregnant === "boolean" || typeof healthProfile.pregnant === "string" ? healthProfile.pregnant : null,
+  };
+  const preSafety = needsEvidence && evidenceOptions.length ? await applySafetyChecks(safetyContext, evidenceOptions.map((option) => ({
+    name: option.name,
+    dose: option.doseGuidance?.startingDose ?? null,
+    is_current: isCurrentSupplement(option.name, regimen),
+  }))) : null;
+  const safetyByName = new Map(preSafety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
+  facts.evidence_options = evidenceOptions.map((option) => {
+    const safety = safetyByName.get(healthItemIdentityKey(option.name));
+    const current = supplementItems(regimen).find((item) => healthItemIdentityKey(item.name) === healthItemIdentityKey(option.name));
+    return {
+      id: option.id,
+      name: option.name,
+      best_fit: option.bestFit,
+      evidence_strength: option.evidenceStrength,
+      evidence_summary: option.evidenceSummary,
+      citation_label: option.citationLabel,
+      already_in_stack: Boolean(current),
+      current_dose: current?.dose ?? null,
+      current_timing: current?.timing ?? null,
+      safety_status: safety?.decision === "blocked" ? "REMOVE" : safety?.decision === "review" ? "ALLOW_WITH_NOTE" : "ALLOW",
+      safety_notes: safety?.findings.map((finding) => finding.message).slice(0, 3) ?? [],
+      dose_guidance: intent === "TIMING_OR_DOSING" ? option.doseGuidance : null,
+    };
+  });
+  for (const option of evidenceOptions) {
+    sources.push({ id: option.id, label: `${option.name} evidence`, summary: `${option.evidenceStrength}: ${option.citationLabel}`, href: option.citationUrl });
+  }
+
+  return scopeContext({ page, intent, sources, facts, evidenceOptions, safetyContext, preSafety });
 }
 
-function prompt(question: string, context: CoachContext) {
+function supplementQuestion(question: string, context: CoachContext) {
+  return context.evidenceOptions.length > 0 || /\b(?:supplement|vitamin|mineral|magnesium|glycine|melatonin|theanine|creatine|coq10|b[- ]?12|omega[- ]?3|ashwagandha)\b/i.test(question);
+}
+
+function prompt(question: string, context: CoachContext, repair = false) {
   return [
     {
       role: "system" as const,
       content: [
-        "You are Ask LVE360, a concise lifestyle coach for longevity, vitality, energy, and happiness.",
-        "Use only the supplied member facts. Never invent a fact, diagnosis, symptom, causal claim, interaction, contraindication, or evidence finding.",
-        "You may help with small lifestyle actions, reflection, organization, adherence, and questions to discuss with a qualified professional.",
-        "Never tell the member to start, stop, add, remove, change, or dose a medication, hormone, or supplement. Never diagnose or claim to treat, cure, prevent, or manage disease.",
-        "Do not add health benefits, mechanisms, or expected outcomes. Explain choices only through the supplied record, feasibility, consistency, or the member's explicit weekly target.",
-        "Do not call something the member's goal unless an explicit goal is present in the supplied facts.",
-        "Stay within the supplied context for the current page. Do not pull in or imply information from another dashboard area.",
-        "A sleep rating is a score out of 5, not hours slept. An energy rating is a score out of 10.",
-        "If the records do not support an answer, say what is missing and point to the relevant record to review.",
-        "Use supportive plain language and no shame. Keep the answer under 180 words.",
-        "Return only valid JSON with fields answer (string) and source_ids (array of source id strings). Include every source used for a personalized claim.",
-      ].join(" "),
+        "You are Ask LVE360, an evidence-aware lifestyle coach for longevity, vitality, energy, and happiness.",
+        "Saved LVE360 records describe this member; they personalize and constrain your answer but are not the whole knowledge base.",
+        "Use the supplied curated evidence_options for supplement facts, comparisons, and evidence strength. Never invent a study, citation, interaction, diagnosis, symptom, or user fact.",
+        "Answer the actual question in the first sentence. Do not lead with a disclaimer or say the Blueprint lacks the answer unless the user explicitly asks what the Blueprint says.",
+        "You may explain, compare, rank, and recommend considering a supplement when the supplied evidence and safety status support it. You may explain dose or timing only when dose_guidance is supplied.",
+        "Never direct a medication or hormone change. Never claim to diagnose, treat, cure, prevent, or manage disease. Never claim that a supplement is absolutely safe.",
+        "Recommendation is not mutation: do not say a record, stack, routine, reminder, medication, hormone, or supplement was changed.",
+        "For personalized recommendations, materially use relevant member facts, recognize already_in_stack items, prefer one change at a time, and end with a measurable next step.",
+        "Do not recommend adding an already_in_stack item again. Discuss its recorded form, dose, or timing instead when available.",
+        "Do not recommend an option whose safety_status is REMOVE. An ALLOW_WITH_NOTE option must retain its supplied safety note.",
+        "Use supportive plain language and no shame. Keep the result concise enough for mobile use.",
+        repair ? "The previous candidate failed the quality gate. Be concrete, name supported options when asked, and include a useful next step." : "",
+        "Return only valid JSON with: intent, direct_answer, options, recommendation, next_step, source_ids.",
+        "options is an array of {name, fit: strong|neutral|weak, reason}; use only exact names from evidence_options. recommendation is null or {candidate, reason, trial_period_days, metrics}. source_ids must use only supplied source IDs.",
+      ].filter(Boolean).join(" "),
     },
-    { role: "user" as const, content: JSON.stringify({ question, current_page: context.page, available_sources: context.sources, member_facts: context.facts }) },
+    {
+      role: "user" as const,
+      content: JSON.stringify({
+        question,
+        classified_intent: context.intent,
+        current_page: context.page,
+        available_sources: context.sources.map(({ id, label, summary }) => ({ id, label, summary })),
+        member_context_and_evidence: context.facts,
+      }),
+    },
   ];
 }
 
+function deterministicRecordMutation(question: string, context: CoachContext) {
+  if (context.intent !== "REQUEST_TO_CHANGE_RECORD") return null;
+  const option = context.evidenceOptions[0];
+  const itemText = option ? ` Before adding ${option.name}, I can compare it with your current routine and run the LVE360 safety rules.` : " I can first explain the likely implications and review the relevant safety context.";
+  return {
+    answer: `I have not changed your saved records.${itemText} When you are ready, use the controlled add or edit action on Routine so you can review the exact name, dose, timing, and schedule before saving.`,
+    sourceIds: context.sources.filter((source) => source.id === "current_routine" || source.id === option?.id).map((source) => source.id),
+    responseSource: "deterministic" as const,
+  };
+}
+
+function deterministicPlanLookup(question: string, context: CoachContext) {
+  if (context.intent !== "CURRENT_PLAN_LOOKUP") return null;
+  const routine = Array.isArray(context.facts.routine) ? context.facts.routine as Array<Record<string, unknown>> : [];
+  const namedEvidence = context.evidenceOptions[0]?.name;
+  if (namedEvidence) {
+    const identity = healthItemIdentityKey(namedEvidence);
+    const match = routine.find((item) => healthItemIdentityKey(String(item.name ?? "")) === identity);
+    return {
+      answer: match
+        ? `Yes. ${String(match.name)} is already in your current Routine${match.dose ? ` at ${String(match.dose)}` : ""}${match.timing ? `, recorded for ${String(match.timing)}` : ""}. I would not add a duplicate. The useful next step is to review whether the recorded form, dose, and timing fit the goal you have in mind.`
+        : `${namedEvidence} is not listed in your current Routine. This is a record lookup only; nothing has been added or changed.`,
+      sourceIds: ["current_routine"],
+      responseSource: "deterministic" as const,
+    };
+  }
+  const nightOnly = /\b(?:night|evening|bed|bedtime)\b/i.test(question);
+  const supplements = routine.filter((item) => ["supplement", "endocrine_active_supplement"].includes(String(item.kind ?? "")))
+    .filter((item) => !nightOnly || /\b(?:night|evening|bed|pm|dinner)\b/i.test(String(item.timing ?? "")));
+  const answer = supplements.length
+    ? `${nightOnly ? "Your current nighttime supplements are" : "Your current supplements are"}:\n${supplements.map((item) => `• ${String(item.name)}${item.dose ? ` — ${String(item.dose)}` : ""}${item.timing ? ` (${String(item.timing)})` : ""}`).join("\n")}`
+    : `I did not find any ${nightOnly ? "supplements with nighttime timing" : "current supplements"} in your saved Routine. No general recommendations were added because you asked for a record lookup.`;
+  return { answer, sourceIds: ["current_routine"], responseSource: "deterministic" as const };
+}
+
 function deterministicTodayStep(question: string, context: CoachContext) {
-  if (context.page !== "today" || !/\b(?:smallest|next|today|right now)\b/i.test(question)) return null;
-  const practice = context.facts.weekly_practice as {
-    action?: unknown;
-    minimum_version?: unknown;
-  } | undefined;
+  if (context.page !== "today" || context.intent !== "PROGRESS_COACHING" || !/\b(?:smallest|next|today|right now)\b/i.test(question)) return null;
+  const practice = context.facts.weekly_practice as { action?: unknown; minimum_version?: unknown } | undefined;
   const action = typeof practice?.action === "string" ? practice.action : null;
   const minimum = typeof practice?.minimum_version === "string" ? practice.minimum_version : null;
   if (!action || !minimum) return null;
   return {
-    answer: `Use the minimum version of your current weekly practice: ${minimum}. That is the smallest version you already chose for your active practice: ${action} Completing it keeps today's decision tied to your active plan without adding another task.`,
-    sourceIds: ["weekly_practice"],
-    responseSource: "deterministic" as const,
-  };
-}
-
-function deterministicRoutineOverview(question: string, context: CoachContext) {
-  if (context.page !== "routine" || !/\b(?:recorded routine|routine fits|routine fit|routine work together)\b/i.test(question)) return null;
-  const items = Array.isArray(context.facts.routine) ? context.facts.routine as Array<Record<string, unknown>> : [];
-  if (!items.length) return null;
-  const counts = items.reduce<{ medications: number; hormones: number; supplements: number; withTiming: number }>((result, item) => {
-    const kind = String(item.kind ?? "");
-    if (kind === "medication") result.medications += 1;
-    else if (kind === "hormone") result.hormones += 1;
-    else result.supplements += 1;
-    if (typeof item.timing === "string" && item.timing.trim()) result.withTiming += 1;
-    return result;
-  }, { medications: 0, hormones: 0, supplements: 0, withTiming: 0 });
-  return {
-    answer: `Your current Routine records ${counts.medications} medication${counts.medications === 1 ? "" : "s"}, ${counts.hormones} hormone${counts.hormones === 1 ? "" : "s"}, and ${counts.supplements} supplement${counts.supplements === 1 ? "" : "s"}. ${counts.withTiming} of those records include timing details. LVE360 is organizing the schedule you entered, not deciding whether the items are safe together. The most useful review is to confirm each name, dose, and timing against your current clinician or pharmacist instructions.`,
-    sourceIds: ["current_routine"],
-    responseSource: "deterministic" as const,
+    answer: `Use the minimum version of your current weekly practice: ${minimum}. That is the smallest version you already chose for ${action}. Completing it keeps today's decision tied to your active plan without adding another task.`,
+    sourceIds: ["weekly_practice"], responseSource: "deterministic" as const,
   };
 }
 
 function deterministicJourneyPattern(question: string, context: CoachContext) {
-  if (context.page !== "journey" || !/\b(?:pattern|recent progress|small win|build on)\b/i.test(question)) return null;
-  const checkIns = Array.isArray(context.facts.recent_check_ins)
-    ? context.facts.recent_check_ins as Array<Record<string, unknown>>
-    : [];
-  const sleepRatings = checkIns.map((item) => Number(item.sleep_rating_out_of_5)).filter((value) => Number.isFinite(value) && value >= 0 && value <= 5);
-  const energyRatings = checkIns.map((item) => Number(item.energy_rating_out_of_10)).filter((value) => Number.isFinite(value) && value >= 0 && value <= 10);
-  if (!sleepRatings.length && !energyRatings.length) return null;
+  if (context.intent !== "PROGRESS_COACHING" || !/\b(?:pattern|recent progress|small win|build on)\b/i.test(question)) return null;
+  const checkIns = Array.isArray(context.facts.recent_check_ins) ? context.facts.recent_check_ins as Array<Record<string, unknown>> : [];
+  const sleep = checkIns.map((item) => Number(item.sleep_rating_out_of_5)).filter((value) => Number.isFinite(value) && value >= 0 && value <= 5);
+  const energy = checkIns.map((item) => Number(item.energy_rating_out_of_10)).filter((value) => Number.isFinite(value) && value >= 0 && value <= 10);
+  if (!sleep.length && !energy.length) return null;
   const average = (values: number[]) => (values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(1).replace(/\.0$/, "");
-  const observations = [
-    sleepRatings.length ? `an average sleep rating of ${average(sleepRatings)}/5 across ${sleepRatings.length} check-in${sleepRatings.length === 1 ? "" : "s"}` : null,
-    energyRatings.length ? `an average energy rating of ${average(energyRatings)}/10 across ${energyRatings.length} check-in${energyRatings.length === 1 ? "" : "s"}` : null,
-  ].filter(Boolean);
-  const practice = context.facts.weekly_practice as { completions?: unknown; target?: unknown } | undefined;
-  const completions = Number(practice?.completions);
-  const target = Number(practice?.target);
-  const practiceObservation = Number.isFinite(completions) && Number.isFinite(target)
-    ? ` Your active weekly practice shows ${completions} of ${target} planned repetitions completed.`
-    : "";
+  const observations = [sleep.length ? `average sleep ${average(sleep)}/5` : null, energy.length ? `average energy ${average(energy)}/10` : null].filter(Boolean);
   return {
-    answer: `Your recent records show ${observations.join(" and ")}.${practiceObservation} These are recorded observations, not evidence that the practice caused either rating. Keep logging on both practice and non-practice days so future reviews can compare like with like.`,
-    sourceIds: [
-      ...(checkIns.length ? ["recent_check_ins"] : []),
-      ...(practiceObservation ? ["weekly_practice"] : []),
-    ],
+    answer: `Your recent check-ins show ${observations.join(" and ")}. These are observations, not proof that one habit caused the result. Keep the same small weekly practice and log on both completed and missed days so the next review can compare like with like.`,
+    sourceIds: ["recent_check_ins", ...(context.facts.weekly_practice ? ["weekly_practice"] : [])],
     responseSource: "deterministic" as const,
   };
 }
 
-export async function generateCoachAnswer(userId: string, question: string, context: CoachContext) {
-  const deterministic = deterministicTodayStep(question, context)
-    ?? deterministicRoutineOverview(question, context)
-    ?? deterministicJourneyPattern(question, context);
-  if (deterministic) return deterministic;
-  const response = await generateAI({
-    task: "contextual_coach",
-    userId,
-    messages: prompt(question, context),
-    maxTokens: 350,
-    timeoutMs: 20_000,
-    temperature: 0.2,
+function fallbackStructured(question: string, context: CoachContext): StructuredCoachAnswer {
+  if (!context.evidenceOptions.length) {
+    const blueprint = context.facts.blueprint as { priorities?: Array<{ label?: unknown }> } | undefined;
+    const priorities = (blueprint?.priorities ?? []).map((item) => String(item.label ?? "")).filter(Boolean).slice(0, 3);
+    const practice = context.facts.weekly_practice as { action?: unknown; completions?: unknown; target?: unknown } | undefined;
+    const directAnswer = context.intent === "PLAN_EXPLANATION" && priorities.length
+      ? `Your current Blueprint is organized around ${priorities.join(", ")}. Those are longer-term priorities; the weekly practice is where one of them becomes a small repeatable action.`
+      : context.intent === "PROGRESS_COACHING" && practice?.action
+        ? `Your active practice is ${String(practice.action)}, with ${Number(practice.completions ?? 0)} of ${Number(practice.target ?? 0)} planned repetitions recorded. That is the clearest current progress signal in LVE360.`
+        : "I could not create the full personalized interpretation, but your saved LVE360 records are still available and unchanged.";
+    return {
+      intent: context.intent,
+      directAnswer,
+      options: [],
+      recommendation: null,
+      nextStep: context.intent === "PLAN_EXPLANATION" && priorities[0]
+        ? `Choose one small weekly action connected to ${priorities[0]}.`
+        : "Review the linked record, then ask one narrower follow-up question.",
+      sourceIds: context.sources.map((source) => source.id),
+    };
+  }
+  const safetyByName = new Map(context.preSafety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
+  const available = context.evidenceOptions.filter((option) => safetyByName.get(healthItemIdentityKey(option.name))?.decision !== "blocked").slice(0, 3);
+  const topic = /\bsleep\b/i.test(question) ? "sleep" : /\benergy|fatigue|tired\b/i.test(question) ? "energy" : "your goal";
+  const directAnswer = available.length
+    ? `Several evidence-informed options may fit ${topic}, but they are useful for different reasons. The best choice depends on your current routine, the outcome you want, and the LVE360 safety checks.`
+    : `The available LVE360 evidence options for ${topic} all require a higher level of review based on the information currently saved, so I would not select one as a new experiment yet.`;
+  const current = available.find((option) => safetyByName.get(healthItemIdentityKey(option.name))?.isCurrent);
+  const selected = current ?? available[0] ?? null;
+  return {
+    intent: context.intent,
+    directAnswer,
+    options: available.map((option, index) => ({ name: option.name, fit: index === 0 ? "strong" : "neutral", reason: option.bestFit })),
+    recommendation: selected ? {
+      candidate: selected.name,
+      reason: current ? `It is already in your Routine, so optimizing the recorded dose and timing is more useful than adding a duplicate.` : selected.bestFit,
+      trialPeriodDays: current ? null : 14,
+      metrics: /\bsleep\b/i.test(question) ? ["sleep quality", "time to fall asleep", "morning energy"] : ["energy", "consistency"],
+    } : null,
+    nextStep: selected
+      ? current ? `Review the saved dose and timing for ${selected.name}; do not add a second product.` : `Change only one thing, then track the selected outcomes for 7–14 days before deciding whether it helped.`
+      : "Review the highlighted safety notes before considering a new supplement.",
+    sourceIds: [...context.sources.map((source) => source.id)],
+  };
+}
+
+async function postValidate(context: CoachContext, answer: StructuredCoachAnswer) {
+  if (!answer.options.length) return { answer, safety: context.preSafety, removed: 0 };
+  const routine = Array.isArray(context.facts.routine) ? context.facts.routine as Array<Record<string, unknown>> : [];
+  const candidates = answer.options.map((option) => {
+    const evidence = evidenceOptionByName(context.evidenceOptions, option.name);
+    const identity = healthItemIdentityKey(option.name);
+    const current = routine.find((item) => healthItemIdentityKey(String(item.name ?? "")) === identity
+      && ["supplement", "endocrine_active_supplement"].includes(String(item.kind ?? "")));
+    return { name: option.name, dose: current?.dose ? String(current.dose) : evidence?.doseGuidance?.startingDose ?? null, is_current: Boolean(current) };
   });
-  const parsed = parseCoachAnswer(response.text, new Set(context.sources.map((source) => source.id)));
-  if (parsed && /\byour goal\b/i.test(parsed.answer) && !("goals" in context.facts)) return null;
-  return parsed ? { ...parsed, responseSource: "ai" as const } : null;
+  const safety = await applySafetyChecks(context.safetyContext, candidates);
+  const decisions = new Map(safety.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]));
+  const options = answer.options.filter((option) => decisions.get(healthItemIdentityKey(option.name))?.decision !== "blocked");
+  const recommendation = answer.recommendation && options.some((option) => option.name === answer.recommendation?.candidate)
+    ? answer.recommendation
+    : null;
+  return { answer: { ...answer, options, recommendation }, safety, removed: answer.options.length - options.length };
+}
+
+function renderAnswer(answer: StructuredCoachAnswer, context: CoachContext, safety: AppliedSafetyResult | null) {
+  const evidenceByName = new Map(context.evidenceOptions.map((option) => [healthItemIdentityKey(option.name), option]));
+  const safetyByName = new Map(safety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
+  const lines = [answer.directAnswer];
+  if (answer.options.length) {
+    lines.push("", "Options worth comparing:");
+    answer.options.forEach((option, index) => {
+      const evidence = evidenceByName.get(healthItemIdentityKey(option.name));
+      const safetyResult = safetyByName.get(healthItemIdentityKey(option.name));
+      const current = safetyResult?.isCurrent ? " Already in your Routine." : "";
+      lines.push(`${index + 1}. ${option.name} — ${evidence?.evidenceStrength ?? "Evidence not graded"}. ${option.reason}${current}`);
+      const note = safetyResult?.findings[0]?.message;
+      if (note) lines.push(`   Safety note: ${note.slice(0, 280)}`);
+    });
+  }
+  if (answer.recommendation) {
+    const safetyResult = safetyByName.get(healthItemIdentityKey(answer.recommendation.candidate));
+    lines.push("", `Why this fits you: ${answer.recommendation.reason}`);
+    if (safetyResult?.isCurrent) {
+      lines.push(`You already take ${answer.recommendation.candidate}, so do not add a duplicate. Review the recorded form, dose, and timing instead.`);
+    } else if (safetyResult?.decision === "clear") {
+      lines.push("No major conflict was identified by the structured LVE360 rules using the information currently saved. This is not an absolute guarantee of safety.");
+    }
+    if (answer.recommendation.trialPeriodDays || answer.recommendation.metrics.length) {
+      lines.push(`Experiment: ${answer.recommendation.trialPeriodDays ? `${answer.recommendation.trialPeriodDays} days` : "one change at a time"}${answer.recommendation.metrics.length ? `; track ${answer.recommendation.metrics.join(", ")}` : ""}.`);
+    }
+  }
+  lines.push("", `Next step: ${answer.nextStep}`);
+  return lines.join("\n");
+}
+
+export async function generateCoachAnswer(userId: string, question: string, context: CoachContext) {
+  const deterministic = deterministicRecordMutation(question, context)
+    ?? deterministicPlanLookup(question, context)
+    ?? deterministicTodayStep(question, context)
+    ?? deterministicJourneyPattern(question, context);
+  if (deterministic) {
+    return {
+      ...deterministic,
+      diagnostics: {
+        intent: context.intent,
+        qualityScore: 100,
+        safetyRuleCount: context.preSafety?.findings.length ?? 0,
+        recommendationsRemoved: 0,
+        regenerationCount: 0,
+        evidenceIds: context.evidenceOptions.map((option) => option.id),
+      } satisfies CoachDiagnostics,
+    };
+  }
+
+  const validSourceIds = new Set(context.sources.map((source) => source.id));
+  const allowedNames = new Set(context.evidenceOptions.map((option) => option.name.toLowerCase()));
+  const isSupplementQuestion = supplementQuestion(question, context);
+  let regenerationCount = 0;
+  let proposal: StructuredCoachAnswer | null = null;
+  let generatedByModel = false;
+  for (let attempt = 0; attempt < 2 && !proposal; attempt += 1) {
+    try {
+      const response = await generateAI({
+        task: "contextual_coach",
+        userId,
+        messages: prompt(question, context, attempt > 0),
+        maxTokens: 650,
+        timeoutMs: 20_000,
+        temperature: 0.2,
+      });
+      proposal = parseStructuredCoachAnswer(response.text, context.intent, validSourceIds, allowedNames);
+      if (proposal) generatedByModel = true;
+      if (!proposal && attempt === 0) regenerationCount = 1;
+    } catch (error) {
+      console.warn("[coach.v2] model unavailable; using deterministic evidence repair", error);
+      break;
+    }
+  }
+  proposal ??= fallbackStructured(question, context);
+  let validated = await postValidate(context, proposal);
+  let rendered = renderAnswer(validated.answer, context, validated.safety);
+  let quality: CoachQualityReport = assessCoachAnswerQuality({
+    answer: validated.answer,
+    supplementQuestion: isSupplementQuestion,
+    safetyChecked: !isSupplementQuestion || Boolean(validated.safety?.complete),
+    usedMemberContext: context.intent !== "GENERAL_EDUCATION",
+    allCandidatesBlocked: Boolean(context.preSafety?.candidates.length && context.preSafety.candidates.every((candidate) => candidate.decision === "blocked")),
+  });
+  if (!quality.passed) {
+    regenerationCount = Math.max(regenerationCount, 1);
+    validated = await postValidate(context, fallbackStructured(question, context));
+    rendered = renderAnswer(validated.answer, context, validated.safety);
+    quality = assessCoachAnswerQuality({
+      answer: validated.answer,
+      supplementQuestion: isSupplementQuestion,
+      safetyChecked: !isSupplementQuestion || Boolean(validated.safety?.complete),
+      usedMemberContext: context.intent !== "GENERAL_EDUCATION",
+      allCandidatesBlocked: Boolean(context.preSafety?.candidates.length && context.preSafety.candidates.every((candidate) => candidate.decision === "blocked")),
+    });
+  }
+  const evidenceIds = validated.answer.options
+    .map((option) => evidenceOptionByName(context.evidenceOptions, option.name)?.id)
+    .filter((id): id is string => Boolean(id));
+  const sourceIds = [...new Set([
+    ...validated.answer.sourceIds,
+    ...evidenceIds,
+    ...(validated.safety?.findings.length && validSourceIds.has("current_routine") ? ["current_routine"] : []),
+    ...(validated.safety?.findings.length && validSourceIds.has("health_profile") ? ["health_profile"] : []),
+  ])].filter((id) => validSourceIds.has(id));
+  return {
+    answer: rendered,
+    sourceIds,
+    responseSource: generatedByModel ? "ai" as const : "fallback" as const,
+    diagnostics: {
+      intent: context.intent,
+      qualityScore: quality.score,
+      safetyRuleCount: validated.safety?.findings.length ?? 0,
+      recommendationsRemoved: validated.removed,
+      regenerationCount,
+      evidenceIds,
+    } satisfies CoachDiagnostics,
+  };
 }

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -110,6 +110,16 @@ function supplementItems(regimen: Awaited<ReturnType<typeof getCurrentRegimen>>)
   return regimen.filter((item) => item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement");
 }
 
+function explicitlyNamedEvidenceOption(question: string, options: CoachEvidenceOption[]) {
+  const normalizedQuestion = question.toLowerCase();
+  return options.find((option) => {
+    const normalizedName = option.name.toLowerCase();
+    const firstWord = normalizedName.split(/\s+/)[0];
+    return normalizedQuestion.includes(normalizedName)
+      || (firstWord.length >= 4 && normalizedQuestion.includes(firstWord));
+  }) ?? null;
+}
+
 function isCurrentSupplement(name: string, regimen: Awaited<ReturnType<typeof getCurrentRegimen>>) {
   const identity = healthItemIdentityKey(name);
   return supplementItems(regimen).some((item) => healthItemIdentityKey(item.name) === identity);
@@ -437,7 +447,7 @@ function fallbackStructured(question: string, context: CoachContext): Structured
   };
 }
 
-async function postValidate(context: CoachContext, answer: StructuredCoachAnswer) {
+async function postValidate(question: string, context: CoachContext, answer: StructuredCoachAnswer) {
   if (!answer.options.length) return { answer, safety: context.preSafety, removed: 0 };
   const routine = Array.isArray(context.facts.routine) ? context.facts.routine as Array<Record<string, unknown>> : [];
   const candidates = answer.options.map((option) => {
@@ -450,9 +460,21 @@ async function postValidate(context: CoachContext, answer: StructuredCoachAnswer
   const safety = await applySafetyChecks(context.safetyContext, candidates);
   const decisions = new Map(safety.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]));
   const options = answer.options.filter((option) => decisions.get(healthItemIdentityKey(option.name))?.decision !== "blocked");
-  const recommendation = answer.recommendation && options.some((option) => option.name === answer.recommendation?.candidate)
+  let recommendation = answer.recommendation && options.some((option) => option.name === answer.recommendation?.candidate)
     ? answer.recommendation
     : null;
+  const explicitlyNamed = explicitlyNamedEvidenceOption(question, context.evidenceOptions);
+  const namedAnswerOption = explicitlyNamed
+    ? options.find((option) => healthItemIdentityKey(option.name) === healthItemIdentityKey(explicitlyNamed.name))
+    : null;
+  if (namedAnswerOption && recommendation?.candidate !== namedAnswerOption.name) {
+    recommendation = {
+      candidate: namedAnswerOption.name,
+      reason: namedAnswerOption.reason,
+      trialPeriodDays: recommendation?.trialPeriodDays ?? null,
+      metrics: recommendation?.metrics ?? [],
+    };
+  }
   const recommendationSafety = recommendation
     ? decisions.get(healthItemIdentityKey(recommendation.candidate))
     : null;
@@ -555,7 +577,7 @@ export async function generateCoachAnswer(userId: string, question: string, cont
     }
   }
   proposal ??= fallbackStructured(question, context);
-  let validated = await postValidate(context, proposal);
+  let validated = await postValidate(question, context, proposal);
   let rendered = renderAnswer(validated.answer, context, validated.safety);
   let quality: CoachQualityReport = assessCoachAnswerQuality({
     answer: validated.answer,
@@ -566,7 +588,7 @@ export async function generateCoachAnswer(userId: string, question: string, cont
   });
   if (!quality.passed) {
     regenerationCount = Math.max(regenerationCount, 1);
-    validated = await postValidate(context, fallbackStructured(question, context));
+    validated = await postValidate(question, context, fallbackStructured(question, context));
     rendered = renderAnswer(validated.answer, context, validated.safety);
     quality = assessCoachAnswerQuality({
       answer: validated.answer,

--- a/src/lib/coachEvidence.ts
+++ b/src/lib/coachEvidence.ts
@@ -1,0 +1,149 @@
+import { getEvidenceEntriesFor } from "@/lib/evidence";
+import { getSupplementDoseGuidance } from "@/lib/supplementDosingRegistry";
+
+export type CoachEvidenceStrength = "Strong" | "Moderate" | "Emerging" | "Limited" | "Mixed" | "Insufficient";
+
+export type CoachEvidenceOption = {
+  id: string;
+  name: string;
+  bestFit: string;
+  evidenceStrength: CoachEvidenceStrength;
+  evidenceSummary: string;
+  citationLabel: string;
+  citationUrl: string;
+  doseGuidance: ReturnType<typeof getSupplementDoseGuidance>;
+};
+
+type EvidenceSeed = Omit<CoachEvidenceOption, "id" | "citationLabel" | "citationUrl" | "doseGuidance"> & {
+  aliases: RegExp;
+  topics: string[];
+};
+
+// This is a retrieval index over LVE360's curated evidence, not a fixed recommendation list.
+// Personal fit and final inclusion are decided later by the member context and safety engine.
+const EVIDENCE_SEEDS: EvidenceSeed[] = [
+  {
+    name: "Magnesium Glycinate",
+    aliases: /\bmagnesium(?:\s+(?:bis)?glycinate)?\b/i,
+    topics: ["sleep", "stress", "recovery"],
+    bestFit: "General sleep support when magnesium intake may be low; evidence for insomnia itself is mixed.",
+    evidenceStrength: "Mixed",
+    evidenceSummary: "The LVE360 evidence record supports cautious use and highlights dose, bowel, drowsiness, kidney, and medication-spacing considerations.",
+  },
+  {
+    name: "Glycine",
+    aliases: /\bglycine\b/i,
+    topics: ["sleep", "recovery"],
+    bestFit: "Sleep quality and next-day tiredness when a simple bedtime experiment is appropriate.",
+    evidenceStrength: "Emerging",
+    evidenceSummary: "Small sleep studies are promising, but the evidence base is not yet large or definitive.",
+  },
+  {
+    name: "Melatonin",
+    aliases: /\bmelatonin\b/i,
+    topics: ["sleep"],
+    bestFit: "Circadian timing problems, jet lag, or a shifted sleep schedule rather than general sedation.",
+    evidenceStrength: "Moderate",
+    evidenceSummary: "Evidence is strongest for sleep timing and sleep-onset contexts; morning grogginess and medication context still matter.",
+  },
+  {
+    name: "L-Theanine",
+    aliases: /\bl[- ]?theanine\b/i,
+    topics: ["sleep", "stress", "focus"],
+    bestFit: "Stress-related difficulty winding down, with less direct evidence than timing-focused melatonin.",
+    evidenceStrength: "Emerging",
+    evidenceSummary: "Early controlled evidence suggests possible sleep and stress benefits, but it remains less established than first-line sleep habits.",
+  },
+  {
+    name: "Creatine Monohydrate",
+    aliases: /\bcreatine(?:\s+monohydrate)?\b/i,
+    topics: ["energy", "exercise", "recovery", "focus", "cognition"],
+    bestFit: "Strength, training capacity, and recovery; possible cognitive value in selected contexts rather than a stimulant-like energy boost.",
+    evidenceStrength: "Strong",
+    evidenceSummary: "The LVE360 evidence library includes controlled and review-level evidence, with kidney context and total dose as important guardrails.",
+  },
+  {
+    name: "CoQ10",
+    aliases: /\b(?:coq10|coenzyme q10|ubiquinol|ubiquinone)\b/i,
+    topics: ["energy", "heart", "recovery"],
+    bestFit: "Context-specific fatigue or statin-related discussions rather than a universal energy supplement.",
+    evidenceStrength: "Mixed",
+    evidenceSummary: "Benefits vary substantially by population and reason for use, so it should not be presented as a general energy fix.",
+  },
+  {
+    name: "Vitamin B12",
+    aliases: /\b(?:vitamin\s+)?b[- ]?12\b/i,
+    topics: [],
+    bestFit: "Correcting low B12 intake or deficiency, not boosting energy when B12 status is already adequate.",
+    evidenceStrength: "Strong",
+    evidenceSummary: "The evidence is strong for correcting deficiency but insufficient for a general energy benefit without deficiency risk or testing.",
+  },
+  {
+    name: "Omega-3",
+    aliases: /\b(?:omega[- ]?3|fish oil|epa|dha)\b/i,
+    topics: ["heart", "cognition", "recovery"],
+    bestFit: "Dietary omega-3 gaps and selected cardiovascular goals, with benefits depending on dose and context.",
+    evidenceStrength: "Moderate",
+    evidenceSummary: "Evidence varies by outcome; anticoagulant use and procedures require extra review.",
+  },
+  {
+    name: "Ashwagandha",
+    aliases: /\bashwagandha\b/i,
+    topics: ["stress", "sleep"],
+    bestFit: "Stress-related sleep difficulty when thyroid, liver, pregnancy, and medication cautions do not dominate.",
+    evidenceStrength: "Moderate",
+    evidenceSummary: "Some trials report stress or sleep benefits, while product variability and safety context limit broad recommendations.",
+  },
+];
+
+function slug(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+}
+
+export function coachQuestionTopics(question: string): string[] {
+  const value = question.toLowerCase();
+  return [
+    /\b(?:sleep|insomnia|bedtime|fall asleep|stay asleep|wake up)\b/.test(value) ? "sleep" : null,
+    /\b(?:energy|fatigue|tired|vitality)\b/.test(value) ? "energy" : null,
+    /\b(?:exercise|workout|training|strength|muscle)\b/.test(value) ? "exercise" : null,
+    /\b(?:recovery|sore|rebuild)\b/.test(value) ? "recovery" : null,
+    /\b(?:focus|attention|concentration)\b/.test(value) ? "focus" : null,
+    /\b(?:cognition|cognitive|memory|brain)\b/.test(value) ? "cognition" : null,
+    /\b(?:stress|anxiety|calm|wind down)\b/.test(value) ? "stress" : null,
+    /\b(?:heart|cardiovascular|cholesterol|triglyceride)\b/.test(value) ? "heart" : null,
+  ].filter((topic): topic is string => Boolean(topic));
+}
+
+export function retrieveCoachEvidence(question: string, limit = 4): CoachEvidenceOption[] {
+  const topics = coachQuestionTopics(question);
+  const explicit = EVIDENCE_SEEDS.filter((seed) => seed.aliases.test(question));
+  const topical = topics.length
+    ? EVIDENCE_SEEDS.filter((seed) => seed.topics.some((topic) => topics.includes(topic)))
+    : [];
+  const seeds = [...explicit, ...topical].filter((seed, index, values) =>
+    values.findIndex((candidate) => candidate.name === seed.name) === index
+  ).slice(0, limit);
+
+  return seeds.flatMap((seed) => {
+    const evidence = getEvidenceEntriesFor(seed.name, 1)[0];
+    if (!evidence) return [];
+    return [{
+      id: `evidence_${slug(seed.name)}`,
+      name: seed.name,
+      bestFit: seed.bestFit,
+      evidenceStrength: seed.evidenceStrength,
+      evidenceSummary: seed.evidenceSummary,
+      citationLabel: [evidence.journal, evidence.year].filter(Boolean).join(" · ") || "LVE360 curated evidence",
+      citationUrl: evidence.url,
+      doseGuidance: getSupplementDoseGuidance(seed.name),
+    }];
+  });
+}
+
+export function evidenceOptionByName(options: CoachEvidenceOption[], name: string) {
+  const normalized = name.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+  return options.find((option) => {
+    const candidate = option.name.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+    return normalized === candidate || normalized.includes(candidate) || candidate.includes(normalized);
+  }) ?? null;
+}

--- a/src/lib/contextualCoach.ts
+++ b/src/lib/contextualCoach.ts
@@ -1,4 +1,45 @@
-export const COACH_PROMPT_VERSION = "contextual-coach-v1";
+export const COACH_PROMPT_VERSION = "contextual-coach-v2";
+
+export type CoachIntent =
+  | "GENERAL_EDUCATION"
+  | "PERSONALIZED_RECOMMENDATION"
+  | "CURRENT_PLAN_LOOKUP"
+  | "OPTION_COMPARISON"
+  | "PLAN_EXPLANATION"
+  | "TIMING_OR_DOSING"
+  | "PROGRESS_COACHING"
+  | "REQUEST_TO_CHANGE_RECORD"
+  | "POTENTIAL_MEDICAL_RED_FLAG";
+
+export type ProposedCoachOption = {
+  name: string;
+  fit: "strong" | "neutral" | "weak";
+  reason: string;
+};
+
+export type StructuredCoachAnswer = {
+  intent: CoachIntent;
+  directAnswer: string;
+  options: ProposedCoachOption[];
+  recommendation: { candidate: string; reason: string; trialPeriodDays: number | null; metrics: string[] } | null;
+  nextStep: string;
+  sourceIds: string[];
+};
+
+export type CoachQualityReport = {
+  directly_answered_question: boolean;
+  used_relevant_user_context: boolean;
+  provided_concrete_information: boolean;
+  provided_reasoning_or_why: boolean;
+  evidence_quality_appropriate: boolean;
+  safety_checked: boolean;
+  actionable_next_step: boolean;
+  excessive_referral_language: boolean;
+  unsupported_claims: boolean;
+  record_only_failure: boolean;
+  passed: boolean;
+  score: number;
+};
 
 export type CoachPage = "today" | "routine" | "blueprint" | "journey" | "review" | "settings" | "other";
 export type CoachFeedback = "useful" | "not_useful";
@@ -46,19 +87,51 @@ export function isCoachFeedback(value: unknown): value is CoachFeedback {
   return value === "useful" || value === "not_useful";
 }
 
+export function classifyCoachIntent(question: string): CoachIntent {
+  const value = question.toLowerCase();
+  if (/\b(suicid|kill myself|overdose|chest pain|can(?:not|'t) breathe|stroke|severe allergic|anaphyl|fainted|unconscious|medical emergency|vomiting blood|face (?:is )?swelling|tongue (?:is )?swelling|black stools?|severe confusion)\b/.test(value)) {
+    return "POTENTIAL_MEDICAL_RED_FLAG";
+  }
+  if (/\b(?:add|save|record|remove|delete)\b[\s\S]{0,80}\b(?:my|the)\s+(?:stack|routine|record|reminder|medication|hormone|supplement)\b/.test(value)
+    || /\b(?:add|remove|delete)\b[\s\S]{0,60}\b(?:to|from)\s+(?:my\s+)?(?:stack|routine|records?)\b/.test(value)) {
+    return "REQUEST_TO_CHANGE_RECORD";
+  }
+  if (/\b(?:what|which|list|show|am i|do i)\b[\s\S]{0,70}\b(?:taking|take|currently|current|recorded|in my stack|in my routine)\b/.test(value)
+    || /\bis\s+[a-z0-9 -]+\s+(?:already\s+)?in my (?:stack|routine|records?)\b/.test(value)) {
+    return "CURRENT_PLAN_LOOKUP";
+  }
+  if (/\b(?:compare|versus|vs\.?|difference between|better for me|or)\b/.test(value)
+    && /\b(?:supplement|vitamin|mineral|magnesium|glycine|melatonin|theanine|creatine|coq10|b[- ]?12|omega[- ]?3|ashwagandha)\b/.test(value)) {
+    return "OPTION_COMPARISON";
+  }
+  if (/\b(?:when should|what time|morning or evening|with food|without food|dose|dosage|how much|timing|space|spacing)\b/.test(value)) {
+    return "TIMING_OR_DOSING";
+  }
+  if (/\b(?:why|explain|what does|how does)\b[\s\S]{0,80}\b(?:blueprint|plan|priority|recommendation|routine)\b/.test(value)) {
+    return "PLAN_EXPLANATION";
+  }
+  if (/\b(?:this week|progress|trend|recent|check[- ]?ins?|small win|next habit|weekly practice|focus on)\b/.test(value)) {
+    return "PROGRESS_COACHING";
+  }
+  if (/\b(?:for me|my\s+(?:sleep|energy|goals?|stack|medications?|routine)|should i|what should i try|best for my|makes? sense for me|fit my)\b/.test(value)) {
+    return "PERSONALIZED_RECOMMENDATION";
+  }
+  return "GENERAL_EDUCATION";
+}
+
 export type CoachSafetyBoundary = "emergency" | "diagnosis" | "regimen_change" | null;
 
 export function coachSafetyBoundary(question: string): CoachSafetyBoundary {
   const value = question.toLowerCase();
-  if (/\b(suicid|kill myself|overdose|chest pain|can't breathe|cannot breathe|stroke|medical emergency)\b/.test(value)) {
+  if (/\b(suicid|kill myself|overdose|chest pain|can't breathe|cannot breathe|stroke|medical emergency|severe allergic|anaphyl|fainted|unconscious|vomiting blood|face (?:is )?swelling|tongue (?:is )?swelling|black stools?|severe confusion)\b/.test(value)) {
     return "emergency";
   }
   if (/\b(diagnose|diagnosis|what disease|what condition|is this cancer|do i have (?:a disease|a condition|cancer|diabetes|depression|anxiety|hypertension))\b/.test(value)) {
     return "diagnosis";
   }
-  const change = /\b(start|begin|stop|quit|add|remove|increase|decrease|double|halve|change|adjust|skip|replace|switch|take|use)\b/;
-  const healthItem = /\b(medication|medicine|prescription|dose|dosage|hormone|supplement|vitamin|b\s?12|magnesium|creatine|melatonin|omega-?3|zepbound|insulin|thyroid)\b/;
-  return change.test(value) && healthItem.test(value) ? "regimen_change" : null;
+  const change = /\b(start|begin|stop|quit|add|remove|increase|decrease|double|halve|change|adjust|skip|replace|switch)\b/;
+  const medicationOrHormone = /\b(medication|medicine|prescription|prescribed|hormone|zepbound|insulin|thyroid|testosterone|estrogen|progesterone)\b/;
+  return change.test(value) && medicationOrHormone.test(value) ? "regimen_change" : null;
 }
 
 export function coachBoundaryAnswer(boundary: Exclude<CoachSafetyBoundary, null>): string {
@@ -68,7 +141,110 @@ export function coachBoundaryAnswer(boundary: Exclude<CoachSafetyBoundary, null>
   if (boundary === "diagnosis") {
     return "I can help you organize your recorded information and prepare questions for a qualified clinician, but I cannot diagnose a condition. If you describe what you want to understand, I can help you create a concise discussion list.";
   }
-  return "I cannot tell you to start, stop, or change a medication, hormone, supplement, or dose. I can summarize what LVE360 currently records and help you prepare specific questions for your clinician or pharmacist before making a change.";
+  return "I cannot direct a medication or hormone change. I can summarize what LVE360 currently records, explain the relevant evidence and safety context, and help you prepare specific questions for your clinician or pharmacist before changing a prescribed plan.";
+}
+
+function cleanText(value: unknown, max = 1000) {
+  return typeof value === "string" ? value.replace(/\s+/g, " ").trim().slice(0, max) : "";
+}
+
+function isCoachIntent(value: unknown): value is CoachIntent {
+  return [
+    "GENERAL_EDUCATION", "PERSONALIZED_RECOMMENDATION", "CURRENT_PLAN_LOOKUP",
+    "OPTION_COMPARISON", "PLAN_EXPLANATION", "TIMING_OR_DOSING",
+    "PROGRESS_COACHING", "REQUEST_TO_CHANGE_RECORD", "POTENTIAL_MEDICAL_RED_FLAG",
+  ].includes(String(value));
+}
+
+export function parseStructuredCoachAnswer(
+  text: string,
+  expectedIntent: CoachIntent,
+  validSourceIds: Set<string>,
+  allowedOptionNames: Set<string>,
+): StructuredCoachAnswer | null {
+  const candidate = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+  try {
+    const value = JSON.parse(candidate) as Record<string, unknown>;
+    const intent = isCoachIntent(value.intent) ? value.intent : expectedIntent;
+    if (intent !== expectedIntent) return null;
+    const directAnswer = cleanText(value.direct_answer, 700);
+    const nextStep = cleanText(value.next_step, 350);
+    if (directAnswer.length < 12 || nextStep.length < 8 || !isCoachAnswerSafe(`${directAnswer} ${nextStep}`)) return null;
+
+    const options = Array.isArray(value.options) ? value.options.flatMap((raw): ProposedCoachOption[] => {
+      if (!raw || typeof raw !== "object") return [];
+      const item = raw as Record<string, unknown>;
+      const name = cleanText(item.name, 100);
+      const reason = cleanText(item.reason, 260);
+      const fit = item.fit === "strong" || item.fit === "neutral" || item.fit === "weak" ? item.fit : "neutral";
+      if (!name || !reason || !allowedOptionNames.has(name.toLowerCase())) return [];
+      return [{ name, fit, reason }];
+    }).slice(0, 3) : [];
+
+    const rawRecommendation = value.recommendation;
+    let recommendation: StructuredCoachAnswer["recommendation"] = null;
+    if (rawRecommendation && typeof rawRecommendation === "object") {
+      const item = rawRecommendation as Record<string, unknown>;
+      const selected = cleanText(item.candidate, 100);
+      const reason = cleanText(item.reason, 400);
+      const matched = options.find((option) => option.name.toLowerCase() === selected.toLowerCase());
+      if (matched && reason) {
+        const days = Number(item.trial_period_days);
+        recommendation = {
+          candidate: matched.name,
+          reason,
+          trialPeriodDays: Number.isFinite(days) && days >= 1 && days <= 60 ? Math.round(days) : null,
+          metrics: Array.isArray(item.metrics)
+            ? item.metrics.map((metric) => cleanText(metric, 80)).filter(Boolean).slice(0, 3)
+            : [],
+        };
+      }
+    }
+    const sourceIds = Array.isArray(value.source_ids)
+      ? [...new Set(value.source_ids.filter((id): id is string => typeof id === "string" && validSourceIds.has(id)))]
+      : [];
+    return { intent, directAnswer, options, recommendation, nextStep, sourceIds };
+  } catch {
+    return null;
+  }
+}
+
+export function assessCoachAnswerQuality(input: {
+  answer: StructuredCoachAnswer;
+  supplementQuestion: boolean;
+  safetyChecked: boolean;
+  usedMemberContext: boolean;
+  allCandidatesBlocked?: boolean;
+}): CoachQualityReport {
+  const combined = `${input.answer.directAnswer} ${input.answer.options.map((option) => option.reason).join(" ")} ${input.answer.nextStep}`;
+  const referralCount = (combined.match(/clinician|pharmacist|professional|doctor/gi) ?? []).length;
+  const recordOnlyFailure = /(?:blueprint|records?|saved information) (?:does not|doesn't|do not|don't) (?:specify|contain|include|answer)/i.test(combined)
+    && input.answer.options.length === 0;
+  const checks = {
+    directly_answered_question: input.answer.directAnswer.length >= 12,
+    used_relevant_user_context: !input.usedMemberContext || /\b(?:your|you|recorded|current|recent|already)\b/i.test(combined),
+    provided_concrete_information: !input.supplementQuestion || input.answer.options.length > 0 || input.allCandidatesBlocked === true,
+    provided_reasoning_or_why: input.answer.options.some((option) => option.reason.length >= 12)
+      || Boolean(input.answer.recommendation?.reason)
+      || (!input.supplementQuestion && input.answer.directAnswer.length >= 40),
+    evidence_quality_appropriate: !input.supplementQuestion || input.answer.options.length > 0 || input.allCandidatesBlocked === true,
+    safety_checked: input.safetyChecked,
+    actionable_next_step: input.answer.nextStep.length >= 8,
+    excessive_referral_language: referralCount >= 3 && referralCount * 35 > combined.split(/\s+/).length,
+    unsupported_claims: false,
+    record_only_failure: recordOnlyFailure,
+  };
+  const positive = [
+    checks.directly_answered_question, checks.used_relevant_user_context, checks.provided_concrete_information,
+    checks.provided_reasoning_or_why, checks.evidence_quality_appropriate, checks.safety_checked,
+    checks.actionable_next_step,
+  ].filter(Boolean).length;
+  const passed = positive >= 6
+    && !checks.excessive_referral_language
+    && !checks.unsupported_claims
+    && !checks.record_only_failure
+    && (!input.supplementQuestion || checks.provided_concrete_information);
+  return { ...checks, passed, score: Math.round((positive / 7) * 100) };
 }
 
 export function parseCoachAnswer(text: string, validSourceIds: Set<string>) {
@@ -89,20 +265,20 @@ export function parseCoachAnswer(text: string, validSourceIds: Set<string>) {
 export function isCoachAnswerSafe(answer: string) {
   const value = answer.toLowerCase();
   if (/\b(you have|this is|you are suffering from)\s+(?:a\s+)?(?:disease|condition|cancer|diabetes|depression|anxiety|hypertension)\b/.test(value)) return false;
-  const directive = /\b(?:you should|i recommend|go ahead and|please)\s+(?:start|begin|stop|quit|add|remove|increase|decrease|double|halve|change|adjust|skip|replace|switch|take|use)\b/;
-  const healthItem = /\b(medication|medicine|prescription|dose|dosage|hormone|supplement|vitamin|b\s?12|magnesium|creatine|melatonin|omega-?3|zepbound|insulin|thyroid)\b/;
-  if (directive.test(value) && healthItem.test(value)) return false;
-  const benefitClaim = /\b(?:can|may|might|could|will|helps?|supports?|aimed at)\s+(?:help\s+|benefit from\s+)?(?:improve|boost|reduce|lower|increase|prevent|support|supporting|enhance|adjustments?|changes?)\b/;
-  const healthOutcome = /\b(?:digestion|energy levels?|sleep quality|blood pressure|blood sugar|weight loss|mood|cognition|memory|symptoms?|inflammation|disease|longevity)\b/;
-  return !(benefitClaim.test(value) && healthOutcome.test(value));
+  if (/\b(?:treats?|cures?|prevents?|manages?)\b[^.]{0,80}\b(?:disease|cancer|diabetes|depression|anxiety|hypertension|infection)\b/.test(value)) return false;
+  if (/\b(?:completely|absolutely|guaranteed|proven) safe\b|\bno risk\b/.test(value)) return false;
+  if (/https?:\/\/|\bdoi\s*:|\bpmid\s*:/i.test(answer)) return false;
+  const directive = /\b(?:you should|i recommend|go ahead and|please)\s+(?:start|begin|stop|quit|add|remove|increase|decrease|double|halve|change|adjust|skip|replace|switch)\b/;
+  const prescribedItem = /\b(medication|medicine|prescription|prescribed|hormone|zepbound|insulin|thyroid|testosterone|estrogen|progesterone)\b/;
+  return !(directive.test(value) && prescribedItem.test(value));
 }
 
 export function coachSuggestedPrompts(page: CoachPage): string[] {
   const common = "What is the smallest useful step I can take today?";
   const prompts: Record<CoachPage, string[]> = {
     today: [common, "How can I make today's weekly practice easier to complete?"],
-    routine: ["Help me understand how my recorded routine fits together.", "What should I prepare to discuss with my clinician or pharmacist?"],
-    blueprint: ["What are the most important themes in my current Blueprint?", "How can I turn one Blueprint priority into a small weekly practice?"],
+    routine: ["What am I currently taking at night?", "Does anything in my routine deserve a closer safety review?"],
+    blueprint: ["What are the most important themes in my current Blueprint?", "Which Blueprint option best fits my current routine?"],
     journey: ["What pattern can I cautiously learn from my recent progress?", "What small win should I build on next?"],
     review: ["Help me reflect on what made this week easier or harder.", "What is a sensible experiment for next week?"],
     settings: ["Which information should I review so LVE360 stays useful?", common],

--- a/src/lib/evidence.ts
+++ b/src/lib/evidence.ts
@@ -122,7 +122,17 @@ export function normalizeSupplementName(name: string): string {
 }
 
 /** Build a normalized index from the evidence JSON: keyOf(human-key) -> array of entries */
-type EvidenceEntry = { url: string; [k: string]: any };
+export type EvidenceEntry = {
+  url: string;
+  supplement?: string | null;
+  study_type?: string | null;
+  year?: number | null;
+  quality?: string | null;
+  outcome?: string | null;
+  tag?: string | null;
+  journal?: string | null;
+  [k: string]: any;
+};
 const curatedIndex: Record<string, EvidenceEntry[]> = (() => {
   const out: Record<string, EvidenceEntry[]> = {};
   for (const [humanKey, arr] of Object.entries(
@@ -167,6 +177,25 @@ export function getTopCitationsFor(name: string, limit = 2): string[] {
 
   if (!arr || arr.length === 0) return [];
   return sanitizeCitations(arr.slice(0, limit).map((e) => e.url));
+}
+
+/** Curated evidence metadata for server-side retrieval and structured coaching. */
+export function getEvidenceEntriesFor(name: string, limit = 3): EvidenceEntry[] {
+  if (!name) return [];
+  const lowered = name.toLowerCase().trim();
+  if (IGNORE_FOR_EVIDENCE.has(lowered)) return [];
+
+  const canonical = normalizeSupplementName(name);
+  const canonicalKey = keyOf(canonical);
+  const rawKey = keyOf(name);
+  const arr = curatedIndex[canonicalKey]
+    ?? curatedIndex[rawKey]
+    ?? curatedIndex[Object.keys(curatedIndex).find((candidate) => candidate.includes(canonicalKey) || canonicalKey.includes(candidate)) ?? ""];
+
+  return (arr ?? []).slice(0, limit).flatMap((entry) => {
+    const urls = sanitizeCitations([entry.url]);
+    return urls.length ? [{ ...entry, url: urls[0] }] : [];
+  });
 }
 
 /** Keep the same curated-source policy used by report generation. */

--- a/supabase/migrations/20260813090000_pr107_coaching_diagnostics.sql
+++ b/supabase/migrations/20260813090000_pr107_coaching_diagnostics.sql
@@ -1,0 +1,38 @@
+-- PR107: privacy-safe diagnostics for Ask LVE360 Coaching Engine v2.
+alter table public.ai_coaching_turns
+  add column intent text,
+  add column quality_score smallint,
+  add column safety_rule_count smallint not null default 0,
+  add column recommendations_removed smallint not null default 0,
+  add column regeneration_count smallint not null default 0,
+  add column evidence_ids jsonb not null default '[]'::jsonb;
+
+alter table public.ai_coaching_turns
+  add constraint ai_coaching_turns_intent check (
+    intent is null or intent in (
+      'GENERAL_EDUCATION',
+      'PERSONALIZED_RECOMMENDATION',
+      'CURRENT_PLAN_LOOKUP',
+      'OPTION_COMPARISON',
+      'PLAN_EXPLANATION',
+      'TIMING_OR_DOSING',
+      'PROGRESS_COACHING',
+      'REQUEST_TO_CHANGE_RECORD',
+      'POTENTIAL_MEDICAL_RED_FLAG'
+    )
+  ),
+  add constraint ai_coaching_turns_quality_score check (quality_score is null or quality_score between 0 and 100),
+  add constraint ai_coaching_turns_safety_rule_count check (safety_rule_count >= 0),
+  add constraint ai_coaching_turns_recommendations_removed check (recommendations_removed >= 0),
+  add constraint ai_coaching_turns_regeneration_count check (regeneration_count between 0 and 2),
+  add constraint ai_coaching_turns_evidence_ids_array check (jsonb_typeof(evidence_ids) = 'array');
+
+comment on column public.ai_coaching_turns.intent is
+  'Deterministically classified coaching intent used to assemble only relevant context.';
+comment on column public.ai_coaching_turns.quality_score is
+  'Aggregate 0-100 score from the deterministic response quality gate.';
+comment on column public.ai_coaching_turns.evidence_ids is
+  'Stable identifiers for curated LVE360 evidence used by the answer; contains no raw health data.';
+
+-- Existing row-level security and grants are intentionally unchanged. Members can
+-- continue selecting only their own coaching turns; all writes remain service-role only.


### PR DESCRIPTION
## Purpose

Replace the record-only Ask LVE360 behavior with an evidence-aware, personalized coaching pipeline that directly answers ordinary wellness questions while retaining deterministic safety and read-only record boundaries.

## Confirmed root cause

The v1 implementation combined four constraints that produced the reported sleep answer:

- the prompt said to use only supplied member facts
- page-scoped retrieval omitted the Routine when questions were asked from Today
- the validator rejected ordinary supplement benefit language
- the coach had no evidence retrieval or deterministic candidate-safety stage

Recommendation and saved-record mutation were also treated as the same boundary, making the model needlessly noncommittal.

## Architecture

Question → deterministic intent → intent-scoped member context → curated LVE360 evidence → pre-generation safety → structured model ranking → post-generation safety veto → response quality gate/repair → deterministic rendering.

The cost-efficient `contextual_coach` model remains behind the canonical AI gateway. The model ranks and explains only supplied evidence candidates. It cannot invent candidate names or source IDs, and a failed or invalid model response falls back to an evidence-bound deterministic repair.

## What changed

- adds all nine required coaching intents
- retrieves only intent-relevant goals, Routine items, health profile, Blueprint, practice, and check-ins
- exposes curated evidence metadata through the existing evidence index
- distinguishes records as personalization from evidence as knowledge
- runs the existing interactions/rules safety engine before and after generation
- removes deterministically blocked candidates
- preserves required safety notes
- recognizes supplements already in the Routine and prevents duplicate-add language
- supports evidence-bound timing/dose explanations where the current dosing registry has guidance
- makes record mutation requests explicit and read-only
- rejects fabricated source IDs, free-form citations, prescribed-plan directives, absolute safety claims, and disease-treatment claims
- rejects the concrete record-only non-answer through a quality gate
- repairs one invalid model response, then uses a deterministic fallback
- changes evidence links to open in a new tab
- clarifies the UI: health record = personalization, evidence = knowledge, rules = safety
- records privacy-safe intent, quality, safety, removal, repair, and evidence diagnostics

## Safety behavior

Deterministic:
- emergency and diagnosis routing
- medication/hormone change boundary
- current-stack identity matching and deduplication
- interactions, contraindications, allergy matching, upper limits, spacing, life-stage, kidney/liver, and unknown-medication rules
- post-generation veto
- source allowlist
- response quality/hard-failure rules
- no record mutation

Model-driven:
- concise direct answer
- ranking among allowed evidence options
- personalized explanation
- one-change experiment and outcomes to track

## Database

Adds six privacy-safe fields to `ai_coaching_turns`: intent, quality score, safety-rule count, recommendations removed, regeneration count, and evidence IDs.

The additive migration is already applied. RLS remains enabled, the member-owned SELECT policy is unchanged, and writes remain service-role only.

## Verification

Passed:

- `npm.cmd run qa:pr105`
- `npm.cmd run qa:pr106`
- `npm.cmd run qa:pr107`
- `npm.cmd run typecheck`
- `git diff --check`
- all eight requested acceptance scenarios
- live Supabase column, RLS, and policy verification
- Supabase security/performance advisor scan with no new PR107-specific finding

The production build compiled and completed type validation. Local prerender stopped at `/login` because protected public Supabase values are intentionally absent from this checkout; Vercel Preview will provide the configured-environment build.

## Preview QA required

Use an authenticated paid/trial profile and ask:

1. “What supplements are good for sleep?”
2. “What should I try for sleep?”
3. “Would magnesium help my sleep?”
4. “What supplements am I currently taking at night?”
5. “Add glycine to my stack.”

Confirm direct answers, source links, current-magnesium recognition, safety notes, and zero record mutation.

## Known limitations

- The first evidence retrieval index intentionally covers the highest-value sleep, energy, cognition, stress, exercise, recovery, and heart candidates rather than the entire supplement catalog.
- Quality scoring is deterministic and conservative; beta feedback should guide threshold refinement.
- Product-event analytics beyond the existing coaching-turn diagnostics and thumbs feedback are deferred until live answer quality is proven.

## Rollback

Revert this PR. The additive diagnostics columns may remain safely unused or be removed later in a separate migration after any desired metrics export.