### PR TITLE
PR108: Establish canonical member intelligence context

### DIFF
--- a/docs/member-intelligence-context.md
+++ b/docs/member-intelligence-context.md
@@ -1,0 +1,83 @@
+# Canonical member intelligence context
+
+## Purpose
+
+`getMemberIntelligenceContext(userId)` is the server-only, typed source of truth for the member facts required by LVE360's intelligence layer. It prepares the KNOW stage of the product loop without changing records or generating recommendations.
+
+The contract is versioned as `member-intelligence-context-v1` and assembled by a pure function so it can be regression-tested without production data.
+
+## Current architecture findings
+
+The Trust-to-Intelligence audit was directionally correct. The current application has separate context assembly paths for Ask LVE360, Today, Journey, weekly synthesis, Blueprint, and Routine. `current_regimen_items` is already the canonical regimen source and preserves medication, hormone, supplement, and endocrine-active supplement types, but the AI context previously flattened selected data into loosely typed facts.
+
+These details in the program brief required adjustment:
+
+- The repository currently runs Next.js 15.5, although `AGENTS.md` still describes Next.js 14.
+- Preferences live in `user_preferences`, not `account_preferences`.
+- Weekly reviews live in `weekly_experiment_reviews`.
+- The current schema stores Blueprint linkage on weekly practices, but it does not store an explicit practice-to-saved-goal relation. The context therefore reports that relation as `not_recorded` instead of guessing.
+- Existing Blueprint context already centralizes freshness and safety acknowledgement, but it did not expose structured Blueprint goals.
+- Safety provenance metadata is incomplete in the current rule tables. This PR reports the available source and source URL without fabricating clinical review metadata; the deeper provenance work remains in the dedicated safety PR.
+
+## Contract
+
+The context keeps materially different concepts separate:
+
+- member identity and tier
+- intake health profile
+- explicit saved goals and numeric targets
+- current Blueprint goals and priorities
+- medications
+- hormones
+- supplements
+- endocrine-active supplements
+- active weekly practice
+- recent practice history, completions, and reviews
+- recent weight, sleep, and energy check-ins
+- reminder and quiet-hour preferences
+- unresolved findings from the existing deterministic safety engine
+- section-level provenance, missingness, timestamps, and stale Blueprint state
+
+Missing records remain `null` or empty collections with `status: "missing"` and a reason. The loader does not infer missing doses, timing, goals, or practice relationships.
+
+## PR 1 implementation plan
+
+### Files
+
+- `src/lib/memberContext.ts`: pure types, grouping, provenance, freshness, goal-source alignment, and practice-link assembly.
+- `src/lib/memberContextData.ts`: server-only Supabase loader and existing safety-engine adapter.
+- `src/lib/blueprintContext.ts`: backward-compatible optional Blueprint goal field.
+- `src/lib/currentBlueprintContext.ts`: populate structured Blueprint goals from the parsed report.
+- `src/_tests_/pr108MemberContext.assert.ts`: representative simple, moderate, complex, missing-source, stale, and practice states.
+- `src/_tests_/pr108Architecture.assert.mjs`: read-only and boundary assertions.
+- `package.json`: focused PR QA command.
+
+### Schema impact
+
+None. The implementation reads existing tables and uses existing server-only service-role access. There is no migration, RLS change, backfill, or new environment variable.
+
+### Migration path
+
+PR 2 can replace Ask LVE360's ad hoc `buildCoachContext` queries with an intent-scoped adapter over this contract. Today, Journey, and weekly synthesis can migrate separately after their current behavior is covered by regression tests.
+
+### Risks and controls
+
+- **Additional read cost when adopted:** the full context queries several existing sources. Consumers should request or cache one snapshot per request instead of rebuilding it repeatedly.
+- **Legacy safety quality:** the context exposes current deterministic findings but does not correct rule provenance or unit conversion. Those changes remain isolated to the safety PR.
+- **Goal mismatch interpretation:** `different` means exact recorded labels differ; it is not a clinical or semantic judgment that the goals conflict.
+- **Historical linkage gaps:** unresolved Blueprint references and absent saved-goal linkage are reported explicitly.
+
+## Explicit non-goals
+
+This PR does not:
+
+- change Ask LVE360 answers, intent classification, or quality scoring
+- change Today, Journey, Blueprint, Routine, or reminder UI
+- mutate member records
+- add a public or client-side context endpoint
+- repair safety rules, unit conversions, model routing, or prompt telemetry
+- introduce recommendation actions or weekly adaptation
+
+## Rollback
+
+Remove the two new context modules and PR108 tests, remove the Blueprint `goals` field population, and remove the `qa:pr108` script. No database rollback is required.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "qa:pr105": "node --experimental-strip-types src/_tests_/pr105ContextualCoach.assert.ts && node src/_tests_/pr105Page.assert.mjs",
     "qa:pr106": "node src/_tests_/pr106CoachWorkspace.assert.mjs",
     "qa:pr107": "node --experimental-strip-types src/_tests_/pr107CoachingEngine.assert.ts && node src/_tests_/pr107Architecture.assert.mjs",
+    "qa:pr108": "node --experimental-strip-types src/_tests_/pr108MemberContext.assert.ts && node src/_tests_/pr108Architecture.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr108Architecture.assert.mjs
+++ b/src/_tests_/pr108Architecture.assert.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const contract = fs.readFileSync("src/lib/memberContext.ts", "utf8");
+const loader = fs.readFileSync("src/lib/memberContextData.ts", "utf8");
+
+assert.match(contract, /MEMBER_CONTEXT_VERSION/);
+assert.match(contract, /medications:[\s\S]*hormones:[\s\S]*supplements:[\s\S]*endocrineActiveSupplements:/);
+assert.match(contract, /provenance/);
+assert.match(contract, /contextFreshness/);
+assert.match(loader, /import "server-only"/);
+assert.match(loader, /getCurrentRegimen/);
+assert.match(loader, /getCurrentBlueprintContext/);
+assert.match(loader, /weekly_experiment_reviews/);
+assert.match(loader, /daily_practice_completions/);
+assert.doesNotMatch(loader, /\.insert\(|\.update\(|\.upsert\(|\.delete\(/, "The canonical context loader must remain read-only.");
+
+console.log("PR108 canonical member context architecture checks passed.");

--- a/src/_tests_/pr108MemberContext.assert.ts
+++ b/src/_tests_/pr108MemberContext.assert.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+
+import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "../lib/blueprintContext.ts";
+import type { CurrentRegimenItem, CurrentRegimenKind } from "../lib/currentRegimenModel.ts";
+import {
+  buildMemberIntelligenceContext,
+  MEMBER_CONTEXT_VERSION,
+  type MemberContextExperimentInput,
+  type MemberIntelligenceContextInput,
+} from "../lib/memberContext.ts";
+
+const NOW = "2026-08-14T12:00:00.000Z";
+
+function regimenItem(index: number, kind: CurrentRegimenKind, overrides: Partial<CurrentRegimenItem> = {}): CurrentRegimenItem {
+  const name = overrides.name ?? `${kind} ${index}`;
+  return {
+    id: overrides.id ?? `regimen-${index}`,
+    user_id: "member-1",
+    source_submission_id: "submission-1",
+    source_stack_item_id: null,
+    item_kind: kind,
+    name,
+    normalized_name: name.toLowerCase(),
+    purpose: null,
+    dose: null,
+    timing: null,
+    brand: null,
+    reorder_url: null,
+    image_url: null,
+    product_source: null,
+    product_sku: null,
+    instruction_source: "intake",
+    instruction_authority: null,
+    schedule: null,
+    active: true,
+    created_at: "2026-08-01T12:00:00.000Z",
+    updated_at: "2026-08-13T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function blueprint(overrides: Partial<CurrentBlueprintContext> = {}): CurrentBlueprintContext {
+  return {
+    stack_id: "stack-1",
+    created_at: "2026-08-10T12:00:00.000Z",
+    goals: ["Improve sleep"],
+    safety_status: "safe",
+    safety_acknowledged: false,
+    needs_refresh: false,
+    priorities: [{ id: "priority-1", label: "Keep a consistent wake time", category: "sleep", kind: "lifestyle" }],
+    ...overrides,
+  };
+}
+
+function experiment(overrides: Partial<MemberContextExperimentInput> = {}): MemberContextExperimentInput {
+  return {
+    id: "experiment-1",
+    source_stack_id: "stack-1",
+    source_action_id: "priority-1",
+    identity_direction: "sleep",
+    action_label: "Keep a consistent wake time",
+    cue: "After my alarm",
+    frequency_per_week: 5,
+    minimum_version: "Get out of bed at the planned time",
+    status: "active",
+    week_start: "2026-08-10",
+    created_at: "2026-08-10T12:00:00.000Z",
+    updated_at: "2026-08-13T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function blueprintLink(overrides: Partial<ExperimentBlueprintContext> = {}): ExperimentBlueprintContext {
+  return {
+    source_stack_id: "stack-1",
+    source_action_id: "priority-1",
+    priority_label: "Keep a consistent wake time",
+    priority_category: "sleep",
+    priority_kind: "lifestyle",
+    blueprint_created_at: "2026-08-10T12:00:00.000Z",
+    is_current_blueprint: true,
+    needs_review: false,
+    ...overrides,
+  };
+}
+
+function baseInput(overrides: Partial<MemberIntelligenceContextInput> = {}): MemberIntelligenceContextInput {
+  const active = experiment();
+  return {
+    generatedAt: NOW,
+    member: { id: "member-1", tier: "premium", joinedAt: "2026-07-01T12:00:00.000Z", updatedAt: "2026-08-01T12:00:00.000Z" },
+    healthProfile: {
+      submissionId: "submission-1",
+      updatedAt: "2026-08-01T12:00:00.000Z",
+      age: 52,
+      sex: "male",
+      conditions: [],
+      allergies: [],
+      procedures: [],
+      pregnant: null,
+      dosingPreference: null,
+      brandPreference: null,
+    },
+    preferences: {
+      preferredName: "Luke",
+      weightUnit: "lb",
+      reminderPreference: "email",
+      timezone: "America/Denver",
+      cueHour: 6,
+      quietStartHour: 21,
+      quietEndHour: 5,
+      updatedAt: "2026-08-13T12:00:00.000Z",
+    },
+    savedGoals: [{
+      label: "Improve sleep",
+      kind: "named",
+      targetValue: null,
+      provenance: { source: "goals", recordId: "goal-1", updatedAt: "2026-08-12T12:00:00.000Z" },
+    }],
+    goalsUpdatedAt: "2026-08-12T12:00:00.000Z",
+    blueprint: blueprint(),
+    regimen: [
+      regimenItem(1, "medication", { name: "Medication A", dose: "10 mg", timing: "morning" }),
+      regimenItem(2, "hormone", { name: "Hormone A", dose: "1 mg", timing: "weekly" }),
+      regimenItem(3, "supplement", { name: "Supplement A", dose: "100 mg", timing: "evening" }),
+      regimenItem(4, "endocrine_active_supplement", { name: "Endocrine supplement A" }),
+    ],
+    experiments: [active],
+    reviews: [],
+    completions: [{ id: "completion-1", experiment_id: active.id, completion_date: "2026-08-12", completion_kind: "full", updated_at: "2026-08-12T12:00:00.000Z" }],
+    practiceBlueprintContexts: { [active.id]: blueprintLink() },
+    checkIns: [{ id: "log-1", log_date: "2026-08-13", weight: 200, sleep: 4, energy: 7, updated_at: "2026-08-13T12:00:00.000Z" }],
+    safetyFindings: [],
+    safetyEvaluationComplete: true,
+    ...overrides,
+  };
+}
+
+// 1. Simple member with four distinct regimen records.
+const simple = buildMemberIntelligenceContext(baseInput());
+assert.equal(simple.version, MEMBER_CONTEXT_VERSION);
+assert.equal(simple.regimen.medications.value.length, 1);
+assert.equal(simple.regimen.hormones.value.length, 1);
+assert.equal(simple.regimen.supplements.value.length, 1);
+assert.equal(simple.regimen.endocrineActiveSupplements.value.length, 1);
+assert.equal(simple.regimen.endocrineActiveSupplements.value[0].dose, null, "Missing dose must remain explicitly null.");
+assert.equal(simple.regimen.medications.value[0].provenance.source, "current_regimen_items");
+assert.equal(simple.unresolvedSafetyItems.status, "present", "A completed evaluation with no findings is known-clear, not missing.");
+
+// 2. Moderate member retains all records and source distinctions.
+const moderateRegimen = [
+  ...Array.from({ length: 3 }, (_, index) => regimenItem(index, "medication")),
+  ...Array.from({ length: 5 }, (_, index) => regimenItem(index + 10, "supplement")),
+];
+const moderate = buildMemberIntelligenceContext(baseInput({ regimen: moderateRegimen }));
+assert.equal(moderate.regimen.medications.value.length, 3);
+assert.equal(moderate.regimen.supplements.value.length, 5);
+
+// 3. Complex member keeps 20+ regimen records without a hidden slice.
+const complexRegimen = [
+  ...Array.from({ length: 5 }, (_, index) => regimenItem(index, "medication")),
+  regimenItem(20, "hormone"),
+  ...Array.from({ length: 18 }, (_, index) => regimenItem(index + 30, "supplement")),
+];
+const complex = buildMemberIntelligenceContext(baseInput({ regimen: complexRegimen }));
+assert.equal(
+  complex.regimen.medications.value.length + complex.regimen.hormones.value.length + complex.regimen.supplements.value.length,
+  24,
+  "Canonical context must not truncate a complex regimen.",
+);
+
+// 4. No-supplement state is explicit rather than fabricated.
+const noSupplements = buildMemberIntelligenceContext(baseInput({ regimen: [regimenItem(1, "medication")] }));
+assert.equal(noSupplements.regimen.supplements.status, "missing");
+assert.match(noSupplements.regimen.supplements.missingReason ?? "", /No active supplements/);
+assert.equal(noSupplements.regimen.medications.status, "present");
+
+// 5. No-medication state remains distinguishable from no regimen.
+const noMedications = buildMemberIntelligenceContext(baseInput({ regimen: [regimenItem(1, "supplement")] }));
+assert.equal(noMedications.regimen.medications.status, "missing");
+assert.equal(noMedications.regimen.supplements.status, "present");
+
+// 6. A stale Blueprint is represented in the section and aggregate freshness.
+const stale = buildMemberIntelligenceContext(baseInput({ blueprint: blueprint({ needs_refresh: true }) }));
+assert.equal(stale.blueprint.status, "stale");
+assert.ok(stale.contextFreshness.staleSections.includes("blueprint"));
+
+// 7. Conflicting and missing goal sources are observable rather than flattened.
+const differentGoals = buildMemberIntelligenceContext(baseInput({
+  blueprint: blueprint({ goals: ["Build strength"] }),
+}));
+assert.equal(differentGoals.goals.alignment.status, "different");
+const missingGoals = buildMemberIntelligenceContext(baseInput({
+  savedGoals: [],
+  goalsUpdatedAt: null,
+  blueprint: blueprint({ goals: [] }),
+}));
+assert.equal(missingGoals.goals.alignment.status, "missing");
+assert.equal(missingGoals.goals.saved.status, "missing");
+
+// 8. Active-practice linkage, completion evidence, and no-active state are explicit.
+assert.equal(simple.activePractice.status, "present");
+assert.equal(simple.activePractice.value?.blueprintLink.status, "current");
+assert.equal(simple.activePractice.value?.goalLink.status, "not_recorded");
+assert.equal(simple.activePractice.value?.completionCount, 1);
+const noActivePractice = buildMemberIntelligenceContext(baseInput({
+  experiments: [experiment({ status: "completed" })],
+}));
+assert.equal(noActivePractice.activePractice.status, "missing");
+assert.equal(noActivePractice.recentPracticeHistory.status, "present");
+
+console.log("PR108 canonical member context acceptance scenarios passed.");

--- a/src/lib/blueprintContext.ts
+++ b/src/lib/blueprintContext.ts
@@ -11,6 +11,7 @@ export type BlueprintPriorityContext = {
 export type CurrentBlueprintContext = {
   stack_id: string;
   created_at: string;
+  goals?: string[];
   safety_status: BlueprintSafetyStatus;
   safety_acknowledged: boolean;
   needs_refresh: boolean;

--- a/src/lib/currentBlueprintContext.ts
+++ b/src/lib/currentBlueprintContext.ts
@@ -77,6 +77,7 @@ export async function getCurrentBlueprintContext(userId: string): Promise<Curren
   return {
     stack_id: stack.id,
     created_at: stack.created_at,
+    goals: extractBlueprintGoalNames(report.sections.Goals),
     safety_status: deriveBlueprintSafetyStatus(markdown),
     safety_acknowledged: Boolean(stack.safety_acknowledged_at),
     needs_refresh: needsRefresh,

--- a/src/lib/memberContext.ts
+++ b/src/lib/memberContext.ts
@@ -1,0 +1,545 @@
+import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "./blueprintContext";
+import type { CurrentRegimenItem } from "./currentRegimenModel";
+import type { SafetyFinding } from "./safetyEngine";
+
+export const MEMBER_CONTEXT_VERSION = "member-intelligence-context-v1";
+
+export type MemberContextStatus = "present" | "missing" | "stale";
+
+export type MemberContextSource =
+  | "users"
+  | "user_preferences"
+  | "submissions"
+  | "goals"
+  | "stacks"
+  | "current_regimen_items"
+  | "weekly_experiments"
+  | "daily_practice_completions"
+  | "weekly_experiment_reviews"
+  | "logs"
+  | "interactions"
+  | "rules"
+  | "intake"
+  | "system";
+
+export type MemberContextProvenance = {
+  source: MemberContextSource;
+  recordId: string | null;
+  updatedAt: string | null;
+};
+
+export type MemberContextSection<T> = {
+  status: MemberContextStatus;
+  value: T;
+  updatedAt: string | null;
+  provenance: MemberContextProvenance[];
+  missingReason: string | null;
+};
+
+export type MemberIdentityContext = {
+  id: string;
+  tier: string;
+  joinedAt: string | null;
+};
+
+export type MemberHealthProfileContext = {
+  age: number | null;
+  sex: string | null;
+  conditions: string[];
+  allergies: string[];
+  procedures: string[];
+  pregnant: boolean | string | null;
+  dosingPreference: string | null;
+  brandPreference: string | null;
+};
+
+export type MemberPreferencesContext = {
+  preferredName: string | null;
+  weightUnit: "lb" | "kg";
+  reminderPreference: "none" | "email";
+  timezone: string;
+  cueHour: number;
+  quietStartHour: number;
+  quietEndHour: number;
+};
+
+export type MemberGoalContext = {
+  label: string;
+  kind: "named" | "weight_target" | "sleep_target" | "energy_target";
+  targetValue: number | null;
+  provenance: MemberContextProvenance;
+};
+
+export type GoalSourceAlignment = {
+  status: "aligned" | "different" | "single_source" | "missing";
+  sharedLabels: string[];
+  explanation: string;
+};
+
+export type MemberRegimenItemContext = Pick<
+  CurrentRegimenItem,
+  | "id"
+  | "item_kind"
+  | "name"
+  | "purpose"
+  | "dose"
+  | "timing"
+  | "schedule"
+  | "instruction_source"
+  | "instruction_authority"
+  | "updated_at"
+> & {
+  provenance: MemberContextProvenance;
+};
+
+export type MemberRegimenContext = {
+  medications: MemberContextSection<MemberRegimenItemContext[]>;
+  hormones: MemberContextSection<MemberRegimenItemContext[]>;
+  supplements: MemberContextSection<MemberRegimenItemContext[]>;
+  endocrineActiveSupplements: MemberContextSection<MemberRegimenItemContext[]>;
+};
+
+export type PracticeGoalLink = {
+  status: "linked" | "not_recorded";
+  goalLabel: string | null;
+  explanation: string;
+};
+
+export type PracticeBlueprintLink = {
+  status: "current" | "historical" | "independent" | "unresolved";
+  stackId: string | null;
+  actionId: string | null;
+  priorityLabel: string | null;
+  explanation: string;
+};
+
+export type MemberPracticeContext = {
+  id: string;
+  identityDirection: string | null;
+  actionLabel: string | null;
+  cue: string | null;
+  frequencyPerWeek: number | null;
+  minimumVersion: string | null;
+  weekStart: string;
+  status: "draft" | "active" | "completed" | "archived";
+  completionCount: number;
+  fullCompletionCount: number;
+  minimumCompletionCount: number;
+  review: {
+    difficulty: number | null;
+    valueRating: number | null;
+    decision: "keep" | "shrink" | "swap" | "pause" | "advance" | null;
+    status: "draft" | "completed";
+    completedAt: string | null;
+  } | null;
+  goalLink: PracticeGoalLink;
+  blueprintLink: PracticeBlueprintLink;
+  provenance: MemberContextProvenance[];
+};
+
+export type MemberCheckInContext = {
+  date: string;
+  weight: number | null;
+  sleep: number | null;
+  energy: number | null;
+  provenance: MemberContextProvenance;
+};
+
+export type MemberSafetyItemContext = {
+  code: string;
+  item: string;
+  message: string;
+  severity: "info" | "warning" | "danger";
+  decision: "review" | "blocked";
+  sourceUrl: string | null;
+  provenance: MemberContextProvenance;
+};
+
+export type MemberContextFreshness = {
+  generatedAt: string;
+  staleSections: string[];
+  missingSections: string[];
+  latestRecordedUpdate: string | null;
+};
+
+export type MemberIntelligenceContext = {
+  version: typeof MEMBER_CONTEXT_VERSION;
+  member: MemberContextSection<MemberIdentityContext | null>;
+  healthProfile: MemberContextSection<MemberHealthProfileContext | null>;
+  goals: {
+    saved: MemberContextSection<MemberGoalContext[]>;
+    blueprint: MemberContextSection<string[]>;
+    alignment: GoalSourceAlignment;
+  };
+  blueprint: MemberContextSection<CurrentBlueprintContext | null>;
+  regimen: MemberRegimenContext;
+  activePractice: MemberContextSection<MemberPracticeContext | null>;
+  recentPracticeHistory: MemberContextSection<MemberPracticeContext[]>;
+  recentCheckIns: MemberContextSection<MemberCheckInContext[]>;
+  preferences: MemberContextSection<MemberPreferencesContext | null>;
+  unresolvedSafetyItems: MemberContextSection<MemberSafetyItemContext[]>;
+  contextFreshness: MemberContextFreshness;
+};
+
+export type MemberContextExperimentInput = {
+  id: string;
+  source_stack_id: string | null;
+  source_action_id: string | null;
+  identity_direction: string | null;
+  action_label: string | null;
+  cue: string | null;
+  frequency_per_week: number | null;
+  minimum_version: string | null;
+  status: "draft" | "active" | "completed" | "archived";
+  week_start: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MemberContextReviewInput = {
+  id: string;
+  experiment_id: string;
+  difficulty: number | null;
+  value_rating: number | null;
+  decision: "keep" | "shrink" | "swap" | "pause" | "advance" | null;
+  status: "draft" | "completed";
+  completed_at: string | null;
+  updated_at: string;
+};
+
+export type MemberContextCompletionInput = {
+  id: string;
+  experiment_id: string;
+  completion_date: string;
+  completion_kind: "full" | "minimum";
+  updated_at: string;
+};
+
+export type MemberContextCheckInInput = {
+  id: string;
+  log_date: string;
+  weight: number | null;
+  sleep: number | null;
+  energy: number | null;
+  updated_at: string | null;
+};
+
+export type MemberIntelligenceContextInput = {
+  generatedAt: string;
+  member: (MemberIdentityContext & { updatedAt: string | null }) | null;
+  healthProfile: (MemberHealthProfileContext & { submissionId: string; updatedAt: string | null }) | null;
+  preferences: (MemberPreferencesContext & { updatedAt: string | null }) | null;
+  savedGoals: MemberGoalContext[];
+  goalsUpdatedAt: string | null;
+  blueprint: CurrentBlueprintContext | null;
+  regimen: CurrentRegimenItem[];
+  experiments: MemberContextExperimentInput[];
+  reviews: MemberContextReviewInput[];
+  completions: MemberContextCompletionInput[];
+  practiceBlueprintContexts: Record<string, ExperimentBlueprintContext>;
+  checkIns: MemberContextCheckInInput[];
+  safetyFindings: SafetyFinding[];
+  safetyEvaluationComplete: boolean;
+};
+
+function section<T>(
+  value: T,
+  status: MemberContextStatus,
+  updatedAt: string | null,
+  provenance: MemberContextProvenance[],
+  missingReason: string | null = null,
+): MemberContextSection<T> {
+  return { status, value, updatedAt, provenance, missingReason };
+}
+
+function validTimestamp(value: string | null | undefined): string | null {
+  if (!value || Number.isNaN(Date.parse(value))) return null;
+  return value;
+}
+
+function latestTimestamp(values: Array<string | null | undefined>): string | null {
+  const valid = values.map(validTimestamp).filter((value): value is string => Boolean(value));
+  return valid.sort((left, right) => Date.parse(right) - Date.parse(left))[0] ?? null;
+}
+
+function normalizedGoal(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function goalAlignment(saved: MemberGoalContext[], blueprint: string[]): GoalSourceAlignment {
+  const savedLabels = new Map(saved.map((goal) => [normalizedGoal(goal.label), goal.label]));
+  const blueprintLabels = new Map(blueprint.map((goal) => [normalizedGoal(goal), goal]));
+  if (!savedLabels.size && !blueprintLabels.size) {
+    return { status: "missing", sharedLabels: [], explanation: "No saved goals or Blueprint goals are currently recorded." };
+  }
+  if (!savedLabels.size || !blueprintLabels.size) {
+    return { status: "single_source", sharedLabels: [], explanation: "Goals are currently recorded in only one source." };
+  }
+  const sharedLabels = [...savedLabels.keys()].filter((key) => blueprintLabels.has(key)).map((key) => savedLabels.get(key) as string);
+  return sharedLabels.length
+    ? { status: "aligned", sharedLabels, explanation: "At least one saved goal is also present in the current Blueprint." }
+    : { status: "different", sharedLabels: [], explanation: "Saved goals and current Blueprint goals are both present but do not share an exact recorded label." };
+}
+
+function regimenSection(items: CurrentRegimenItem[], kind: CurrentRegimenItem["item_kind"], missingReason: string) {
+  const selected = items.filter((item) => item.item_kind === kind).map((item): MemberRegimenItemContext => ({
+    id: item.id,
+    item_kind: item.item_kind,
+    name: item.name,
+    purpose: item.purpose,
+    dose: item.dose,
+    timing: item.timing,
+    schedule: item.schedule,
+    instruction_source: item.instruction_source,
+    instruction_authority: item.instruction_authority,
+    updated_at: item.updated_at,
+    provenance: { source: "current_regimen_items", recordId: item.id, updatedAt: item.updated_at ?? null },
+  }));
+  return section(
+    selected,
+    selected.length ? "present" : "missing",
+    latestTimestamp(selected.map((item) => item.updated_at)),
+    selected.map((item) => item.provenance),
+    selected.length ? null : missingReason,
+  );
+}
+
+function practiceContext(
+  experiment: MemberContextExperimentInput,
+  reviews: MemberContextReviewInput[],
+  completions: MemberContextCompletionInput[],
+  blueprintContexts: Record<string, ExperimentBlueprintContext>,
+): MemberPracticeContext {
+  const review = reviews.find((item) => item.experiment_id === experiment.id) ?? null;
+  const recorded = completions.filter((item) => item.experiment_id === experiment.id);
+  const blueprint = blueprintContexts[experiment.id] ?? null;
+  let blueprintLink: PracticeBlueprintLink;
+  if (!experiment.source_stack_id && !experiment.source_action_id) {
+    blueprintLink = {
+      status: "independent",
+      stackId: null,
+      actionId: null,
+      priorityLabel: null,
+      explanation: "The member chose this practice independently of a Blueprint action.",
+    };
+  } else if (blueprint?.priority_label) {
+    blueprintLink = {
+      status: blueprint.is_current_blueprint ? "current" : "historical",
+      stackId: blueprint.source_stack_id,
+      actionId: blueprint.source_action_id,
+      priorityLabel: blueprint.priority_label,
+      explanation: blueprint.is_current_blueprint
+        ? "This practice is linked to a priority in the current Blueprint."
+        : "This practice is linked to a priority from an earlier Blueprint.",
+    };
+  } else {
+    blueprintLink = {
+      status: "unresolved",
+      stackId: experiment.source_stack_id,
+      actionId: experiment.source_action_id,
+      priorityLabel: null,
+      explanation: "A Blueprint reference is stored, but its priority could not be resolved.",
+    };
+  }
+
+  const provenance: MemberContextProvenance[] = [
+    { source: "weekly_experiments", recordId: experiment.id, updatedAt: experiment.updated_at },
+    ...recorded.map((item) => ({ source: "daily_practice_completions" as const, recordId: item.id, updatedAt: item.updated_at })),
+    ...(review ? [{ source: "weekly_experiment_reviews" as const, recordId: review.id, updatedAt: review.updated_at }] : []),
+  ];
+  return {
+    id: experiment.id,
+    identityDirection: experiment.identity_direction,
+    actionLabel: experiment.action_label,
+    cue: experiment.cue,
+    frequencyPerWeek: experiment.frequency_per_week,
+    minimumVersion: experiment.minimum_version,
+    weekStart: experiment.week_start,
+    status: experiment.status,
+    completionCount: recorded.length,
+    fullCompletionCount: recorded.filter((item) => item.completion_kind === "full").length,
+    minimumCompletionCount: recorded.filter((item) => item.completion_kind === "minimum").length,
+    review: review ? {
+      difficulty: review.difficulty,
+      valueRating: review.value_rating,
+      decision: review.decision,
+      status: review.status,
+      completedAt: review.completed_at,
+    } : null,
+    goalLink: {
+      status: "not_recorded",
+      goalLabel: null,
+      explanation: "The current schema does not store an explicit practice-to-saved-goal relation.",
+    },
+    blueprintLink,
+    provenance,
+  };
+}
+
+export function buildMemberIntelligenceContext(input: MemberIntelligenceContextInput): MemberIntelligenceContext {
+  const member = input.member
+    ? section<MemberIdentityContext>(
+      { id: input.member.id, tier: input.member.tier, joinedAt: input.member.joinedAt },
+      "present",
+      input.member.updatedAt,
+      [{ source: "users", recordId: input.member.id, updatedAt: input.member.updatedAt }],
+    )
+    : section<MemberIdentityContext | null>(null, "missing", null, [], "No member profile row was found.");
+  const healthProfile = input.healthProfile
+    ? section<MemberHealthProfileContext>(
+      {
+        age: input.healthProfile.age,
+        sex: input.healthProfile.sex,
+        conditions: input.healthProfile.conditions,
+        allergies: input.healthProfile.allergies,
+        procedures: input.healthProfile.procedures,
+        pregnant: input.healthProfile.pregnant,
+        dosingPreference: input.healthProfile.dosingPreference,
+        brandPreference: input.healthProfile.brandPreference,
+      },
+      "present",
+      input.healthProfile.updatedAt,
+      [{ source: "submissions", recordId: input.healthProfile.submissionId, updatedAt: input.healthProfile.updatedAt }],
+    )
+    : section<MemberHealthProfileContext | null>(null, "missing", null, [], "No intake health profile is currently available.");
+  const preferences = input.preferences
+    ? section<MemberPreferencesContext>(
+      {
+        preferredName: input.preferences.preferredName,
+        weightUnit: input.preferences.weightUnit,
+        reminderPreference: input.preferences.reminderPreference,
+        timezone: input.preferences.timezone,
+        cueHour: input.preferences.cueHour,
+        quietStartHour: input.preferences.quietStartHour,
+        quietEndHour: input.preferences.quietEndHour,
+      },
+      "present",
+      input.preferences.updatedAt,
+      [{ source: "user_preferences", recordId: input.member?.id ?? null, updatedAt: input.preferences.updatedAt }],
+    )
+    : section<MemberPreferencesContext | null>(null, "missing", null, [], "No saved member preferences were found.");
+
+  const blueprintGoals = input.blueprint?.goals ?? [];
+  const savedGoals = section(
+    input.savedGoals,
+    input.savedGoals.length ? "present" : "missing",
+    input.goalsUpdatedAt,
+    input.savedGoals.map((goal) => goal.provenance),
+    input.savedGoals.length ? null : "No explicit saved goals or targets were found.",
+  );
+  const blueprintGoalSection = section(
+    blueprintGoals,
+    blueprintGoals.length ? "present" : "missing",
+    input.blueprint?.created_at ?? null,
+    input.blueprint ? [{ source: "stacks", recordId: input.blueprint.stack_id, updatedAt: input.blueprint.created_at }] : [],
+    blueprintGoals.length ? null : "The current Blueprint does not contain structured goal rows.",
+  );
+  const blueprint = input.blueprint
+    ? section<CurrentBlueprintContext>(
+      input.blueprint,
+      input.blueprint.needs_refresh ? "stale" : "present",
+      input.blueprint.created_at,
+      [{ source: "stacks", recordId: input.blueprint.stack_id, updatedAt: input.blueprint.created_at }],
+    )
+    : section<CurrentBlueprintContext | null>(null, "missing", null, [], "No Blueprint is currently available.");
+
+  const practices = [...input.experiments]
+    .sort((left, right) => right.week_start.localeCompare(left.week_start) || right.updated_at.localeCompare(left.updated_at))
+    .map((experiment) => practiceContext(experiment, input.reviews, input.completions, input.practiceBlueprintContexts));
+  const active = practices.find((practice) => practice.status === "active") ?? null;
+  const activePractice = active
+    ? section<MemberPracticeContext>(active, "present", latestTimestamp(active.provenance.map((item) => item.updatedAt)), active.provenance)
+    : section<MemberPracticeContext | null>(null, "missing", null, [], "No active weekly practice is currently recorded.");
+  const history = practices.filter((practice) => practice.status !== "draft");
+  const historyProvenance = history.flatMap((practice) => practice.provenance);
+  const recentPracticeHistory = section(
+    history,
+    history.length ? "present" : "missing",
+    latestTimestamp(historyProvenance.map((item) => item.updatedAt)),
+    historyProvenance,
+    history.length ? null : "No active or completed practice history is currently recorded.",
+  );
+
+  const checkIns = input.checkIns.map((item): MemberCheckInContext => ({
+    date: item.log_date,
+    weight: item.weight,
+    sleep: item.sleep,
+    energy: item.energy,
+    provenance: { source: "logs", recordId: item.id, updatedAt: item.updated_at ?? item.log_date },
+  }));
+  const recentCheckIns = section(
+    checkIns,
+    checkIns.length ? "present" : "missing",
+    latestTimestamp(checkIns.map((item) => item.provenance.updatedAt)),
+    checkIns.map((item) => item.provenance),
+    checkIns.length ? null : "No recent weight, sleep, or energy check-ins were found.",
+  );
+  const safetyItems = input.safetyFindings.map((finding): MemberSafetyItemContext => ({
+    code: finding.code,
+    item: finding.item,
+    message: finding.message,
+    severity: finding.severity,
+    decision: finding.decision,
+    sourceUrl: finding.sourceUrl ?? null,
+    provenance: {
+      source: finding.source,
+      recordId: null,
+      updatedAt: input.generatedAt,
+    },
+  }));
+  const unresolvedSafetyItems = section(
+    safetyItems,
+    safetyItems.length || input.safetyEvaluationComplete ? "present" : "missing",
+    input.safetyEvaluationComplete || safetyItems.length ? input.generatedAt : null,
+    safetyItems.map((item) => item.provenance),
+    safetyItems.length || input.safetyEvaluationComplete ? null : "The deterministic safety evaluation was unavailable.",
+  );
+
+  const regimen: MemberRegimenContext = {
+    medications: regimenSection(input.regimen, "medication", "No active medications are currently recorded."),
+    hormones: regimenSection(input.regimen, "hormone", "No active hormones are currently recorded."),
+    supplements: regimenSection(input.regimen, "supplement", "No active supplements are currently recorded."),
+    endocrineActiveSupplements: regimenSection(input.regimen, "endocrine_active_supplement", "No active endocrine-active supplements are currently recorded."),
+  };
+  const trackedSections: Record<string, MemberContextSection<unknown>> = {
+    member,
+    healthProfile,
+    savedGoals,
+    blueprintGoals: blueprintGoalSection,
+    blueprint,
+    medications: regimen.medications,
+    hormones: regimen.hormones,
+    supplements: regimen.supplements,
+    endocrineActiveSupplements: regimen.endocrineActiveSupplements,
+    activePractice,
+    recentPracticeHistory,
+    recentCheckIns,
+    preferences,
+    unresolvedSafetyItems,
+  };
+  const updates = Object.values(trackedSections).map((item) => item.updatedAt);
+
+  return {
+    version: MEMBER_CONTEXT_VERSION,
+    member,
+    healthProfile,
+    goals: {
+      saved: savedGoals,
+      blueprint: blueprintGoalSection,
+      alignment: goalAlignment(input.savedGoals, blueprintGoals),
+    },
+    blueprint,
+    regimen,
+    activePractice,
+    recentPracticeHistory,
+    recentCheckIns,
+    preferences,
+    unresolvedSafetyItems,
+    contextFreshness: {
+      generatedAt: input.generatedAt,
+      staleSections: Object.entries(trackedSections).filter(([, value]) => value.status === "stale").map(([key]) => key),
+      missingSections: Object.entries(trackedSections).filter(([, value]) => value.status === "missing").map(([key]) => key),
+      latestRecordedUpdate: latestTimestamp(updates),
+    },
+  };
+}

--- a/src/lib/memberContextData.ts
+++ b/src/lib/memberContextData.ts
@@ -1,0 +1,245 @@
+import "server-only";
+
+import { applySafetyChecks } from "@/lib/safetyCheck";
+import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
+import { getCurrentRegimen } from "@/lib/currentRegimen";
+import {
+  buildMemberIntelligenceContext,
+  type MemberContextCheckInInput,
+  type MemberContextCompletionInput,
+  type MemberContextExperimentInput,
+  type MemberContextReviewInput,
+  type MemberGoalContext,
+  type MemberHealthProfileContext,
+  type MemberIntelligenceContext,
+  type MemberPreferencesContext,
+} from "@/lib/memberContext";
+import type { SafetyContext } from "@/lib/safetyEngine";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+type MemberRow = {
+  id: string;
+  tier: string;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type PreferencesRow = {
+  preferred_name: string | null;
+  weight_unit: string;
+  reminder_preference: string;
+  timezone: string;
+  cue_hour: number;
+  quiet_start_hour: number;
+  quiet_end_hour: number;
+  updated_at: string | null;
+};
+
+type SubmissionRow = {
+  id: string;
+  dob: string | null;
+  sex: string | null;
+  gender: string | null;
+  conditions: string | null;
+  allergies: string | null;
+  pregnant: string | null;
+  dosing_pref: string | null;
+  brand_pref: string | null;
+  engine_input_json: unknown;
+  updated_at: string | null;
+  created_at: string | null;
+};
+
+type GoalsRow = {
+  id: string;
+  goals: unknown;
+  custom_goal: string | null;
+  target_weight: number | string | null;
+  target_sleep: number | string | null;
+  target_energy: number | string | null;
+  updated_at: string | null;
+};
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function readableValues(value: unknown): string[] {
+  if (value == null) return [];
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).split(/[,;|\n]/).map((item) => item.replace(/\s+/g, " ").trim())
+      .filter((item) => item.length > 0 && !/^(?:none|no|n\/?a|not provided|unknown)$/i.test(item));
+  }
+  if (Array.isArray(value)) return [...new Set(value.flatMap(readableValues))];
+  const source = objectValue(value);
+  const named = source.name ?? source.label ?? source.text ?? source.value ?? source.answer
+    ?? source.condition_name ?? source.allergy_name ?? source.med_name;
+  if (named != null) return readableValues(named);
+  return [...new Set(Object.values(source).flatMap(readableValues))];
+}
+
+function cleanText(value: unknown, max = 160): string | null {
+  if (typeof value !== "string") return null;
+  return value.replace(/\s+/g, " ").trim().slice(0, max) || null;
+}
+
+function calculateAge(dob: string | null, now: Date): number | null {
+  if (!dob || !/^\d{4}-\d{2}-\d{2}$/.test(dob)) return null;
+  const born = new Date(`${dob}T00:00:00Z`);
+  if (Number.isNaN(born.getTime())) return null;
+  let age = now.getUTCFullYear() - born.getUTCFullYear();
+  const beforeBirthday = now.getUTCMonth() < born.getUTCMonth()
+    || (now.getUTCMonth() === born.getUTCMonth() && now.getUTCDate() < born.getUTCDate());
+  if (beforeBirthday) age -= 1;
+  return age >= 13 && age <= 120 ? age : null;
+}
+
+function numberOrNull(value: number | string | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const result = Number(value);
+  return Number.isFinite(result) ? result : null;
+}
+
+function healthProfile(row: SubmissionRow | null, now: Date): (MemberHealthProfileContext & { submissionId: string; updatedAt: string | null }) | null {
+  if (!row) return null;
+  const engine = objectValue(row.engine_input_json);
+  const client = objectValue(engine.client ?? engine);
+  return {
+    submissionId: row.id,
+    updatedAt: row.updated_at ?? row.created_at,
+    age: calculateAge(row.dob, now),
+    sex: cleanText(String(row.sex ?? row.gender ?? client.sex ?? client.gender ?? ""), 40),
+    conditions: [...new Set(readableValues(client.conditions ?? row.conditions))].slice(0, 24),
+    allergies: [...new Set(readableValues(client.allergies ?? row.allergies))].slice(0, 24),
+    procedures: [...new Set(readableValues(client.procedures ?? client.upcoming_procedures ?? client.surgeries))].slice(0, 16),
+    pregnant: typeof client.pregnant === "boolean" || typeof client.pregnant === "string" ? client.pregnant : row.pregnant,
+    dosingPreference: cleanText(String(row.dosing_pref ?? client.dosing_pref ?? ""), 100),
+    brandPreference: cleanText(String(row.brand_pref ?? client.brand_pref ?? ""), 100),
+  };
+}
+
+function savedGoals(row: GoalsRow | null): MemberGoalContext[] {
+  if (!row) return [];
+  const provenance = { source: "goals" as const, recordId: row.id, updatedAt: row.updated_at };
+  const named = [...new Set([...readableValues(row.goals), ...readableValues(row.custom_goal)])]
+    .map((label): MemberGoalContext => ({ label, kind: "named", targetValue: null, provenance }));
+  const targets: MemberGoalContext[] = [];
+  const weight = numberOrNull(row.target_weight);
+  const sleep = numberOrNull(row.target_sleep);
+  const energy = numberOrNull(row.target_energy);
+  if (weight != null) targets.push({ label: "Target weight", kind: "weight_target", targetValue: weight, provenance });
+  if (sleep != null) targets.push({ label: "Target sleep", kind: "sleep_target", targetValue: sleep, provenance });
+  if (energy != null) targets.push({ label: "Target energy", kind: "energy_target", targetValue: energy, provenance });
+  return [...named, ...targets];
+}
+
+function preferences(row: PreferencesRow | null): (MemberPreferencesContext & { updatedAt: string | null }) | null {
+  if (!row) return null;
+  return {
+    preferredName: cleanText(row.preferred_name, 80),
+    weightUnit: row.weight_unit === "kg" ? "kg" : "lb",
+    reminderPreference: row.reminder_preference === "email" ? "email" : "none",
+    timezone: row.timezone || "UTC",
+    cueHour: row.cue_hour,
+    quietStartHour: row.quiet_start_hour,
+    quietEndHour: row.quiet_end_hour,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function getMemberIntelligenceContext(userId: string): Promise<MemberIntelligenceContext> {
+  const admin = getSupabaseAdmin();
+  const now = new Date();
+  const generatedAt = now.toISOString();
+  const [
+    memberResult,
+    preferenceResult,
+    submissionResult,
+    goalsResult,
+    blueprint,
+    regimen,
+    experimentResult,
+    checkInResult,
+  ] = await Promise.all([
+    admin.from("users").select("id,tier,created_at,updated_at").eq("id", userId).maybeSingle(),
+    admin.from("user_preferences")
+      .select("preferred_name,weight_unit,reminder_preference,timezone,cue_hour,quiet_start_hour,quiet_end_hour,updated_at")
+      .eq("user_id", userId).maybeSingle(),
+    admin.from("submissions")
+      .select("id,dob,sex,gender,conditions,allergies,pregnant,dosing_pref,brand_pref,engine_input_json,updated_at,created_at")
+      .eq("user_id", userId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    admin.from("goals").select("id,goals,custom_goal,target_weight,target_sleep,target_energy,updated_at")
+      .eq("user_id", userId).maybeSingle(),
+    getCurrentBlueprintContext(userId),
+    getCurrentRegimen(userId),
+    admin.from("weekly_experiments")
+      .select("id,source_stack_id,source_action_id,identity_direction,action_label,cue,frequency_per_week,minimum_version,status,week_start,created_at,updated_at")
+      .eq("user_id", userId).order("week_start", { ascending: false }).limit(12),
+    admin.from("logs").select("id,log_date,weight,sleep,energy,updated_at")
+      .eq("user_id", userId).order("log_date", { ascending: false }).limit(30),
+  ]);
+  for (const result of [memberResult, preferenceResult, submissionResult, goalsResult, experimentResult, checkInResult]) {
+    if (result.error) throw result.error;
+  }
+
+  const experiments = (experimentResult.data ?? []) as MemberContextExperimentInput[];
+  const experimentIds = experiments.map((item) => item.id);
+  let reviews: MemberContextReviewInput[] = [];
+  let completions: MemberContextCompletionInput[] = [];
+  if (experimentIds.length) {
+    const [reviewResult, completionResult] = await Promise.all([
+      admin.from("weekly_experiment_reviews")
+        .select("id,experiment_id,difficulty,value_rating,decision,status,completed_at,updated_at")
+        .eq("user_id", userId).in("experiment_id", experimentIds),
+      admin.from("daily_practice_completions")
+        .select("id,experiment_id,completion_date,completion_kind,updated_at")
+        .eq("user_id", userId).in("experiment_id", experimentIds),
+    ]);
+    if (reviewResult.error || completionResult.error) throw reviewResult.error ?? completionResult.error;
+    reviews = (reviewResult.data ?? []) as MemberContextReviewInput[];
+    completions = (completionResult.data ?? []) as MemberContextCompletionInput[];
+  }
+
+  const profile = healthProfile(submissionResult.data as SubmissionRow | null, now);
+  const safetyContext: SafetyContext = {
+    medications: regimen.filter((item) => item.item_kind === "medication").map((item) => item.name),
+    conditions: profile?.conditions ?? [],
+    allergies: profile?.allergies ?? [],
+    procedures: profile?.procedures ?? [],
+    pregnant: profile?.pregnant ?? null,
+  };
+  const currentSupplementCandidates = regimen
+    .filter((item) => item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement")
+    .map((item) => ({ name: item.name, dose: item.dose, is_current: true }));
+  const [safety, practiceBlueprintContexts] = await Promise.all([
+    currentSupplementCandidates.length
+      ? applySafetyChecks(safetyContext, currentSupplementCandidates)
+      : Promise.resolve({ complete: true, findings: [] }),
+    getExperimentBlueprintContexts(userId, experiments, blueprint),
+  ]);
+  const memberRow = memberResult.data as MemberRow | null;
+  const goalsRow = goalsResult.data as GoalsRow | null;
+
+  return buildMemberIntelligenceContext({
+    generatedAt,
+    member: memberRow ? {
+      id: memberRow.id,
+      tier: memberRow.tier,
+      joinedAt: memberRow.created_at,
+      updatedAt: memberRow.updated_at ?? memberRow.created_at,
+    } : null,
+    healthProfile: profile,
+    preferences: preferences(preferenceResult.data as PreferencesRow | null),
+    savedGoals: savedGoals(goalsRow),
+    goalsUpdatedAt: goalsRow?.updated_at ?? null,
+    blueprint,
+    regimen,
+    experiments,
+    reviews,
+    completions,
+    practiceBlueprintContexts,
+    checkIns: (checkInResult.data ?? []) as MemberContextCheckInInput[],
+    safetyFindings: safety.findings,
+    safetyEvaluationComplete: safety.complete,
+  });
+}


### PR DESCRIPTION
## Purpose

Establish the typed KNOW layer for the LVE360 Trust-to-Intelligence program.

Member facts are currently assembled separately for Ask LVE360, Today, Journey, weekly synthesis, Blueprint, and Routine. That fragmentation makes it possible for features to see different slices of the same member and for regimen types or goal sources to be flattened accidentally.

## Root cause

The app already has strong domain sources, especially `current_regimen_items` and current Blueprint context, but no single typed contract combines:

- member and intake context
- saved goals and Blueprint goals
- medications, hormones, supplements, and endocrine-active supplements
- active practice and recent practice history
- completions, reviews, and check-ins
- preferences
- deterministic safety findings
- provenance, missingness, and freshness

## Architecture

- Adds pure `buildMemberIntelligenceContext` assembly with a versioned contract.
- Adds server-only `getMemberIntelligenceContext(userId)` loader.
- Preserves regimen types as distinct collections.
- Keeps saved goals separate from Blueprint goals and reports source alignment.
- Represents absent doses, timing, goals, records, and practice linkage explicitly.
- Captures existing Blueprint links while reporting practice-to-saved-goal linkage as not recorded because the current schema has no such relation.
- Reuses the existing deterministic safety engine for current findings.
- Adds structured Blueprint goals to the existing Blueprint context.
- Keeps the loader read-only and inaccessible to client code.

## Behavior change

No user-facing feature consumes the new context in this PR. Existing behavior is intentionally unchanged.

PR109 will migrate Ask LVE360 to an intent-scoped adapter over this contract after PR108 review.

## Files changed

- `src/lib/memberContext.ts`
- `src/lib/memberContextData.ts`
- `src/lib/blueprintContext.ts`
- `src/lib/currentBlueprintContext.ts`
- `src/_tests_/pr108MemberContext.assert.ts`
- `src/_tests_/pr108Architecture.assert.mjs`
- `docs/member-intelligence-context.md`
- `package.json`

## Verification

Passed:

- `npm.cmd run qa:pr108`
- `npm.cmd run typecheck`
- `npm.cmd run qa:pr107`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:journey`
- `npm.cmd run qa:blueprint-safety`
- `npm.cmd run qa:safety-engine`
- `git diff --check`
- Next.js production compilation and lint/type validation

Representative context tests cover:

1. simple four-item regimen
2. moderate regimen
3. complex 24-item regimen without truncation
4. no supplements
5. no medications
6. stale Blueprint
7. different or missing goal sources
8. active and absent weekly practice

## What was not verified locally

The final static prerender step cannot complete in this checkout because launch secrets are intentionally absent from `.env.local`. `qa:env` correctly reported the missing Supabase, Stripe, OpenAI, Tally, and cron values. Vercel Preview is the runtime build authority because it has environment-specific configuration.

There is no new user-facing UI to screenshot.

## Database and migration impact

None.

- no migration
- no backfill
- no RLS or grants change
- no new environment variable
- no production data mutation

The live Supabase schema was inspected before implementation. The loader uses current table and column names, including `user_preferences` and `weekly_experiment_reviews`.

## Safety considerations

- The context never changes medications, hormones, supplements, schedules, or saved records.
- Missing facts stay missing.
- Existing deterministic safety findings are exposed without inventing provenance.
- Safety rule correction, nutrient unit conversion, and deeper provenance remain scoped to PR111.
- No diagnosis, treatment, or medication-management behavior is introduced.

## Risks

- Once adopted, the full context performs several reads. Consumers should build one snapshot per request and avoid duplicate loads.
- Goal alignment is exact-record alignment, not a semantic or clinical judgment.
- Legacy safety rule quality is unchanged.

## Rollback

Revert commit `3de38c8`. No database rollback is needed.

## Not included

- coaching intent changes
- deterministic factual answer rendering
- task-success quality validation
- safety rule or unit-conversion changes
- Today/Journey/UI changes
- recommendation-to-action mutations
- adaptive weekly synthesis
