### PR TITLE
PR109: Make coaching intent-first and factual retrieval deterministic

### DIFF
--- a/app/api/coach/route.ts
+++ b/app/api/coach/route.ts
@@ -5,12 +5,13 @@ import { NextResponse, type NextRequest } from "next/server";
 import { buildCoachContext, generateCoachAnswer, type CoachDiagnostics } from "@/lib/ai/contextualCoachData";
 import {
   COACH_PROMPT_VERSION,
-  classifyCoachIntent,
+  classifyCoachRequest,
   cleanCoachQuestion,
   coachBoundaryAnswer,
   coachPageFromPath,
   coachSafetyBoundary,
   isCoachFeedback,
+  storedCoachIntent,
   type CoachSource,
   type CoachTurn,
 } from "@/lib/contextualCoach";
@@ -95,7 +96,15 @@ export async function POST(req: NextRequest) {
     const question = cleanCoachQuestion(body?.question);
     if (!question) return NextResponse.json({ ok: false, error: "invalid_question" }, { status: 400 });
     const page = coachPageFromPath(body?.pathname);
-    const intent = classifyCoachIntent(question);
+    const routing = classifyCoachRequest(question);
+    const intent = routing.intent;
+    const persistedIntent = storedCoachIntent(intent);
+    console.info("[coach.route]", {
+      intent,
+      constraints: routing.constraints,
+      requestedRegimenKinds: routing.requestedRegimenKinds,
+      page,
+    });
     const boundary = coachSafetyBoundary(question);
     if (boundary || intent === "POTENTIAL_MEDICAL_RED_FLAG") {
       const turn = await saveTurn(auth.user.id, {
@@ -105,7 +114,7 @@ export async function POST(req: NextRequest) {
         response_source: "safety",
         generation_status: "blocked",
         source_refs: [],
-        intent,
+        intent: persistedIntent,
         quality_score: 100,
         safety_rule_count: 1,
       });
@@ -121,12 +130,12 @@ export async function POST(req: NextRequest) {
         response_source: "budget",
         generation_status: "limited",
         source_refs: [],
-        intent,
+        intent: persistedIntent,
       });
       return NextResponse.json({ ok: true, turn, usage: await usage(auth.user.id) });
     }
 
-    const context = await buildCoachContext(auth.user.id, page, question, intent);
+    const context = await buildCoachContext(auth.user.id, page, question, routing);
     const { data: pending, error: pendingError } = await getSupabaseAdmin().from("ai_coaching_turns").insert({
       user_id: auth.user.id,
       page_context: page,
@@ -136,7 +145,7 @@ export async function POST(req: NextRequest) {
       generation_status: "pending",
       prompt_version: COACH_PROMPT_VERSION,
       source_refs: context.sources,
-      intent,
+      intent: persistedIntent,
       evidence_ids: context.evidenceOptions.map((option) => option.id),
     }).select("id").single();
     if (pendingError) throw pendingError;
@@ -147,6 +156,7 @@ export async function POST(req: NextRequest) {
     let generationStatus: CoachTurn["generation_status"] = "failed";
     let diagnostics: CoachDiagnostics = {
       intent,
+      constraints: routing.constraints,
       qualityScore: 0,
       safetyRuleCount: context.preSafety?.findings.length ?? 0,
       recommendationsRemoved: 0,
@@ -171,7 +181,7 @@ export async function POST(req: NextRequest) {
       source_refs: sourceRefs,
       response_source: responseSource,
       generation_status: generationStatus,
-      intent: diagnostics.intent,
+      intent: storedCoachIntent(diagnostics.intent),
       quality_score: diagnostics.qualityScore,
       safety_rule_count: diagnostics.safetyRuleCount,
       recommendations_removed: diagnostics.recommendationsRemoved,

--- a/docs/coach-intent-routing.md
+++ b/docs/coach-intent-routing.md
@@ -1,0 +1,38 @@
+# Ask LVE360 intent-first routing
+
+PR109 changes the coaching request path to:
+
+1. Classify the member's requested job.
+2. Capture explicit regimen constraints separately from the job.
+3. Select only the context required for that job.
+4. Retrieve exact saved facts from the canonical member context.
+5. Use deterministic rendering for factual and bounded tasks.
+6. Retrieve curated supplement evidence only for evidence-oriented jobs.
+7. Use model synthesis only when interpretation adds value.
+
+## Deterministic tasks
+
+The model does not compose answers for:
+
+- medication, hormone, supplement, or combined regimen lookup
+- current deterministic safety-review findings
+- missing-context analysis
+- highest-value weekly prioritization when an active practice is available
+- the poor-sleep behavioral regression with explicit regimen exclusions
+- out-of-scope requests
+
+Missing dose, timing, and schedule fields remain explicitly missing. Requested regimen categories are never replaced by other item types.
+
+## Constraints
+
+Phrases such as “without changing my medications or supplements” are represented independently from intent. The deterministic path enforces them directly, and any model path receives them as hard prompt constraints. Medication and hormone changes remain behind the existing safety boundary.
+
+## Context and evidence
+
+Ask LVE360 now builds one `MemberIntelligenceContext` snapshot per request. The coach adapter exposes only the sections required by the resolved intent. Behavioral, progress, prioritization, safety-review, and missing-context requests do not retrieve supplement evidence by default.
+
+## Diagnostics compatibility
+
+Detailed routing metadata is emitted to privacy-safe server logs without the member's question or health facts. The database keeps the existing coarse intent values so PR109 does not require a migration or break current Preview and Production schemas. Prompt telemetry is aligned on `contextual-coach-v3`.
+
+Task-success scoring remains PR110. PR109 intentionally does not redesign the existing quality score.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "qa:pr106": "node src/_tests_/pr106CoachWorkspace.assert.mjs",
     "qa:pr107": "node --experimental-strip-types src/_tests_/pr107CoachingEngine.assert.ts && node src/_tests_/pr107Architecture.assert.mjs",
     "qa:pr108": "node --experimental-strip-types src/_tests_/pr108MemberContext.assert.ts && node src/_tests_/pr108Architecture.assert.mjs",
+    "qa:pr109": "node --experimental-strip-types src/_tests_/pr109IntentRouting.assert.ts && node src/_tests_/pr109Architecture.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr107Architecture.assert.mjs
+++ b/src/_tests_/pr107Architecture.assert.mjs
@@ -18,7 +18,7 @@ assert.match(data, /requiresReviewBeforeStart/, "A non-current recommendation wi
 assert.match(data, /isCurrentRecommendation/, "An already-recorded recommendation must not become an instruction to add a duplicate.");
 assert.match(data, /explicitlyNamedEvidenceOption/, "A direct question about a named option must stay focused on that option.");
 assert.match(data, /Keep your saved Routine unchanged until that review is complete/, "Safety-review recommendations must hand off to a clinician or pharmacist before a new start.");
-assert.match(route, /classifyCoachIntent\(question\)/, "The API must classify intent before context assembly.");
+assert.match(route, /classifyCoachRequest\(question\)/, "The API must classify intent and constraints before context assembly.");
 assert.match(route, /quality_score/, "The API must persist privacy-safe quality diagnostics.");
 assert.match(migration, /service-role only/i, "The additive migration must preserve server-only writes and existing RLS.");
 assert.match(coach, /health record, evidence library, and safety rules/i, "The UI must describe all four product layers accurately.");

--- a/src/_tests_/pr107CoachingEngine.assert.ts
+++ b/src/_tests_/pr107CoachingEngine.assert.ts
@@ -67,7 +67,7 @@ const missingDataButUseful: StructuredCoachAnswer = {
 };
 assert.equal(assessCoachAnswerQuality({ answer: missingDataButUseful, supplementQuestion: true, safetyChecked: true, usedMemberContext: false }).passed, true, "Scenario 5: missing user data must not force an abstention.");
 
-assert.equal(classifyCoachIntent("What supplements am I currently taking at night?"), "CURRENT_PLAN_LOOKUP", "Scenario 6: current-plan lookup must stay record-based.");
+assert.equal(classifyCoachIntent("What supplements am I currently taking at night?"), "SUPPLEMENT_LOOKUP", "Scenario 6: current-plan lookup must stay record-based and type-specific.");
 assert.equal(classifyCoachIntent("Add glycine to my stack."), "REQUEST_TO_CHANGE_RECORD", "Scenario 7: mutation language must enter the controlled workflow.");
 assert.equal(coachSafetyBoundary("Add glycine to my stack."), null, "Scenario 7: discussing a supplement record request must not be mistaken for a prescribed-plan change.");
 assert.equal(classifyCoachIntent("I have chest pain and can't breathe"), "POTENTIAL_MEDICAL_RED_FLAG", "Scenario 8: a serious issue must stop normal coaching.");

--- a/src/_tests_/pr109Architecture.assert.mjs
+++ b/src/_tests_/pr109Architecture.assert.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const route = readFileSync("app/api/coach/route.ts", "utf8");
+const coach = readFileSync("src/lib/ai/contextualCoachData.ts", "utf8");
+const intent = readFileSync("src/lib/contextualCoach.ts", "utf8");
+const modelConfig = readFileSync("src/lib/ai/modelConfig.ts", "utf8");
+
+assert.match(route, /classifyCoachRequest\(question\)/, "The API must resolve intent and constraints before context retrieval.");
+assert.match(route, /buildCoachContext\(auth\.user\.id, page, question, routing\)/, "The routing decision must control context retrieval.");
+assert.match(route, /console\.info\("\[coach\.route\]"/, "Detailed intent and constraints must be observable without logging the question or health facts.");
+assert.match(route, /storedCoachIntent\(diagnostics\.intent\)/, "Detailed routing must remain compatible with the deployed diagnostics constraint.");
+
+assert.match(coach, /getMemberIntelligenceContext\(userId\)/, "Ask LVE360 must consume the PR108 canonical member context.");
+assert.doesNotMatch(coach, /getCurrentRegimen\(/, "Ask LVE360 must not rebuild a parallel regimen context.");
+assert.doesNotMatch(coach, /getCurrentBlueprintContext\(/, "Ask LVE360 must not rebuild a parallel Blueprint context.");
+assert.match(coach, /BEHAVIORAL_COACHING:\s*\["weekly_practice", "recent_check_ins", "goals", "preferences", "recent_coaching"\]/, "Behavioral coaching must not retrieve supplement evidence by default.");
+assert.match(coach, /SAFETY_REVIEW:\s*\["safety_review", "current_routine", "health_profile"\]/, "Safety review must use deterministic findings and member context.");
+assert.match(coach, /deterministicCoachTask\(routing, context\.memberContext, question\)/, "Deterministic tasks must run before model generation.");
+
+assert.match(intent, /preserveMedicationPlan/);
+assert.match(intent, /preserveSupplementPlan/);
+assert.match(intent, /CURRENT_REGIMEN_LOOKUP/);
+assert.match(intent, /OUT_OF_SCOPE/);
+assert.match(intent, /contextual-coach-v3/);
+assert.match(modelConfig, /promptVersion:\s*"contextual-coach-v3"/, "Runtime ledger and saved-turn prompt versions must agree.");
+
+console.log("PR109 intent-first coaching architecture checks passed.");

--- a/src/_tests_/pr109IntentRouting.assert.ts
+++ b/src/_tests_/pr109IntentRouting.assert.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+
+import { deterministicCoachTask } from "../lib/coachIntent.ts";
+import {
+  classifyCoachRequest,
+  storedCoachIntent,
+  type CoachRoutingDecision,
+} from "../lib/contextualCoach.ts";
+import type { CurrentRegimenItem, CurrentRegimenKind } from "../lib/currentRegimenModel.ts";
+import {
+  buildMemberIntelligenceContext,
+  type MemberIntelligenceContextInput,
+} from "../lib/memberContext.ts";
+
+const NOW = "2026-08-14T12:00:00.000Z";
+
+function regimenItem(index: number, kind: CurrentRegimenKind, overrides: Partial<CurrentRegimenItem> = {}): CurrentRegimenItem {
+  const name = overrides.name ?? `${kind} ${index}`;
+  return {
+    id: `regimen-${index}`,
+    user_id: "member-1",
+    source_submission_id: "submission-1",
+    source_stack_item_id: null,
+    item_kind: kind,
+    name,
+    normalized_name: name.toLowerCase(),
+    purpose: null,
+    dose: null,
+    timing: null,
+    brand: null,
+    reorder_url: null,
+    image_url: null,
+    product_source: null,
+    product_sku: null,
+    instruction_source: "intake",
+    instruction_authority: null,
+    schedule: null,
+    active: true,
+    created_at: "2026-08-01T12:00:00.000Z",
+    updated_at: "2026-08-13T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function memberInput(overrides: Partial<MemberIntelligenceContextInput> = {}): MemberIntelligenceContextInput {
+  return {
+    generatedAt: NOW,
+    member: { id: "member-1", tier: "premium", joinedAt: "2026-07-01T12:00:00.000Z", updatedAt: NOW },
+    healthProfile: {
+      submissionId: "submission-1",
+      updatedAt: NOW,
+      age: 52,
+      sex: "male",
+      conditions: ["Hypertension"],
+      allergies: [],
+      procedures: [],
+      pregnant: null,
+      dosingPreference: null,
+      brandPreference: null,
+    },
+    preferences: {
+      preferredName: "Luke",
+      weightUnit: "lb",
+      reminderPreference: "email",
+      timezone: "America/Denver",
+      cueHour: 6,
+      quietStartHour: 21,
+      quietEndHour: 5,
+      updatedAt: NOW,
+    },
+    savedGoals: [{
+      label: "Improve sleep and energy",
+      kind: "named",
+      targetValue: null,
+      provenance: { source: "goals", recordId: "goal-1", updatedAt: NOW },
+    }],
+    goalsUpdatedAt: NOW,
+    blueprint: {
+      stack_id: "stack-1",
+      created_at: "2026-08-10T12:00:00.000Z",
+      goals: ["Improve sleep and energy"],
+      safety_status: "review",
+      safety_acknowledged: false,
+      needs_refresh: false,
+      priorities: [{ id: "priority-1", label: "Keep a consistent wake time", category: "sleep", kind: "lifestyle" }],
+    },
+    regimen: [
+      regimenItem(1, "medication", { name: "Zepbound", dose: "10 mg/0.5 mL", timing: "Sunday morning" }),
+      regimenItem(2, "medication", { name: "Lisinopril", dose: "10 mg", timing: "morning" }),
+      regimenItem(3, "hormone", { name: "Testosterone cypionate", dose: "80 mg", timing: "twice weekly" }),
+      regimenItem(4, "supplement", { name: "Magnesium glycinate", dose: "200 mg", timing: "evening" }),
+      regimenItem(5, "endocrine_active_supplement", { name: "DHEA" }),
+    ],
+    experiments: [{
+      id: "experiment-1",
+      source_stack_id: "stack-1",
+      source_action_id: "priority-1",
+      identity_direction: "sleep",
+      action_label: "Keep a consistent wake time",
+      cue: "After my alarm",
+      frequency_per_week: 5,
+      minimum_version: "Get out of bed at the planned time",
+      status: "active",
+      week_start: "2026-08-10",
+      created_at: "2026-08-10T12:00:00.000Z",
+      updated_at: NOW,
+    }],
+    reviews: [],
+    completions: [{ id: "completion-1", experiment_id: "experiment-1", completion_date: "2026-08-12", completion_kind: "full", updated_at: NOW }],
+    practiceBlueprintContexts: {
+      "experiment-1": {
+        source_stack_id: "stack-1",
+        source_action_id: "priority-1",
+        priority_label: "Keep a consistent wake time",
+        priority_category: "sleep",
+        priority_kind: "lifestyle",
+        blueprint_created_at: "2026-08-10T12:00:00.000Z",
+        is_current_blueprint: true,
+        needs_review: false,
+      },
+    },
+    checkIns: [{ id: "log-1", log_date: "2026-08-13", weight: 200, sleep: 2, energy: 5, updated_at: NOW }],
+    safetyFindings: [{
+      code: "interaction_anticoagulant",
+      item: "Omega-3",
+      message: "Review possible additive bleeding risk with the recorded anticoagulant.",
+      severity: "danger",
+      decision: "blocked",
+      source: "interactions",
+      sourceUrl: "https://example.com/source",
+    }],
+    safetyEvaluationComplete: true,
+    ...overrides,
+  };
+}
+
+const context = buildMemberIntelligenceContext(memberInput());
+
+const regimenPrompt = "What medications and hormones do I currently have saved, including doses and timing?";
+const regimenRoute = classifyCoachRequest(regimenPrompt);
+assert.equal(regimenRoute.intent, "CURRENT_REGIMEN_LOOKUP");
+assert.deepEqual(regimenRoute.requestedRegimenKinds, ["medication", "hormone"]);
+const regimenAnswer = deterministicCoachTask(regimenRoute, context, regimenPrompt);
+assert.ok(regimenAnswer);
+assert.match(regimenAnswer.answer, /Zepbound.*10 mg\/0\.5 mL.*Sunday morning/s);
+assert.match(regimenAnswer.answer, /Lisinopril.*10 mg.*morning/s);
+assert.match(regimenAnswer.answer, /Testosterone cypionate.*80 mg.*twice weekly/s);
+assert.doesNotMatch(regimenAnswer.answer, /Magnesium glycinate/);
+
+const safetyPrompt = "Which items in my current routine need clinician or pharmacist review, and why?";
+const safetyRoute = classifyCoachRequest(safetyPrompt);
+assert.equal(safetyRoute.intent, "SAFETY_REVIEW", "Safety meaning must outrank inventory wording.");
+const safetyAnswer = deterministicCoachTask(safetyRoute, context, safetyPrompt);
+assert.ok(safetyAnswer);
+assert.match(safetyAnswer.answer, /Omega-3/);
+assert.match(safetyAnswer.answer, /bleeding risk/);
+
+const priorityPrompt = "Based on my saved goals, recent check-ins, and active weekly practice, what is the highest-value action I should focus on this week?";
+const priorityRoute = classifyCoachRequest(priorityPrompt);
+assert.equal(priorityRoute.intent, "PRIORITIZATION");
+const priorityAnswer = deterministicCoachTask(priorityRoute, context, priorityPrompt);
+assert.ok(priorityAnswer);
+assert.match(priorityAnswer.answer, /Keep a consistent wake time/);
+assert.match(priorityAnswer.answer, /1 of 5 planned completions/);
+assert.doesNotMatch(priorityAnswer.answer, /magnesium|glycine|melatonin/i);
+
+const behaviorPrompt = "I slept poorly last night. How should I adjust tomorrow without changing my medications or supplements?";
+const behaviorRoute = classifyCoachRequest(behaviorPrompt);
+assert.equal(behaviorRoute.intent, "BEHAVIORAL_COACHING");
+assert.equal(behaviorRoute.constraints.preserveMedicationPlan, true);
+assert.equal(behaviorRoute.constraints.preserveSupplementPlan, true);
+const behaviorAnswer = deterministicCoachTask(behaviorRoute, context, behaviorPrompt);
+assert.ok(behaviorAnswer);
+assert.match(behaviorAnswer.answer, /medications and supplements unchanged/i);
+assert.doesNotMatch(behaviorAnswer.answer, /(?:start|stop|add|increase|decrease|switch).{0,30}(?:medication|supplement)/i);
+
+const missingPrompt = "What important information is missing from my profile that would make your recommendations better?";
+const missingRoute = classifyCoachRequest(missingPrompt);
+assert.equal(missingRoute.intent, "MISSING_CONTEXT");
+const missingAnswer = deterministicCoachTask(missingRoute, context, missingPrompt);
+assert.ok(missingAnswer);
+assert.match(missingAnswer.answer, /missing dose for DHEA/i);
+assert.doesNotMatch(missingAnswer.answer, /health profile.*missing/i, "Existing profile data must not be mislabeled as missing.");
+
+const outsidePrompt = "What is the capital of France?";
+const outsideRoute = classifyCoachRequest(outsidePrompt);
+assert.equal(outsideRoute.intent, "OUT_OF_SCOPE");
+assert.match(deterministicCoachTask(outsideRoute, context, outsidePrompt)?.answer ?? "", /focused on your saved health/i);
+
+const typoRoute = classifyCoachRequest("Show my meds and hormons with dose and timing");
+assert.equal(typoRoute.intent, "CURRENT_REGIMEN_LOOKUP", "Common shorthand and a minor typo must still route correctly.");
+assert.deepEqual(typoRoute.requestedRegimenKinds, ["medication", "hormone"]);
+
+const mixedRoute = classifyCoachRequest("List my routine items that need a pharmasist review because of safety interactions");
+assert.equal(mixedRoute.intent, "SAFETY_REVIEW", "Mixed inventory and safety wording must preserve the safety job.");
+
+assert.equal(storedCoachIntent(regimenRoute.intent), "CURRENT_PLAN_LOOKUP", "Detailed routing remains compatible with the deployed diagnostics constraint.");
+
+const noSafetyContext = buildMemberIntelligenceContext(memberInput({ safetyFindings: [], safetyEvaluationComplete: true }));
+const noSafetyAnswer = deterministicCoachTask(safetyRoute, noSafetyContext, safetyPrompt);
+assert.match(noSafetyAnswer?.answer ?? "", /not identify an unresolved/i);
+assert.match(noSafetyAnswer?.answer ?? "", /not a guarantee/i);
+
+const routeShape: CoachRoutingDecision = classifyCoachRequest("What supplements am I currently taking?");
+assert.equal(routeShape.intent, "SUPPLEMENT_LOOKUP");
+assert.deepEqual(routeShape.requestedRegimenKinds, ["supplement", "endocrine_active_supplement"]);
+
+console.log("PR109 intent-first coaching and deterministic retrieval scenarios passed.");

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -1,20 +1,23 @@
 import "server-only";
 
-import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
 import { generateAI } from "@/lib/ai/gateway";
 import { evidenceOptionByName, retrieveCoachEvidence, type CoachEvidenceOption } from "@/lib/coachEvidence";
+import { deterministicCoachTask } from "@/lib/coachIntent";
 import {
   assessCoachAnswerQuality,
   parseStructuredCoachAnswer,
+  type CoachConstraints,
   type CoachIntent,
   type CoachPage,
   type CoachQualityReport,
+  type CoachRegimenKind,
+  type CoachRoutingDecision,
   type CoachSource,
   type StructuredCoachAnswer,
 } from "@/lib/contextualCoach";
-import { getCurrentBlueprintContext } from "@/lib/currentBlueprintContext";
-import { getCurrentRegimen } from "@/lib/currentRegimen";
 import { healthItemIdentityKey } from "@/lib/healthItemIdentity";
+import type { MemberIntelligenceContext, MemberRegimenItemContext } from "@/lib/memberContext";
+import { getMemberIntelligenceContext } from "@/lib/memberContextData";
 import { applySafetyChecks, type AppliedSafetyResult } from "@/lib/safetyCheck";
 import type { SafetyContext } from "@/lib/safetyEngine";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
@@ -22,6 +25,9 @@ import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 export type CoachContext = {
   page: CoachPage;
   intent: CoachIntent;
+  constraints: CoachConstraints;
+  requestedRegimenKinds: CoachRegimenKind[];
+  memberContext: MemberIntelligenceContext;
   sources: CoachSource[];
   facts: Record<string, unknown>;
   evidenceOptions: CoachEvidenceOption[];
@@ -31,6 +37,7 @@ export type CoachContext = {
 
 export type CoachDiagnostics = {
   intent: CoachIntent;
+  constraints: CoachConstraints;
   qualityScore: number;
   safetyRuleCount: number;
   recommendationsRemoved: number;
@@ -41,7 +48,17 @@ export type CoachDiagnostics = {
 const INTENT_SOURCE_IDS: Record<CoachIntent, string[]> = {
   GENERAL_EDUCATION: ["evidence", "current_routine", "health_profile", "recent_coaching"],
   PERSONALIZED_RECOMMENDATION: ["evidence", "current_routine", "health_profile", "goals", "recent_check_ins", "current_blueprint", "recent_coaching"],
+  CURRENT_REGIMEN_LOOKUP: ["current_routine"],
+  MEDICATION_LOOKUP: ["current_routine"],
+  HORMONE_LOOKUP: ["current_routine"],
+  SUPPLEMENT_LOOKUP: ["current_routine"],
   CURRENT_PLAN_LOOKUP: ["current_routine"],
+  SAFETY_REVIEW: ["safety_review", "current_routine", "health_profile"],
+  BEHAVIORAL_COACHING: ["weekly_practice", "recent_check_ins", "goals", "preferences", "recent_coaching"],
+  PRIORITIZATION: ["weekly_practice", "recent_check_ins", "goals", "current_blueprint"],
+  MISSING_CONTEXT: ["context_status", "current_routine", "goals", "health_profile", "weekly_practice", "recent_check_ins", "preferences"],
+  EVIDENCE_COMPARISON: ["evidence", "current_routine", "health_profile", "goals", "recent_coaching"],
+  OUT_OF_SCOPE: [],
   OPTION_COMPARISON: ["evidence", "current_routine", "health_profile", "goals", "recent_check_ins", "recent_coaching"],
   PLAN_EXPLANATION: ["current_blueprint", "current_routine", "goals", "recent_coaching"],
   TIMING_OR_DOSING: ["evidence", "current_routine", "health_profile", "recent_coaching"],
@@ -50,64 +67,21 @@ const INTENT_SOURCE_IDS: Record<CoachIntent, string[]> = {
   POTENTIAL_MEDICAL_RED_FLAG: [],
 };
 
-const FACT_KEY_BY_SOURCE: Record<string, string> = {
-  current_blueprint: "blueprint",
-  current_routine: "routine",
-  weekly_practice: "weekly_practice",
-  recent_check_ins: "recent_check_ins",
-  goals: "goals",
-  health_profile: "health_profile",
-  recent_coaching: "recent_coaching",
-};
-
 function compact(value: string | null | undefined, length = 160) {
   return value?.replace(/\s+/g, " ").trim().slice(0, length) || null;
 }
 
-function objectValue(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+function regimenItems(context: MemberIntelligenceContext): MemberRegimenItemContext[] {
+  return [
+    ...context.regimen.medications.value,
+    ...context.regimen.hormones.value,
+    ...context.regimen.supplements.value,
+    ...context.regimen.endocrineActiveSupplements.value,
+  ];
 }
 
-function readableValues(value: unknown): string[] {
-  if (value == null) return [];
-  if (typeof value === "string" || typeof value === "number") {
-    return String(value).split(/[,;|\n]/).map((item) => item.replace(/\s+/g, " ").trim())
-      .filter((item) => item.length > 0 && !/^(?:none|no|n\/?a|not provided|unknown)$/i.test(item));
-  }
-  if (Array.isArray(value)) return [...new Set(value.flatMap(readableValues))];
-  const source = objectValue(value);
-  const named = source.name ?? source.label ?? source.text ?? source.value ?? source.answer
-    ?? source.condition_name ?? source.allergy_name ?? source.med_name;
-  if (named != null) return readableValues(named);
-  return [...new Set(Object.values(source).flatMap(readableValues))];
-}
-
-function calculateAge(dob: unknown) {
-  if (typeof dob !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(dob)) return null;
-  const born = new Date(`${dob}T00:00:00Z`);
-  if (Number.isNaN(born.getTime())) return null;
-  const now = new Date();
-  let age = now.getUTCFullYear() - born.getUTCFullYear();
-  const beforeBirthday = now.getUTCMonth() < born.getUTCMonth()
-    || (now.getUTCMonth() === born.getUTCMonth() && now.getUTCDate() < born.getUTCDate());
-  if (beforeBirthday) age -= 1;
-  return age >= 13 && age <= 120 ? age : null;
-}
-
-function scopeContext(context: CoachContext): CoachContext {
-  const allowed = new Set(INTENT_SOURCE_IDS[context.intent]);
-  const sources = context.sources.filter((source) => source.id.startsWith("evidence_") ? allowed.has("evidence") : allowed.has(source.id));
-  const facts = Object.fromEntries(sources.flatMap((source) => {
-    if (source.id.startsWith("evidence_")) return [];
-    const key = FACT_KEY_BY_SOURCE[source.id];
-    return key && key in context.facts ? [[key, context.facts[key]]] : [];
-  }));
-  if (allowed.has("evidence")) facts.evidence_options = context.facts.evidence_options;
-  return { ...context, sources, facts };
-}
-
-function supplementItems(regimen: Awaited<ReturnType<typeof getCurrentRegimen>>) {
-  return regimen.filter((item) => item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement");
+function supplementItems(context: MemberIntelligenceContext) {
+  return [...context.regimen.supplements.value, ...context.regimen.endocrineActiveSupplements.value];
 }
 
 function explicitlyNamedEvidenceOption(question: string, options: CoachEvidenceOption[]) {
@@ -120,128 +94,190 @@ function explicitlyNamedEvidenceOption(question: string, options: CoachEvidenceO
   }) ?? null;
 }
 
-function isCurrentSupplement(name: string, regimen: Awaited<ReturnType<typeof getCurrentRegimen>>) {
+function isCurrentSupplement(name: string, context: MemberIntelligenceContext) {
   const identity = healthItemIdentityKey(name);
-  return supplementItems(regimen).some((item) => healthItemIdentityKey(item.name) === identity);
+  return supplementItems(context).some((item) => healthItemIdentityKey(item.name) === identity);
 }
 
-export async function buildCoachContext(userId: string, page: CoachPage, question: string, intent: CoachIntent): Promise<CoachContext> {
-  const admin = getSupabaseAdmin();
-  const requested = new Set(INTENT_SOURCE_IDS[intent]);
+export async function buildCoachContext(
+  userId: string,
+  page: CoachPage,
+  question: string,
+  routing: CoachRoutingDecision,
+): Promise<CoachContext> {
+  const requested = new Set(INTENT_SOURCE_IDS[routing.intent]);
   const needsEvidence = requested.has("evidence");
-  const emptyResult = { data: null, error: null };
-  const [blueprint, regimen, experimentResult, checkInsResult, goalsResult, submissionResult, recentTurnsResult] = await Promise.all([
-    requested.has("current_blueprint") ? getCurrentBlueprintContext(userId) : Promise.resolve(null),
-    requested.has("current_routine") || needsEvidence ? getCurrentRegimen(userId) : Promise.resolve([]),
-    requested.has("weekly_practice") ? admin.from("weekly_experiments")
-      .select("id,identity_direction,action_label,cue,frequency_per_week,minimum_version,week_start,status")
-      .eq("user_id", userId).eq("status", "active").order("updated_at", { ascending: false }).limit(1).maybeSingle() : Promise.resolve(emptyResult),
-    requested.has("recent_check_ins") ? admin.from("logs").select("log_date,weight,sleep,energy")
-      .eq("user_id", userId).order("log_date", { ascending: false }).limit(7) : Promise.resolve({ data: [], error: null }),
-    requested.has("goals") ? admin.from("goals").select("goals,custom_goal,target_weight,target_sleep,target_energy")
-      .eq("user_id", userId).maybeSingle() : Promise.resolve(emptyResult),
-    requested.has("health_profile") || needsEvidence ? admin.from("submissions")
-      .select("dob,sex,gender,conditions,allergies,pregnant,dosing_pref,brand_pref,engine_input_json,goals")
-      .eq("user_id", userId).order("created_at", { ascending: false }).limit(1).maybeSingle() : Promise.resolve(emptyResult),
-    requested.has("recent_coaching") ? admin.from("ai_coaching_turns")
-      .select("question,answer,created_at").eq("user_id", userId).neq("generation_status", "pending")
-      .order("created_at", { ascending: false }).limit(3) : Promise.resolve({ data: [], error: null }),
+  const needsRecentCoaching = requested.has("recent_coaching");
+  const admin = getSupabaseAdmin();
+  const [memberContext, recentTurnsResult] = await Promise.all([
+    getMemberIntelligenceContext(userId),
+    needsRecentCoaching
+      ? admin.from("ai_coaching_turns")
+        .select("question,answer,created_at").eq("user_id", userId).neq("generation_status", "pending")
+        .order("created_at", { ascending: false }).limit(3)
+      : Promise.resolve({ data: [], error: null }),
   ]);
-  for (const result of [experimentResult, checkInsResult, goalsResult, submissionResult, recentTurnsResult]) {
-    if (result.error) throw result.error;
-  }
+  if (recentTurnsResult.error) throw recentTurnsResult.error;
 
+  const allRegimen = regimenItems(memberContext);
   const sources: CoachSource[] = [];
   const facts: Record<string, unknown> = {};
-  if (blueprint) {
+
+  if (requested.has("current_blueprint")) {
+    const blueprint = memberContext.blueprint.value;
     sources.push({
       id: "current_blueprint",
       label: "Current Blueprint",
-      summary: `${blueprint.priorities.length} priorities; ${blueprint.needs_refresh ? "saved changes await review" : "current with saved information"}.`,
-      href: `/blueprints/${blueprint.stack_id}`,
+      summary: blueprint
+        ? `${blueprint.priorities.length} priorities; ${memberContext.blueprint.status === "stale" ? "saved changes await review" : "current with saved information"}.`
+        : "No current Blueprint is recorded.",
+      href: blueprint ? `/blueprints/${blueprint.stack_id}` : "/blueprints",
     });
-    facts.blueprint = {
+    facts.blueprint = blueprint ? {
       generated_at: blueprint.created_at,
       safety_status: blueprint.safety_status,
       safety_acknowledged: blueprint.safety_acknowledged,
       needs_refresh: blueprint.needs_refresh,
       priorities: blueprint.priorities.slice(0, 8).map((item) => ({ label: compact(item.label), category: item.category, kind: item.kind })),
-    };
+    } : null;
   }
-  if (regimen.length) {
-    sources.push({ id: "current_routine", label: "Current Routine", summary: `${regimen.length} active medication, hormone, and supplement records.`, href: "/routine" });
-    facts.routine = regimen.slice(0, 40).map((item) => ({
+
+  if (requested.has("current_routine")) {
+    sources.push({
+      id: "current_routine",
+      label: "Current Routine",
+      summary: `${allRegimen.length} active medication, hormone, and supplement records.`,
+      href: "/routine",
+    });
+    facts.routine = allRegimen.map((item) => ({
+      id: item.id,
       kind: item.item_kind,
-      name: compact(item.name, 100),
-      dose: compact(item.dose, 80),
-      timing: compact(item.timing, 100),
-      purpose: compact(item.purpose, 120),
+      name: item.name,
+      purpose: item.purpose,
+      dose: item.dose,
+      timing: item.timing,
+      schedule: item.schedule,
+      instruction_source: item.instruction_source,
       instruction_authority: item.instruction_authority,
+      updated_at: item.updated_at,
     }));
   }
 
-  const experiment = experimentResult.data as Partial<WeeklyExperiment> | null;
-  if (experiment?.id) {
-    const completionResult = await admin.from("daily_practice_completions")
-      .select("id", { count: "exact", head: true }).eq("user_id", userId).eq("experiment_id", experiment.id);
-    if (completionResult.error) throw completionResult.error;
-    sources.push({ id: "weekly_practice", label: "Weekly Practice", summary: `${completionResult.count ?? 0} completions recorded toward this week's ${experiment.frequency_per_week ?? 0}-day target.`, href: "/today" });
-    facts.weekly_practice = {
-      identity: identityLabel(experiment.identity_direction ?? null),
-      action: compact(experiment.action_label),
-      cue: compact(experiment.cue),
-      minimum_version: compact(experiment.minimum_version),
-      target: experiment.frequency_per_week,
-      completions: completionResult.count ?? 0,
-      week_start: experiment.week_start,
-    };
+  if (requested.has("weekly_practice")) {
+    const practice = memberContext.activePractice.value;
+    sources.push({
+      id: "weekly_practice",
+      label: "Weekly Practice",
+      summary: practice
+        ? `${practice.completionCount} completions recorded toward this week's ${practice.frequencyPerWeek ?? 0}-day target.`
+        : "No active weekly practice is recorded.",
+      href: "/today",
+    });
+    facts.weekly_practice = practice ? {
+      identity: practice.identityDirection,
+      action: practice.actionLabel,
+      cue: practice.cue,
+      minimum_version: practice.minimumVersion,
+      target: practice.frequencyPerWeek,
+      completions: practice.completionCount,
+      week_start: practice.weekStart,
+      blueprint_link: practice.blueprintLink,
+      goal_link: practice.goalLink,
+    } : null;
   }
 
-  const checkIns = checkInsResult.data ?? [];
-  if (checkIns.length) {
-    sources.push({ id: "recent_check_ins", label: "Recent check-ins", summary: `${checkIns.length} recent weight, sleep, or energy entries.`, href: "/journey" });
-    facts.recent_check_ins = checkIns.map((item) => ({ date: item.log_date, weight: item.weight, sleep_rating_out_of_5: item.sleep, energy_rating_out_of_10: item.energy }));
+  if (requested.has("recent_check_ins")) {
+    const checkIns = memberContext.recentCheckIns.value;
+    sources.push({
+      id: "recent_check_ins",
+      label: "Recent check-ins",
+      summary: `${checkIns.length} recent weight, sleep, or energy entries.`,
+      href: "/journey",
+    });
+    facts.recent_check_ins = checkIns.map((item) => ({
+      date: item.date,
+      weight: item.weight,
+      sleep_rating_out_of_5: item.sleep,
+      energy_rating_out_of_10: item.energy,
+    }));
   }
 
-  const goals = goalsResult.data;
-  const goalNames = [...new Set([
-    ...readableValues(goals?.goals),
-    ...readableValues(goals?.custom_goal),
-  ])].slice(0, 8);
-  if (goalNames.length || goals?.target_weight != null || goals?.target_sleep != null || goals?.target_energy != null) {
-    sources.push({ id: "goals", label: "Goals", summary: `${goalNames.length} saved goal${goalNames.length === 1 ? "" : "s"} and dashboard targets.`, href: "/settings" });
+  if (requested.has("goals")) {
+    const saved = memberContext.goals.saved.value;
+    const blueprintGoals = memberContext.goals.blueprint.value;
+    sources.push({
+      id: "goals",
+      label: "Goals",
+      summary: `${saved.length} saved goals and ${blueprintGoals.length} Blueprint goals.`,
+      href: "/settings",
+    });
     facts.goals = {
-      names: goalNames,
-      target_weight: goals?.target_weight ?? null,
-      target_sleep_out_of_5: goals?.target_sleep ?? null,
-      target_energy_out_of_10: goals?.target_energy ?? null,
+      saved: saved.map((goal) => ({ label: goal.label, kind: goal.kind, target_value: goal.targetValue })),
+      blueprint: blueprintGoals,
+      alignment: memberContext.goals.alignment,
     };
   }
 
-  const submission = submissionResult.data;
-  const engine = objectValue(submission?.engine_input_json);
-  const client = objectValue(engine.client ?? engine);
-  const conditions = [...new Set(readableValues(client.conditions ?? submission?.conditions))].slice(0, 12);
-  const allergies = [...new Set(readableValues(client.allergies ?? submission?.allergies))].slice(0, 12);
-  const procedures = [...new Set(readableValues(client.procedures ?? client.upcoming_procedures ?? client.surgeries))].slice(0, 8);
-  const healthProfile = {
-    age: calculateAge(submission?.dob),
-    sex: compact(String(submission?.sex ?? submission?.gender ?? client.sex ?? client.gender ?? ""), 40),
-    conditions,
-    allergies,
-    procedures,
-    pregnant: client.pregnant ?? submission?.pregnant ?? null,
-    dosing_preference: compact(String(submission?.dosing_pref ?? client.dosing_pref ?? ""), 100),
-    brand_preference: compact(String(submission?.brand_pref ?? client.brand_pref ?? ""), 100),
-  };
-  if (Object.values(healthProfile).some((value) => Array.isArray(value) ? value.length > 0 : value != null && value !== "")) {
-    sources.push({ id: "health_profile", label: "Health profile", summary: "Saved age/life-stage, conditions, allergies, procedures, and preferences used only when relevant.", href: "/settings" });
-    facts.health_profile = healthProfile;
+  if (requested.has("health_profile")) {
+    sources.push({
+      id: "health_profile",
+      label: "Health profile",
+      summary: memberContext.healthProfile.status === "present"
+        ? "Saved age/life-stage, conditions, allergies, procedures, and preferences used only when relevant."
+        : "No intake health profile is currently available.",
+      href: "/settings",
+    });
+    facts.health_profile = memberContext.healthProfile.value;
+  }
+
+  if (requested.has("preferences")) {
+    sources.push({
+      id: "preferences",
+      label: "Preferences",
+      summary: memberContext.preferences.status === "present"
+        ? "Saved timezone, reminder, quiet-hour, and unit preferences."
+        : "No member preferences are currently recorded.",
+      href: "/settings",
+    });
+    facts.preferences = memberContext.preferences.value;
+  }
+
+  if (requested.has("safety_review")) {
+    const safetyItems = memberContext.unresolvedSafetyItems.value;
+    sources.push({
+      id: "safety_review",
+      label: "Deterministic safety review",
+      summary: memberContext.unresolvedSafetyItems.status === "missing"
+        ? "The current safety evaluation was unavailable."
+        : `${safetyItems.length} unresolved finding${safetyItems.length === 1 ? "" : "s"} from the current Routine.`,
+      href: "/blueprints",
+    });
+    facts.safety_items = safetyItems;
+  }
+
+  if (requested.has("context_status")) {
+    sources.push({
+      id: "context_status",
+      label: "Member context status",
+      summary: `${memberContext.contextFreshness.missingSections.length} missing and ${memberContext.contextFreshness.staleSections.length} stale context sections.`,
+      href: "/settings",
+    });
+    facts.context_status = {
+      missing_sections: memberContext.contextFreshness.missingSections,
+      stale_sections: memberContext.contextFreshness.staleSections,
+      generated_at: memberContext.contextFreshness.generatedAt,
+      latest_recorded_update: memberContext.contextFreshness.latestRecordedUpdate,
+    };
   }
 
   const recentTurns = recentTurnsResult.data ?? [];
-  if (recentTurns.length) {
-    sources.push({ id: "recent_coaching", label: "Recent coaching", summary: `${recentTurns.length} recent Ask LVE360 turn${recentTurns.length === 1 ? "" : "s"} used to understand follow-up wording.`, href: page === "other" ? "/today" : page === "blueprint" ? "/blueprints" : `/${page}` });
+  if (needsRecentCoaching && recentTurns.length) {
+    sources.push({
+      id: "recent_coaching",
+      label: "Recent coaching",
+      summary: `${recentTurns.length} recent Ask LVE360 turn${recentTurns.length === 1 ? "" : "s"} used to understand follow-up wording.`,
+      href: page === "other" ? "/today" : page === "blueprint" ? "/blueprints" : `/${page}`,
+    });
     facts.recent_coaching = recentTurns.map((turn) => ({
       question: compact(turn.question, 240),
       answer: compact(turn.answer, 500),
@@ -251,23 +287,26 @@ export async function buildCoachContext(userId: string, page: CoachPage, questio
   const followUpContext = /\b(?:this|that|it|the first|the second|that option|those)\b/i.test(question)
     ? recentTurns.map((turn) => `${turn.question} ${turn.answer}`).join(" ").slice(0, 1200)
     : "";
-  const evidenceOptions = retrieveCoachEvidence(`${question} ${followUpContext}`.trim());
+  const evidenceOptions = needsEvidence ? retrieveCoachEvidence(`${question} ${followUpContext}`.trim()) : [];
+  const profile = memberContext.healthProfile.value;
   const safetyContext: SafetyContext = {
-    medications: regimen.filter((item) => item.item_kind === "medication").map((item) => item.name),
-    conditions,
-    allergies,
-    procedures,
-    pregnant: typeof healthProfile.pregnant === "boolean" || typeof healthProfile.pregnant === "string" ? healthProfile.pregnant : null,
+    medications: memberContext.regimen.medications.value.map((item) => item.name),
+    conditions: profile?.conditions ?? [],
+    allergies: profile?.allergies ?? [],
+    procedures: profile?.procedures ?? [],
+    pregnant: profile?.pregnant ?? null,
   };
-  const preSafety = needsEvidence && evidenceOptions.length ? await applySafetyChecks(safetyContext, evidenceOptions.map((option) => ({
-    name: option.name,
-    dose: option.doseGuidance?.startingDose ?? null,
-    is_current: isCurrentSupplement(option.name, regimen),
-  }))) : null;
+  const preSafety = needsEvidence && evidenceOptions.length
+    ? await applySafetyChecks(safetyContext, evidenceOptions.map((option) => ({
+      name: option.name,
+      dose: option.doseGuidance?.startingDose ?? null,
+      is_current: isCurrentSupplement(option.name, memberContext),
+    })))
+    : null;
   const safetyByName = new Map(preSafety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
   facts.evidence_options = evidenceOptions.map((option) => {
     const safety = safetyByName.get(healthItemIdentityKey(option.name));
-    const current = supplementItems(regimen).find((item) => healthItemIdentityKey(item.name) === healthItemIdentityKey(option.name));
+    const current = supplementItems(memberContext).find((item) => healthItemIdentityKey(item.name) === healthItemIdentityKey(option.name));
     return {
       id: option.id,
       name: option.name,
@@ -280,14 +319,30 @@ export async function buildCoachContext(userId: string, page: CoachPage, questio
       current_timing: current?.timing ?? null,
       safety_status: safety?.decision === "blocked" ? "REMOVE" : safety?.decision === "review" ? "ALLOW_WITH_NOTE" : "ALLOW",
       safety_notes: safety?.findings.map((finding) => finding.message).slice(0, 3) ?? [],
-      dose_guidance: intent === "TIMING_OR_DOSING" ? option.doseGuidance : null,
+      dose_guidance: routing.intent === "TIMING_OR_DOSING" ? option.doseGuidance : null,
     };
   });
   for (const option of evidenceOptions) {
-    sources.push({ id: option.id, label: `${option.name} evidence`, summary: `${option.evidenceStrength}: ${option.citationLabel}`, href: option.citationUrl });
+    sources.push({
+      id: option.id,
+      label: `${option.name} evidence`,
+      summary: `${option.evidenceStrength}: ${option.citationLabel}`,
+      href: option.citationUrl,
+    });
   }
 
-  return scopeContext({ page, intent, sources, facts, evidenceOptions, safetyContext, preSafety });
+  return {
+    page,
+    intent: routing.intent,
+    constraints: routing.constraints,
+    requestedRegimenKinds: routing.requestedRegimenKinds,
+    memberContext,
+    sources,
+    facts,
+    evidenceOptions,
+    safetyContext,
+    preSafety,
+  };
 }
 
 function supplementQuestion(question: string, context: CoachContext) {
@@ -306,6 +361,7 @@ function prompt(question: string, context: CoachContext, repair = false) {
         "You may explain, compare, rank, and recommend considering a supplement when the supplied evidence and safety status support it. You may explain dose or timing only when dose_guidance is supplied.",
         "Never direct a medication or hormone change. Never claim to diagnose, treat, cure, prevent, or manage disease. Never claim that a supplement is absolutely safe.",
         "Recommendation is not mutation: do not say a record, stack, routine, reminder, medication, hormone, or supplement was changed.",
+        "The supplied explicit_constraints are hard limits. Do not propose changing a preserved medication, hormone, or supplement plan.",
         "For personalized recommendations, materially use relevant member facts, recognize already_in_stack items, prefer one change at a time, and end with a measurable next step.",
         "Do not recommend adding an already_in_stack item again. Discuss its recorded form, dose, or timing instead when available.",
         "Do not recommend an option whose safety_status is REMOVE. An ALLOW_WITH_NOTE option must retain its supplied safety note.",
@@ -320,6 +376,7 @@ function prompt(question: string, context: CoachContext, repair = false) {
       content: JSON.stringify({
         question,
         classified_intent: context.intent,
+        explicit_constraints: context.constraints,
         current_page: context.page,
         available_sources: context.sources.map(({ id, label, summary }) => ({ id, label, summary })),
         member_context_and_evidence: context.facts,
@@ -534,7 +591,13 @@ function renderAnswer(answer: StructuredCoachAnswer, context: CoachContext, safe
 }
 
 export async function generateCoachAnswer(userId: string, question: string, context: CoachContext) {
-  const deterministic = deterministicRecordMutation(question, context)
+  const routing: CoachRoutingDecision = {
+    intent: context.intent,
+    constraints: context.constraints,
+    requestedRegimenKinds: context.requestedRegimenKinds,
+  };
+  const deterministic = deterministicCoachTask(routing, context.memberContext, question)
+    ?? deterministicRecordMutation(question, context)
     ?? deterministicPlanLookup(question, context)
     ?? deterministicTodayStep(question, context)
     ?? deterministicJourneyPattern(question, context);
@@ -543,6 +606,7 @@ export async function generateCoachAnswer(userId: string, question: string, cont
       ...deterministic,
       diagnostics: {
         intent: context.intent,
+        constraints: context.constraints,
         qualityScore: 100,
         safetyRuleCount: context.preSafety?.findings.length ?? 0,
         recommendationsRemoved: 0,
@@ -572,7 +636,7 @@ export async function generateCoachAnswer(userId: string, question: string, cont
       if (proposal) generatedByModel = true;
       if (!proposal && attempt === 0) regenerationCount = 1;
     } catch (error) {
-      console.warn("[coach.v2] model unavailable; using deterministic evidence repair", error);
+      console.warn("[coach.v3] model unavailable; using deterministic evidence repair", error);
       break;
     }
   }
@@ -613,6 +677,7 @@ export async function generateCoachAnswer(userId: string, question: string, cont
     responseSource: generatedByModel ? "ai" as const : "fallback" as const,
     diagnostics: {
       intent: context.intent,
+      constraints: context.constraints,
       qualityScore: quality.score,
       safetyRuleCount: validated.safety?.findings.length ?? 0,
       recommendationsRemoved: validated.removed,

--- a/src/lib/ai/modelConfig.ts
+++ b/src/lib/ai/modelConfig.ts
@@ -75,7 +75,7 @@ const TASK_PROFILES: Record<AiTask, AiTaskProfile> = {
   },
   contextual_coach: {
     capability: "mini",
-    promptVersion: "contextual-coach-v1",
+    promptVersion: "contextual-coach-v3",
     reasoningEffort: "low",
   },
 };

--- a/src/lib/coachIntent.ts
+++ b/src/lib/coachIntent.ts
@@ -1,0 +1,188 @@
+import type {
+  CoachRegimenKind,
+  CoachRoutingDecision,
+} from "./contextualCoach";
+import type {
+  MemberIntelligenceContext,
+  MemberRegimenItemContext,
+} from "./memberContext";
+import { regimenScheduleLabel } from "./regimenSchedule.ts";
+
+export type DeterministicCoachTaskResult = {
+  answer: string;
+  sourceIds: string[];
+  responseSource: "deterministic";
+};
+
+const KIND_LABELS: Record<CoachRegimenKind, string> = {
+  medication: "Medications",
+  hormone: "Hormones",
+  supplement: "Supplements",
+  endocrine_active_supplement: "Endocrine-active supplements",
+};
+
+function itemsForKind(context: MemberIntelligenceContext, kind: CoachRegimenKind): MemberRegimenItemContext[] {
+  if (kind === "medication") return context.regimen.medications.value;
+  if (kind === "hormone") return context.regimen.hormones.value;
+  if (kind === "supplement") return context.regimen.supplements.value;
+  return context.regimen.endocrineActiveSupplements.value;
+}
+
+function kindsForRoute(route: CoachRoutingDecision): CoachRegimenKind[] {
+  if (route.requestedRegimenKinds.length) return route.requestedRegimenKinds;
+  if (route.intent === "MEDICATION_LOOKUP") return ["medication"];
+  if (route.intent === "HORMONE_LOOKUP") return ["hormone"];
+  if (route.intent === "SUPPLEMENT_LOOKUP" || route.intent === "CURRENT_PLAN_LOOKUP") {
+    return ["supplement", "endocrine_active_supplement"];
+  }
+  return ["medication", "hormone", "supplement", "endocrine_active_supplement"];
+}
+
+function field(value: string | null | undefined, label: string): string {
+  return value?.trim() || `${label} not recorded`;
+}
+
+function regimenLookup(route: CoachRoutingDecision, context: MemberIntelligenceContext): DeterministicCoachTaskResult {
+  const kinds = kindsForRoute(route);
+  const sections = kinds.map((kind) => {
+    const items = itemsForKind(context, kind);
+    const lines = items.length
+      ? items.map((item) => {
+        const details = [
+          `dose: ${field(item.dose, "dose")}`,
+          `timing: ${field(item.timing, "timing")}`,
+          `schedule: ${item.schedule ? regimenScheduleLabel(item.schedule) : "schedule not recorded"}`,
+        ];
+        return `- ${item.name} (${details.join("; ")})`;
+      })
+      : ["- None currently recorded."];
+    return `${KIND_LABELS[kind]}:\n${lines.join("\n")}`;
+  });
+  return {
+    answer: `Here is exactly what is saved in your current Routine for the requested categories:\n\n${sections.join("\n\n")}\n\nThis is a record lookup. Nothing was added, removed, or changed.`,
+    sourceIds: ["current_routine"],
+    responseSource: "deterministic",
+  };
+}
+
+function safetyReview(context: MemberIntelligenceContext): DeterministicCoachTaskResult {
+  const section = context.unresolvedSafetyItems;
+  if (section.status === "missing") {
+    return {
+      answer: "I could not complete the deterministic safety review from the saved data right now. Your Routine is unchanged. Try again before relying on this view for a clinician or pharmacist discussion.",
+      sourceIds: ["safety_review", "current_routine", "health_profile"],
+      responseSource: "deterministic",
+    };
+  }
+  const unique = [...new Map(section.value.map((item) => [
+    `${item.code}|${item.item.toLowerCase()}|${item.message.toLowerCase()}`,
+    item,
+  ])).values()];
+  if (!unique.length) {
+    return {
+      answer: "LVE360 did not identify an unresolved clinician- or pharmacist-review finding in the current deterministic safety check. That means no rule matched the information currently saved; it is not a guarantee that every combination is risk-free. Review any new symptoms, diagnoses, prescriptions, or incomplete Routine details with a qualified professional.",
+      sourceIds: ["safety_review", "current_routine", "health_profile"],
+      responseSource: "deterministic",
+    };
+  }
+  const rank = { danger: 0, warning: 1, info: 2 } as const;
+  const findings = unique.sort((left, right) => rank[left.severity] - rank[right.severity]);
+  const lines = findings.map((item, index) => `${index + 1}. ${item.item}: ${item.message}`);
+  return {
+    answer: `These saved Routine items currently need clinician or pharmacist review:\n\n${lines.join("\n")}\n\nThese are review signals from LVE360's deterministic rules, not instructions to change a medication, hormone, or supplement.`,
+    sourceIds: ["safety_review", "current_routine", "health_profile"],
+    responseSource: "deterministic",
+  };
+}
+
+function missingContext(context: MemberIntelligenceContext): DeterministicCoachTaskResult {
+  const gaps: string[] = [];
+  const regimen = [
+    ...context.regimen.medications.value,
+    ...context.regimen.hormones.value,
+    ...context.regimen.supplements.value,
+    ...context.regimen.endocrineActiveSupplements.value,
+  ];
+  const missingDose = regimen.filter((item) => !item.dose?.trim()).map((item) => item.name);
+  const missingTiming = regimen.filter((item) => !item.timing?.trim()).map((item) => item.name);
+  if (missingDose.length) gaps.push(`Add the missing dose for ${missingDose.join(", ")}.`);
+  if (missingTiming.length) gaps.push(`Add the missing timing for ${missingTiming.join(", ")}.`);
+  if (context.healthProfile.status === "missing") gaps.push("Complete the intake health profile so conditions, allergies, procedures, and life-stage context can be checked.");
+  if (context.goals.saved.status === "missing" && context.goals.blueprint.status === "missing") gaps.push("Record at least one current goal so coaching can prioritize the outcome that matters most.");
+  if (context.recentCheckIns.status === "missing") gaps.push("Record a few sleep, energy, or weight check-ins so LVE360 can distinguish a one-day issue from a pattern.");
+  if (context.activePractice.status === "missing") gaps.push("Choose one active weekly practice so daily coaching can support a specific action.");
+  if (context.preferences.status === "missing") gaps.push("Save timezone and reminder preferences so timing guidance matches your day.");
+  const selected = gaps.slice(0, 5);
+  return {
+    answer: selected.length
+      ? `The most useful missing information is:\n\n${selected.map((item, index) => `${index + 1}. ${item}`).join("\n")}\n\nI only listed fields that are actually absent from your current LVE360 context.`
+      : "Your core LVE360 context is substantially complete. The next improvement is not another profile field; it is continuing consistent check-ins and weekly reviews so LVE360 has more history to learn from.",
+    sourceIds: ["context_status", "current_routine", "health_profile", "goals", "recent_check_ins", "weekly_practice", "preferences"],
+    responseSource: "deterministic",
+  };
+}
+
+function prioritization(context: MemberIntelligenceContext): DeterministicCoachTaskResult {
+  const practice = context.activePractice.value;
+  const savedGoals = context.goals.saved.value.map((goal) => goal.label);
+  const blueprintGoals = context.goals.blueprint.value;
+  const goals = [...new Set([...savedGoals, ...blueprintGoals])].slice(0, 3);
+  if (!practice?.actionLabel) {
+    const goalText = goals[0] ? ` for your recorded goal, ${goals[0]}` : " toward the outcome that matters most to you";
+    return {
+      answer: `Your highest-value action this week is to choose one small, repeatable weekly practice${goalText}. No active practice is currently recorded, so adding more advice would create options without a clear action. Start with a version that can still count on a hard day.`,
+      sourceIds: ["weekly_practice", "goals", "recent_check_ins", "current_blueprint"],
+      responseSource: "deterministic",
+    };
+  }
+  const progress = `${practice.completionCount} of ${practice.frequencyPerWeek ?? 0} planned completions are recorded`;
+  const minimum = practice.minimumVersion ? ` On a hard day, use your saved minimum version: ${practice.minimumVersion}.` : "";
+  const goalReason = goals.length ? ` It supports your recorded priorities: ${goals.join(", ")}.` : "";
+  return {
+    answer: `The highest-value action is to keep your current weekly practice as the focus: ${practice.actionLabel}. ${progress}.${goalReason}${minimum} Finishing the existing experiment will teach LVE360 more than introducing another change midweek.`,
+    sourceIds: ["weekly_practice", "goals", "recent_check_ins", "current_blueprint"],
+    responseSource: "deterministic",
+  };
+}
+
+function behavioralAdjustment(route: CoachRoutingDecision, context: MemberIntelligenceContext, question: string): DeterministicCoachTaskResult | null {
+  if (!/\b(?:slept poorly|poor sleep|bad night|rough night|adjust tomorrow)\b/i.test(question)) return null;
+  const preserved: string[] = [];
+  if (route.constraints.preserveMedicationPlan) preserved.push("medications");
+  if (route.constraints.preserveHormonePlan) preserved.push("hormones");
+  if (route.constraints.preserveSupplementPlan) preserved.push("supplements");
+  const preserveText = preserved.length
+    ? `Keep your saved ${preserved.join(" and ")} unchanged.`
+    : "Keep your prescribed medication and hormone plan unchanged.";
+  const practice = context.activePractice.value;
+  const practiceStep = practice?.minimumVersion
+    ? `Use the minimum version of your weekly practice if energy is low: ${practice.minimumVersion}.`
+    : "Choose a lighter version of planned activity if you feel unusually tired.";
+  return {
+    answer: `${preserveText} Tomorrow, keep your usual wake time, get outdoor light and gentle movement early in the day, and avoid turning one poor night into an all-or-nothing day. ${practiceStep} In the evening, return to your normal wind-down and record sleep and energy so LVE360 can see whether this was a one-night event or part of a pattern.`,
+    sourceIds: ["weekly_practice", "recent_check_ins", "goals", "preferences"],
+    responseSource: "deterministic",
+  };
+}
+
+export function deterministicCoachTask(
+  route: CoachRoutingDecision,
+  context: MemberIntelligenceContext,
+  question: string,
+): DeterministicCoachTaskResult | null {
+  if (["CURRENT_REGIMEN_LOOKUP", "MEDICATION_LOOKUP", "HORMONE_LOOKUP", "SUPPLEMENT_LOOKUP", "CURRENT_PLAN_LOOKUP"].includes(route.intent)) {
+    return regimenLookup(route, context);
+  }
+  if (route.intent === "SAFETY_REVIEW") return safetyReview(context);
+  if (route.intent === "MISSING_CONTEXT") return missingContext(context);
+  if (route.intent === "PRIORITIZATION") return prioritization(context);
+  if (route.intent === "OUT_OF_SCOPE") {
+    return {
+      answer: "Ask LVE360 is focused on your saved health, wellness, Routine, goals, and weekly progress. I cannot help with unrelated general-knowledge questions here.",
+      sourceIds: [],
+      responseSource: "deterministic",
+    };
+  }
+  if (route.intent === "BEHAVIORAL_COACHING") return behavioralAdjustment(route, context, question);
+  return null;
+}

--- a/src/lib/contextualCoach.ts
+++ b/src/lib/contextualCoach.ts
@@ -1,6 +1,41 @@
-export const COACH_PROMPT_VERSION = "contextual-coach-v2";
+export const COACH_PROMPT_VERSION = "contextual-coach-v3";
 
 export type CoachIntent =
+  | "GENERAL_EDUCATION"
+  | "PERSONALIZED_RECOMMENDATION"
+  | "CURRENT_REGIMEN_LOOKUP"
+  | "MEDICATION_LOOKUP"
+  | "HORMONE_LOOKUP"
+  | "SUPPLEMENT_LOOKUP"
+  | "CURRENT_PLAN_LOOKUP"
+  | "SAFETY_REVIEW"
+  | "BEHAVIORAL_COACHING"
+  | "PRIORITIZATION"
+  | "MISSING_CONTEXT"
+  | "EVIDENCE_COMPARISON"
+  | "OUT_OF_SCOPE"
+  | "OPTION_COMPARISON"
+  | "PLAN_EXPLANATION"
+  | "TIMING_OR_DOSING"
+  | "PROGRESS_COACHING"
+  | "REQUEST_TO_CHANGE_RECORD"
+  | "POTENTIAL_MEDICAL_RED_FLAG";
+
+export type CoachRegimenKind = "medication" | "hormone" | "supplement" | "endocrine_active_supplement";
+
+export type CoachConstraints = {
+  preserveMedicationPlan: boolean;
+  preserveHormonePlan: boolean;
+  preserveSupplementPlan: boolean;
+};
+
+export type CoachRoutingDecision = {
+  intent: CoachIntent;
+  constraints: CoachConstraints;
+  requestedRegimenKinds: CoachRegimenKind[];
+};
+
+export type StoredCoachIntent =
   | "GENERAL_EDUCATION"
   | "PERSONALIZED_RECOMMENDATION"
   | "CURRENT_PLAN_LOOKUP"
@@ -10,6 +45,17 @@ export type CoachIntent =
   | "PROGRESS_COACHING"
   | "REQUEST_TO_CHANGE_RECORD"
   | "POTENTIAL_MEDICAL_RED_FLAG";
+
+export function storedCoachIntent(intent: CoachIntent): StoredCoachIntent {
+  if (intent === "CURRENT_REGIMEN_LOOKUP" || intent === "MEDICATION_LOOKUP" || intent === "HORMONE_LOOKUP" || intent === "SUPPLEMENT_LOOKUP") {
+    return "CURRENT_PLAN_LOOKUP";
+  }
+  if (intent === "SAFETY_REVIEW") return "PLAN_EXPLANATION";
+  if (intent === "BEHAVIORAL_COACHING" || intent === "PRIORITIZATION" || intent === "MISSING_CONTEXT") return "PROGRESS_COACHING";
+  if (intent === "EVIDENCE_COMPARISON") return "OPTION_COMPARISON";
+  if (intent === "OUT_OF_SCOPE") return "GENERAL_EDUCATION";
+  return intent;
+}
 
 export type ProposedCoachOption = {
   name: string;
@@ -87,36 +133,93 @@ export function isCoachFeedback(value: unknown): value is CoachFeedback {
   return value === "useful" || value === "not_useful";
 }
 
-export function classifyCoachIntent(question: string): CoachIntent {
+function explicitCoachConstraints(question: string): CoachConstraints {
   const value = question.toLowerCase();
+  const withoutChange = /\b(?:without|do not|don't|not)\b[\s\S]{0,50}\b(?:chang|adjust|start|stop|add|remove|switch)/.test(value)
+    || /\bkeep\b[\s\S]{0,40}\b(?:unchanged|the same)/.test(value);
+  const allRegimen = withoutChange && /\b(?:routine|regimen|stack|anything i take)\b/.test(value);
+  return {
+    preserveMedicationPlan: allRegimen || (withoutChange && /\b(?:medications?|meds?|medicines?|prescriptions?|prescribed drugs?)\b/.test(value)),
+    preserveHormonePlan: allRegimen || (withoutChange && /\bhormon(?:e|es|s)?\b/.test(value)),
+    preserveSupplementPlan: allRegimen || (withoutChange && /\b(?:supplements?|supplments?|vitamins?|minerals?|stack)\b/.test(value)),
+  };
+}
+
+function requestedRegimenKinds(question: string): CoachRegimenKind[] {
+  const value = question.toLowerCase();
+  const result: CoachRegimenKind[] = [];
+  if (/\b(?:medications?|meds?|medicines?|prescriptions?|prescribed drugs?)\b/.test(value)) result.push("medication");
+  if (/\bhormon(?:e|es|s)?\b/.test(value)) result.push("hormone");
+  if (/\b(?:supplements?|supplments?|vitamins?|minerals?)\b/.test(value)) result.push("supplement", "endocrine_active_supplement");
+  return [...new Set(result)];
+}
+
+export function classifyCoachRequest(question: string): CoachRoutingDecision {
+  const value = question.toLowerCase();
+  const constraints = explicitCoachConstraints(question);
+  const requestedKinds = requestedRegimenKinds(question);
+  const route = (intent: CoachIntent, kinds: CoachRegimenKind[] = requestedKinds): CoachRoutingDecision => ({
+    intent,
+    constraints,
+    requestedRegimenKinds: kinds,
+  });
   if (/\b(suicid|kill myself|overdose|chest pain|can(?:not|'t) breathe|stroke|severe allergic|anaphyl|fainted|unconscious|medical emergency|vomiting blood|face (?:is )?swelling|tongue (?:is )?swelling|black stools?|severe confusion)\b/.test(value)) {
-    return "POTENTIAL_MEDICAL_RED_FLAG";
+    return route("POTENTIAL_MEDICAL_RED_FLAG");
   }
   if (/\b(?:add|save|record|remove|delete)\b[\s\S]{0,80}\b(?:my|the)\s+(?:stack|routine|record|reminder|medication|hormone|supplement)\b/.test(value)
     || /\b(?:add|remove|delete)\b[\s\S]{0,60}\b(?:to|from)\s+(?:my\s+)?(?:stack|routine|records?)\b/.test(value)) {
-    return "REQUEST_TO_CHANGE_RECORD";
+    return route("REQUEST_TO_CHANGE_RECORD");
+  }
+  if (/\b(?:capital of|president of|prime minister of|weather|stock price|sports score|who won|recipe for|write (?:me )?a poem)\b/.test(value)) {
+    return route("OUT_OF_SCOPE", []);
+  }
+  if (/\b(?:clinician|pharmacist|pharmasist|doctor|professional)\b[\s\S]{0,50}\b(?:review|discuss|check|attention)\b/.test(value)
+    || /\b(?:need|needs|requiring?|deserve|flagged? for)\b[\s\S]{0,50}\b(?:clinician|pharmacist|pharmasist|doctor|professional)\b/.test(value)
+    || /\b(?:safety|interaction|contraindication|conflict|warning)s?\b[\s\S]{0,50}\b(?:routine|regimen|stack|review|item)\b/.test(value)) {
+    return route("SAFETY_REVIEW");
+  }
+  if (/\b(?:what|which)\b[\s\S]{0,80}\b(?:missing|incomplete|not (?:saved|recorded)|need(?:ed)? from me)\b/.test(value)
+    || /\b(?:missing|incomplete)\b[\s\S]{0,50}\b(?:profile|context|information|data|record)\b/.test(value)) {
+    return route("MISSING_CONTEXT", []);
+  }
+  if (/\b(?:highest[- ]value|most important|best next|single (?:best|most useful)|prioriti[sz]e|focus on this week|what should i focus)\b/.test(value)) {
+    return route("PRIORITIZATION", []);
+  }
+  if (/\b(?:slept poorly|poor sleep|bad night|rough night|low energy|hard day|off track|missed my|make (?:it|this) easier|adjust tomorrow|adjust today)\b/.test(value)
+    || /\b(?:how (?:can|should) i|help me)\b[\s\S]{0,70}\b(?:sleep|eat|exercise|move|walk|meditat|recover|habit|practice|routine tomorrow)\b/.test(value)) {
+    return route("BEHAVIORAL_COACHING", []);
   }
   if (/\b(?:what|which|list|show|am i|do i)\b[\s\S]{0,70}\b(?:taking|take|currently|current|recorded|in my stack|in my routine)\b/.test(value)
-    || /\bis\s+[a-z0-9 -]+\s+(?:already\s+)?in my (?:stack|routine|records?)\b/.test(value)) {
-    return "CURRENT_PLAN_LOOKUP";
+    || /\bis\s+[a-z0-9 -]+\s+(?:already\s+)?in my (?:stack|routine|records?)\b/.test(value)
+    || /\b(?:show|list)\b[\s\S]{0,50}\b(?:medications?|meds?|hormon(?:e|es|s)?|supplements?|supplments?)\b/.test(value)) {
+    if (requestedKinds.length === 1 && requestedKinds[0] === "medication") return route("MEDICATION_LOOKUP");
+    if (requestedKinds.length === 1 && requestedKinds[0] === "hormone") return route("HORMONE_LOOKUP");
+    if (requestedKinds.length && requestedKinds.every((kind) => kind === "supplement" || kind === "endocrine_active_supplement")) {
+      return route("SUPPLEMENT_LOOKUP");
+    }
+    return route("CURRENT_REGIMEN_LOOKUP", requestedKinds.length ? requestedKinds : ["medication", "hormone", "supplement", "endocrine_active_supplement"]);
   }
   if (/\b(?:compare|versus|vs\.?|difference between|better for me|or)\b/.test(value)
     && /\b(?:supplement|vitamin|mineral|magnesium|glycine|melatonin|theanine|creatine|coq10|b[- ]?12|omega[- ]?3|ashwagandha)\b/.test(value)) {
-    return "OPTION_COMPARISON";
+    return route("EVIDENCE_COMPARISON", ["supplement", "endocrine_active_supplement"]);
   }
   if (/\b(?:when should|what time|morning or evening|with food|without food|dose|dosage|how much|timing|space|spacing)\b/.test(value)) {
-    return "TIMING_OR_DOSING";
+    return route("TIMING_OR_DOSING");
   }
   if (/\b(?:why|explain|what does|how does)\b[\s\S]{0,80}\b(?:blueprint|plan|priority|recommendation|routine)\b/.test(value)) {
-    return "PLAN_EXPLANATION";
+    return route("PLAN_EXPLANATION");
   }
   if (/\b(?:this week|progress|trend|recent|check[- ]?ins?|small win|next habit|weekly practice|focus on)\b/.test(value)) {
-    return "PROGRESS_COACHING";
+    return route("PROGRESS_COACHING", []);
   }
   if (/\b(?:for me|my\s+(?:sleep|energy|goals?|stack|medications?|routine)|should i|what should i try|best for my|makes? sense for me|fit my)\b/.test(value)) {
-    return "PERSONALIZED_RECOMMENDATION";
+    return route("PERSONALIZED_RECOMMENDATION");
   }
-  return "GENERAL_EDUCATION";
+  return route("GENERAL_EDUCATION", []);
+}
+
+export function classifyCoachIntent(question: string): CoachIntent {
+  return classifyCoachRequest(question).intent;
 }
 
 export type CoachSafetyBoundary = "emergency" | "diagnosis" | "regimen_change" | null;
@@ -150,8 +253,10 @@ function cleanText(value: unknown, max = 1000) {
 
 function isCoachIntent(value: unknown): value is CoachIntent {
   return [
-    "GENERAL_EDUCATION", "PERSONALIZED_RECOMMENDATION", "CURRENT_PLAN_LOOKUP",
-    "OPTION_COMPARISON", "PLAN_EXPLANATION", "TIMING_OR_DOSING",
+    "GENERAL_EDUCATION", "PERSONALIZED_RECOMMENDATION", "CURRENT_REGIMEN_LOOKUP",
+    "MEDICATION_LOOKUP", "HORMONE_LOOKUP", "SUPPLEMENT_LOOKUP", "CURRENT_PLAN_LOOKUP",
+    "SAFETY_REVIEW", "BEHAVIORAL_COACHING", "PRIORITIZATION", "MISSING_CONTEXT",
+    "EVIDENCE_COMPARISON", "OUT_OF_SCOPE", "OPTION_COMPARISON", "PLAN_EXPLANATION", "TIMING_OR_DOSING",
     "PROGRESS_COACHING", "REQUEST_TO_CHANGE_RECORD", "POTENTIAL_MEDICAL_RED_FLAG",
   ].includes(String(value));
 }


### PR DESCRIPTION
## Purpose

Make Ask LVE360 understand the requested job before it retrieves records or supplement evidence.

This is PR109 in the Trust-to-Intelligence program. It consumes the canonical member context introduced by PR108.

## Root cause

The previous coach assembled context from a coarse intent map and retrieved supplement evidence for broad personalized prompts. That allowed available supplement evidence to influence the answer even when the member asked for:

- medications and hormones
- clinician or pharmacist review
- a behavioral action
- the highest-value weekly focus
- missing profile information
- an out-of-scope fact

The deterministic current-plan renderer also filtered mainly to supplement-style records.

## Architecture

The request path is now:

1. intent
2. explicit constraints
3. required context
4. deterministic retrieval
5. optional evidence
6. synthesis

Key changes:

- Adds first-class routing for combined regimen, medication, hormone, supplement, safety review, behavioral coaching, prioritization, missing context, evidence comparison, and out-of-scope requests.
- Captures "without changing..." constraints independently from intent.
- Builds one canonical `MemberIntelligenceContext` snapshot per request.
- Adapts only the required canonical sections into coach context.
- Retrieves curated supplement evidence only for evidence-oriented jobs.
- Runs deterministic task rendering before model generation.
- Emits privacy-safe detailed route diagnostics without logging the question or health facts.
- Aligns saved-turn and generation-ledger prompt telemetry on `contextual-coach-v3`.

## Deterministic behavior

The model no longer composes answers for:

- medication, hormone, supplement, or combined regimen lookup
- current clinician/pharmacist safety-review findings
- missing-context analysis
- highest-value weekly focus when the member has an active practice
- the poor-sleep behavioral regression with explicit regimen exclusions
- out-of-scope requests

Missing dose, timing, and schedule values are labeled as not recorded instead of inferred.

## Golden regressions

The suite includes the six production prompts:

1. medications and hormones with dose and timing
2. clinician/pharmacist review and reasons
3. highest-value action this week
4. poor-sleep adjustment without regimen changes
5. missing profile context
6. capital of France

It also covers shorthand, a common typo, mixed inventory/safety intent, a known-clear safety result, and type-specific supplement lookup.

## Files changed

- `src/lib/contextualCoach.ts`
- `src/lib/coachIntent.ts`
- `src/lib/ai/contextualCoachData.ts`
- `app/api/coach/route.ts`
- `src/lib/ai/modelConfig.ts`
- `src/_tests_/pr109IntentRouting.assert.ts`
- `src/_tests_/pr109Architecture.assert.mjs`
- PR107 regression expectations
- `docs/coach-intent-routing.md`
- `package.json`

## Verification

Passed:

- `npm.cmd run qa:pr109`
- `npm.cmd run qa:pr107`
- `npm.cmd run qa:pr108`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:safety-engine`
- `npm.cmd run typecheck`
- `git diff --check`

The Next.js production build compiled successfully and completed lint/type validation. Final static prerender stopped at `/login` because this checkout intentionally lacks the required Supabase and other launch secrets. Vercel Preview remains the runtime build authority.

## Database and migration impact

None.

Detailed route intents are mapped to the existing coarse stored intent values so current Preview and Production schemas remain compatible. Full task-success diagnostics remain PR110.

## Safety considerations

- Medication and hormone change requests still stop at the existing safety boundary.
- Deterministic answers never mutate saved records.
- Explicit preserve-plan constraints are enforced directly for the production behavioral regression and passed as hard constraints to any model synthesis.
- Safety-review answers use current deterministic findings and never claim absolute safety.
- No diagnosis, treatment, or medication-management behavior is introduced.

## Risks and rollback

Risk is concentrated in intent classification. The golden suite covers exact production prompts plus paraphrase, typo, and mixed-intent cases.

Rollback: revert commit `9313f05`. No database rollback is needed.

## Not included

- task-success quality scoring or validator redesign (PR110)
- safety provenance or nutrient unit normalization (PR111)
- Today maintenance hierarchy
- goal/practice schema changes
- recommendation-to-action mutations
- adaptive weekly synthesis
