### PR TITLE
PR110: Validate coaching by task success

### DIFF
--- a/app/api/coach/route.ts
+++ b/app/api/coach/route.ts
@@ -162,6 +162,14 @@ export async function POST(req: NextRequest) {
       recommendationsRemoved: 0,
       regenerationCount: 0,
       evidenceIds: context.evidenceOptions.map((option) => option.id),
+      taskPassed: false,
+      taskCompleteness: 0,
+      factualCoverage: 0,
+      failedValidators: [],
+      missingRequirementCount: 0,
+      constraintViolationCount: 0,
+      repairReason: null,
+      fallbackReason: "model_unavailable",
     };
     try {
       const generated = await generateCoachAnswer(auth.user.id, question, context);
@@ -169,12 +177,27 @@ export async function POST(req: NextRequest) {
         answer = generated.answer;
         sourceRefs = context.sources.filter((source) => generated.sourceIds.includes(source.id));
         responseSource = generated.responseSource;
-        generationStatus = "succeeded";
         diagnostics = generated.diagnostics;
+        generationStatus = diagnostics.taskPassed ? "succeeded" : "failed";
       }
     } catch (error) {
       console.warn("[coach] generation unavailable; returning grounded fallback", error);
     }
+
+    console.info("[coach.validation]", {
+      intent: diagnostics.intent,
+      taskPassed: diagnostics.taskPassed,
+      qualityScore: diagnostics.qualityScore,
+      taskCompleteness: diagnostics.taskCompleteness,
+      factualCoverage: diagnostics.factualCoverage,
+      failedValidators: diagnostics.failedValidators,
+      missingRequirementCount: diagnostics.missingRequirementCount,
+      constraintViolationCount: diagnostics.constraintViolationCount,
+      regenerationCount: diagnostics.regenerationCount,
+      repairReason: diagnostics.repairReason,
+      fallbackReason: diagnostics.fallbackReason,
+      responseSource,
+    });
 
     const { data: turn, error: updateError } = await getSupabaseAdmin().from("ai_coaching_turns").update({
       answer,

--- a/docs/coach-intent-routing.md
+++ b/docs/coach-intent-routing.md
@@ -33,6 +33,6 @@ Ask LVE360 now builds one `MemberIntelligenceContext` snapshot per request. The 
 
 ## Diagnostics compatibility
 
-Detailed routing metadata is emitted to privacy-safe server logs without the member's question or health facts. The database keeps the existing coarse intent values so PR109 does not require a migration or break current Preview and Production schemas. Prompt telemetry is aligned on `contextual-coach-v3`.
+Detailed routing metadata is emitted to privacy-safe server logs without the member's question or health facts. The database keeps the existing coarse intent values so PR109 does not require a migration or break current Preview and Production schemas. Prompt telemetry is aligned on `contextual-coach-v4` after PR110's task-success validator upgrade.
 
-Task-success scoring remains PR110. PR109 intentionally does not redesign the existing quality score.
+PR110 now applies intent-specific [task-success validation](./coach-task-success-validation.md) after this routing path.

--- a/docs/coach-task-success-validation.md
+++ b/docs/coach-task-success-validation.md
@@ -1,0 +1,49 @@
+# Ask LVE360 task-success validation
+
+PR110 replaces the production coach's generic answer-shape score with deterministic validators for the job the member actually requested.
+
+## Validation path
+
+Each coaching request now follows this bounded path:
+
+1. Use the PR109 intent and explicit constraints.
+2. Prefer a deterministic task answer when one exists.
+3. Validate the rendered answer against the canonical member context.
+4. For a model answer, measure intent-specific completeness and factual coverage.
+5. If the first candidate fails, make one repair request containing the failed validator codes, missing requirements, and constraint violations.
+6. If the repair still fails, use a grounded deterministic fallback.
+7. If that fallback cannot complete the task, return a narrow non-guessing response and record the turn as failed.
+
+There is no open-ended retry loop.
+
+## Intent-specific checks
+
+- Regimen lookup checks every requested saved item, requested fields, and exclusion of unrequested item types.
+- Safety review checks each unresolved deterministic finding, its reason, and preserved regimen boundaries.
+- Behavioral coaching checks active-practice use, requested time horizon, and every explicit preserve-plan constraint.
+- Prioritization checks alignment with the active weekly practice or an explicit no-practice state.
+- Missing-context analysis checks actual missing fields and rejects claims that existing profile, goal, or practice data is missing.
+- Progress coaching checks requested metrics and appropriately bounded causal language.
+- Evidence comparison checks grounded option coverage and reasoning.
+- Out-of-scope requests check that Ask LVE360 preserves its product boundary.
+
+## Score compatibility
+
+`quality_score` remains a 0 to 100 column for compatibility, but it is now derived from the average completeness of the required validators. A response with a missing factual item, requested field, safety reason, or violated constraint cannot score 100.
+
+## Observability and privacy
+
+The existing `response_source`, `generation_status`, `quality_score`, and `regeneration_count` fields make the final outcome and bounded repair visible without a migration. Privacy-safe server diagnostics add:
+
+- intent
+- task-success status
+- completeness and factual coverage
+- failed validator IDs
+- counts of missing requirements and constraint violations
+- repair and fallback reason codes
+
+The member's question, regimen names, and health facts are not included in validation logs.
+
+## Database impact
+
+No migration is required. Detailed validator results remain in server diagnostics for this PR; the existing database columns preserve the durable compatibility signals.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "qa:pr107": "node --experimental-strip-types src/_tests_/pr107CoachingEngine.assert.ts && node src/_tests_/pr107Architecture.assert.mjs",
     "qa:pr108": "node --experimental-strip-types src/_tests_/pr108MemberContext.assert.ts && node src/_tests_/pr108Architecture.assert.mjs",
     "qa:pr109": "node --experimental-strip-types src/_tests_/pr109IntentRouting.assert.ts && node src/_tests_/pr109Architecture.assert.mjs",
+    "qa:pr110": "node --experimental-strip-types src/_tests_/pr110TaskSuccess.assert.ts && node src/_tests_/pr110Architecture.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr107Architecture.assert.mjs
+++ b/src/_tests_/pr107Architecture.assert.mjs
@@ -9,7 +9,7 @@ const migration = fs.readFileSync("supabase/migrations/20260813090000_pr107_coac
 assert.match(data, /classif(?:ied_intent|ied intent)/i, "The model must receive a deterministic intent.");
 assert.match(data, /curated evidence_options/i, "The prompt must distinguish LVE360 evidence from member records.");
 assert.match(data, /applySafetyChecks\(context\.safetyContext/, "Generated candidates must pass a deterministic post-generation safety check.");
-assert.match(data, /assessCoachAnswerQuality/, "A deterministic quality gate must run before display.");
+assert.match(data, /validateCoachTaskSuccess/, "A deterministic task-success gate must run before display.");
 assert.match(data, /fallbackStructured/, "A failed model or quality gate must have a useful evidence-bound repair path.");
 assert.match(data, /already_in_stack/, "The prompt context must explicitly identify existing Routine candidates.");
 assert.match(data, /Recommendation is not mutation/i, "The prompt must separate recommendations from stored-record changes.");

--- a/src/_tests_/pr109Architecture.assert.mjs
+++ b/src/_tests_/pr109Architecture.assert.mjs
@@ -22,7 +22,7 @@ assert.match(intent, /preserveMedicationPlan/);
 assert.match(intent, /preserveSupplementPlan/);
 assert.match(intent, /CURRENT_REGIMEN_LOOKUP/);
 assert.match(intent, /OUT_OF_SCOPE/);
-assert.match(intent, /contextual-coach-v3/);
-assert.match(modelConfig, /promptVersion:\s*"contextual-coach-v3"/, "Runtime ledger and saved-turn prompt versions must agree.");
+assert.match(intent, /contextual-coach-v4/);
+assert.match(modelConfig, /promptVersion:\s*"contextual-coach-v4"/, "Runtime ledger and saved-turn prompt versions must agree.");
 
 console.log("PR109 intent-first coaching architecture checks passed.");

--- a/src/_tests_/pr110Architecture.assert.mjs
+++ b/src/_tests_/pr110Architecture.assert.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const route = readFileSync("app/api/coach/route.ts", "utf8");
+const data = readFileSync("src/lib/ai/contextualCoachData.ts", "utf8");
+const validator = readFileSync("src/lib/coachTaskValidation.ts", "utf8");
+const modelConfig = readFileSync("src/lib/ai/modelConfig.ts", "utf8");
+
+assert.match(data, /validateCoachTaskSuccess/, "Production coaching must use intent-specific task-success validation.");
+assert.doesNotMatch(data, /assessCoachAnswerQuality/, "The shallow PR107 quality heuristic must no longer gate production coaching.");
+assert.match(data, /repairInstruction\(finalReport\)/, "The single repair attempt must receive explicit failed requirements.");
+assert.match(data, /regenerationCount = 1/, "Repair behavior must be bounded and observable.");
+assert.doesNotMatch(data, /for \(let attempt = 0; attempt < 2/, "The old parse-only retry loop must not remain in production.");
+assert.match(data, /narrowSafeFallback/, "Invalid repair and deterministic failures need a narrow non-guessing fallback.");
+assert.match(data, /fallbackReason/, "Fallback reasons must remain observable.");
+
+assert.match(validator, /REGIMEN_COVERAGE/);
+assert.match(validator, /REQUESTED_FIELDS/);
+assert.match(validator, /TYPE_EXCLUSIONS/);
+assert.match(validator, /SAFETY_FINDINGS/);
+assert.match(validator, /CONSTRAINT_ADHERENCE/);
+assert.match(validator, /MISSING_CONTEXT_ACCURACY/);
+assert.match(validator, /CAUSAL_BOUNDARY/);
+assert.match(validator, /MEMBER_CONTEXT_USE/);
+assert.match(validator, /score: Math\.round\(completeness \* 100\)/, "The compatibility score must be derived from measured task completion.");
+
+assert.match(route, /console\.info\("\[coach\.validation\]"/, "Privacy-safe task diagnostics must be emitted for each completed coaching attempt.");
+assert.match(route, /generationStatus = diagnostics\.taskPassed \? "succeeded" : "failed"/, "Safe incomplete fallbacks must not be recorded as successful answers.");
+assert.match(route, /regeneration_count: diagnostics\.regenerationCount/, "Repair count must remain stored in the existing diagnostics columns.");
+assert.match(data, /contextual-coach-v4|coach\.v4/);
+assert.match(modelConfig, /promptVersion:\s*"contextual-coach-v4"/);
+
+console.log("PR110 task-success architecture checks passed.");

--- a/src/_tests_/pr110TaskSuccess.assert.ts
+++ b/src/_tests_/pr110TaskSuccess.assert.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+
+import { deterministicCoachTask } from "../lib/coachIntent.ts";
+import { validateCoachTaskSuccess } from "../lib/coachTaskValidation.ts";
+import {
+  classifyCoachRequest,
+  type CoachRoutingDecision,
+  type StructuredCoachAnswer,
+} from "../lib/contextualCoach.ts";
+import type { CurrentRegimenItem, CurrentRegimenKind } from "../lib/currentRegimenModel.ts";
+import {
+  buildMemberIntelligenceContext,
+  type MemberIntelligenceContextInput,
+} from "../lib/memberContext.ts";
+
+const NOW = "2026-08-14T12:00:00.000Z";
+
+function regimenItem(index: number, kind: CurrentRegimenKind, overrides: Partial<CurrentRegimenItem> = {}): CurrentRegimenItem {
+  const name = overrides.name ?? `${kind} ${index}`;
+  return {
+    id: `regimen-${index}`,
+    user_id: "member-1",
+    source_submission_id: "submission-1",
+    source_stack_item_id: null,
+    item_kind: kind,
+    name,
+    normalized_name: name.toLowerCase(),
+    purpose: null,
+    dose: null,
+    timing: null,
+    brand: null,
+    reorder_url: null,
+    image_url: null,
+    product_source: null,
+    product_sku: null,
+    instruction_source: "intake",
+    instruction_authority: null,
+    schedule: null,
+    active: true,
+    created_at: "2026-08-01T12:00:00.000Z",
+    updated_at: "2026-08-13T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function memberInput(): MemberIntelligenceContextInput {
+  return {
+    generatedAt: NOW,
+    member: { id: "member-1", tier: "premium", joinedAt: "2026-07-01T12:00:00.000Z", updatedAt: NOW },
+    healthProfile: {
+      submissionId: "submission-1",
+      updatedAt: NOW,
+      age: 52,
+      sex: "male",
+      conditions: ["Hypertension"],
+      allergies: [],
+      procedures: [],
+      pregnant: null,
+      dosingPreference: null,
+      brandPreference: null,
+    },
+    preferences: {
+      preferredName: "Luke",
+      weightUnit: "lb",
+      reminderPreference: "email",
+      timezone: "America/Denver",
+      cueHour: 6,
+      quietStartHour: 21,
+      quietEndHour: 5,
+      updatedAt: NOW,
+    },
+    savedGoals: [{
+      label: "Improve sleep and energy",
+      kind: "named",
+      targetValue: null,
+      provenance: { source: "goals", recordId: "goal-1", updatedAt: NOW },
+    }],
+    goalsUpdatedAt: NOW,
+    blueprint: {
+      stack_id: "stack-1",
+      created_at: "2026-08-10T12:00:00.000Z",
+      goals: ["Improve sleep and energy"],
+      safety_status: "review",
+      safety_acknowledged: false,
+      needs_refresh: false,
+      priorities: [{ id: "priority-1", label: "Keep a consistent wake time", category: "sleep", kind: "lifestyle" }],
+    },
+    regimen: [
+      regimenItem(1, "medication", { name: "Zepbound", dose: "10 mg/0.5 mL", timing: "Sunday morning" }),
+      regimenItem(2, "medication", { name: "Lisinopril", dose: "10 mg", timing: "morning" }),
+      regimenItem(3, "hormone", { name: "Testosterone cypionate", dose: "80 mg", timing: "twice weekly" }),
+      regimenItem(4, "supplement", { name: "Magnesium glycinate", dose: "200 mg", timing: "evening" }),
+      regimenItem(5, "endocrine_active_supplement", { name: "DHEA" }),
+    ],
+    experiments: [{
+      id: "experiment-1",
+      source_stack_id: "stack-1",
+      source_action_id: "priority-1",
+      identity_direction: "sleep",
+      action_label: "Keep a consistent wake time",
+      cue: "After my alarm",
+      frequency_per_week: 5,
+      minimum_version: "Get out of bed at the planned time",
+      status: "active",
+      week_start: "2026-08-10",
+      created_at: "2026-08-10T12:00:00.000Z",
+      updated_at: NOW,
+    }],
+    reviews: [],
+    completions: [{ id: "completion-1", experiment_id: "experiment-1", completion_date: "2026-08-12", completion_kind: "full", updated_at: NOW }],
+    practiceBlueprintContexts: {
+      "experiment-1": {
+        source_stack_id: "stack-1",
+        source_action_id: "priority-1",
+        priority_label: "Keep a consistent wake time",
+        priority_category: "sleep",
+        priority_kind: "lifestyle",
+        blueprint_created_at: "2026-08-10T12:00:00.000Z",
+        is_current_blueprint: true,
+        needs_review: false,
+      },
+    },
+    checkIns: [{ id: "log-1", log_date: "2026-08-13", weight: 200, sleep: 2, energy: 5, updated_at: NOW }],
+    safetyFindings: [{
+      code: "interaction_anticoagulant",
+      item: "Omega-3",
+      message: "Review possible additive bleeding risk with the recorded anticoagulant.",
+      severity: "danger",
+      decision: "blocked",
+      source: "interactions",
+      sourceUrl: "https://example.com/source",
+    }],
+    safetyEvaluationComplete: true,
+  };
+}
+
+const context = buildMemberIntelligenceContext(memberInput());
+
+function validate(route: CoachRoutingDecision, question: string, answerText: string, structuredAnswer: StructuredCoachAnswer | null = null, evidenceOptionNames: string[] = []) {
+  return validateCoachTaskSuccess({
+    route,
+    question,
+    answerText,
+    structuredAnswer,
+    evidenceOptionNames,
+    memberContext: context,
+    safetyChecked: true,
+  });
+}
+
+function deterministicPass(question: string) {
+  const route = classifyCoachRequest(question);
+  const answer = deterministicCoachTask(route, context, question);
+  assert.ok(answer, `Expected a deterministic task for: ${question}`);
+  const report = validate(route, question, answer.answer);
+  assert.equal(report.passed, true, `Expected golden task to pass: ${question}\n${JSON.stringify(report, null, 2)}`);
+  assert.equal(report.score, 100, `A complete deterministic task should retain a measurable 100 score: ${question}`);
+  return { route, answer, report };
+}
+
+const regimenQuestion = "What medications and hormones do I currently have saved, including doses and timing?";
+const regimen = deterministicPass(regimenQuestion);
+const wrongRegimen = validate(
+  regimen.route,
+  regimenQuestion,
+  "Your current medication is Magnesium glycinate, 200 mg in the evening. Next step: keep taking it.",
+);
+assert.equal(wrongRegimen.passed, false);
+assert.notEqual(wrongRegimen.score, 100, "A wrong medication lookup can never receive a perfect score.");
+assert(wrongRegimen.failedValidators.includes("REGIMEN_COVERAGE"));
+assert(wrongRegimen.failedValidators.includes("TYPE_EXCLUSIONS"));
+
+const safetyQuestion = "Which items in my current routine need clinician or pharmacist review, and why?";
+const safety = deterministicPass(safetyQuestion);
+const wrongSafety = validate(safety.route, safetyQuestion, "Everything looks fine. No review is needed.");
+assert.equal(wrongSafety.passed, false);
+assert(wrongSafety.failedValidators.includes("SAFETY_FINDINGS"));
+assert(wrongSafety.failedValidators.includes("SAFETY_REASONING"));
+
+const priorityQuestion = "Based on my saved goals, recent check-ins, and active weekly practice, what is the highest-value action I should focus on this week?";
+const priority = deterministicPass(priorityQuestion);
+const wrongPriority = validate(priority.route, priorityQuestion, "Add magnesium this week because it may support sleep.");
+assert.equal(wrongPriority.passed, false);
+assert(wrongPriority.failedValidators.includes("PRIORITY_ALIGNMENT"));
+
+const behaviorQuestion = "I slept poorly last night. How should I adjust tomorrow without changing my medications or supplements?";
+const behavior = deterministicPass(behaviorQuestion);
+const wrongBehavior = validate(
+  behavior.route,
+  behaviorQuestion,
+  "Tomorrow, increase Zepbound and add Magnesium glycinate. This should improve sleep.",
+);
+assert.equal(wrongBehavior.passed, false);
+assert(wrongBehavior.failedValidators.includes("CONSTRAINT_ADHERENCE"));
+assert.deepEqual(
+  [...wrongBehavior.constraintViolations].sort(),
+  ["preserve_medication_plan", "preserve_supplement_plan"],
+  "Every explicit preserve-plan constraint must be enforced independently.",
+);
+
+const missingQuestion = "What important information is missing from my profile that would make your recommendations better?";
+const missing = deterministicPass(missingQuestion);
+const wrongMissing = validate(missing.route, missingQuestion, "Your health profile and goals are missing. Add those first.");
+assert.equal(wrongMissing.passed, false);
+assert(wrongMissing.failedValidators.includes("MISSING_CONTEXT_ACCURACY"));
+assert(wrongMissing.constraintViolations.includes("existing_health_profile_labeled_missing"));
+assert(wrongMissing.constraintViolations.includes("existing_goals_labeled_missing"));
+
+const outsideQuestion = "What is the capital of France?";
+const outside = deterministicPass(outsideQuestion);
+const wrongOutside = validate(outside.route, outsideQuestion, "The capital of France is Paris.");
+assert.equal(wrongOutside.passed, false);
+assert(wrongOutside.failedValidators.includes("OUT_OF_SCOPE_BOUNDARY"));
+
+const progressQuestion = "What pattern do my sleep and energy check-ins show this week?";
+const progressRoute = classifyCoachRequest(progressQuestion);
+assert.equal(progressRoute.intent, "PROGRESS_COACHING");
+const goodProgress = validate(
+  progressRoute,
+  progressQuestion,
+  "Your recent sleep and energy check-ins are observations, not proof that one habit caused the pattern. Keep a consistent wake time this week and continue recording both metrics.",
+);
+assert.equal(goodProgress.passed, true);
+const wrongProgress = validate(progressRoute, progressQuestion, "Your sleep proves the supplement worked.");
+assert.equal(wrongProgress.passed, false);
+assert(wrongProgress.failedValidators.includes("PROGRESS_METRICS"));
+assert(wrongProgress.failedValidators.includes("CAUSAL_BOUNDARY"));
+
+const comparisonQuestion = "Compare glycine and melatonin for my sleep goal.";
+const comparisonRoute = classifyCoachRequest(comparisonQuestion);
+assert.equal(comparisonRoute.intent, "EVIDENCE_COMPARISON");
+const comparisonAnswer: StructuredCoachAnswer = {
+  intent: "EVIDENCE_COMPARISON",
+  directAnswer: "Both options can be compared, but they fit different sleep problems.",
+  options: [
+    { name: "Glycine", fit: "strong", reason: "It may fit sleep quality and next-day tiredness." },
+    { name: "Melatonin", fit: "neutral", reason: "It is more directly relevant to sleep timing." },
+  ],
+  recommendation: null,
+  nextStep: "Choose one outcome to track before selecting an option.",
+  sourceIds: ["evidence_glycine", "evidence_melatonin"],
+};
+const goodComparison = validate(comparisonRoute, comparisonQuestion, `${comparisonAnswer.directAnswer} ${comparisonAnswer.options.map((item) => item.reason).join(" ")} ${comparisonAnswer.nextStep}`, comparisonAnswer, ["Glycine", "Melatonin"]);
+assert.equal(goodComparison.passed, true);
+const wrongComparison = validate(comparisonRoute, comparisonQuestion, "Magnesium is best. Try it.", null, ["Glycine", "Melatonin"]);
+assert.equal(wrongComparison.passed, false);
+assert(wrongComparison.failedValidators.includes("EVIDENCE_COVERAGE"));
+
+const personalizedQuestion = "What supplement makes sense for me for my sleep and energy goal?";
+const personalizedRoute = classifyCoachRequest(personalizedQuestion);
+assert.equal(personalizedRoute.intent, "PERSONALIZED_RECOMMENDATION");
+const personalizedAnswer: StructuredCoachAnswer = {
+  intent: "PERSONALIZED_RECOMMENDATION",
+  directAnswer: "Glycine is the more relevant option for your recorded goal to improve sleep and energy.",
+  options: [{ name: "Glycine", fit: "strong", reason: "It may fit sleep quality and next-day tiredness." }],
+  recommendation: { candidate: "Glycine", reason: "It matches the recorded sleep goal.", trialPeriodDays: 14, metrics: ["sleep quality", "energy"] },
+  nextStep: "Track sleep quality and energy for 14 days before deciding whether it helped.",
+  sourceIds: ["goals", "evidence_glycine"],
+};
+const goodPersonalized = validate(personalizedRoute, personalizedQuestion, `${personalizedAnswer.directAnswer} ${personalizedAnswer.options[0].reason} ${personalizedAnswer.nextStep}`, personalizedAnswer, ["Glycine"]);
+assert.equal(goodPersonalized.passed, true);
+const genericPersonalized: StructuredCoachAnswer = {
+  ...personalizedAnswer,
+  directAnswer: "This option has a plausible general wellness rationale and may be worth considering.",
+  sourceIds: ["evidence_glycine"],
+};
+const wrongPersonalized = validate(personalizedRoute, personalizedQuestion, `${genericPersonalized.directAnswer} ${genericPersonalized.options[0].reason} ${genericPersonalized.nextStep}`, genericPersonalized, ["Glycine"]);
+assert.equal(wrongPersonalized.passed, false);
+assert(wrongPersonalized.failedValidators.includes("MEMBER_CONTEXT_USE"));
+
+const malformed = validate(comparisonRoute, comparisonQuestion, "{\"answer\":\"looks valid\"}", null, ["Glycine", "Melatonin"]);
+assert.equal(malformed.passed, false);
+assert(malformed.failedValidators.includes("STRUCTURE"));
+
+console.log("PR110 task-success validation scenarios passed.");

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -4,17 +4,20 @@ import { generateAI } from "@/lib/ai/gateway";
 import { evidenceOptionByName, retrieveCoachEvidence, type CoachEvidenceOption } from "@/lib/coachEvidence";
 import { deterministicCoachTask } from "@/lib/coachIntent";
 import {
-  assessCoachAnswerQuality,
   parseStructuredCoachAnswer,
   type CoachConstraints,
   type CoachIntent,
   type CoachPage,
-  type CoachQualityReport,
   type CoachRegimenKind,
   type CoachRoutingDecision,
   type CoachSource,
   type StructuredCoachAnswer,
 } from "@/lib/contextualCoach";
+import {
+  validateCoachTaskSuccess,
+  type CoachTaskSuccessReport,
+  type CoachTaskValidatorId,
+} from "@/lib/coachTaskValidation";
 import { healthItemIdentityKey } from "@/lib/healthItemIdentity";
 import type { MemberIntelligenceContext, MemberRegimenItemContext } from "@/lib/memberContext";
 import { getMemberIntelligenceContext } from "@/lib/memberContextData";
@@ -43,6 +46,14 @@ export type CoachDiagnostics = {
   recommendationsRemoved: number;
   regenerationCount: number;
   evidenceIds: string[];
+  taskPassed: boolean;
+  taskCompleteness: number;
+  factualCoverage: number;
+  failedValidators: CoachTaskValidatorId[];
+  missingRequirementCount: number;
+  constraintViolationCount: number;
+  repairReason: "parse_failed" | "task_validation_failed" | null;
+  fallbackReason: "model_unavailable" | "repair_failed" | "deterministic_validation_failed" | null;
 };
 
 const INTENT_SOURCE_IDS: Record<CoachIntent, string[]> = {
@@ -345,11 +356,13 @@ export async function buildCoachContext(
   };
 }
 
-function supplementQuestion(question: string, context: CoachContext) {
-  return context.evidenceOptions.length > 0 || /\b(?:supplement|vitamin|mineral|magnesium|glycine|melatonin|theanine|creatine|coq10|b[- ]?12|omega[- ]?3|ashwagandha)\b/i.test(question);
-}
+type CoachRepairInstruction = {
+  failedValidators: CoachTaskValidatorId[];
+  missingRequirements: string[];
+  constraintViolations: string[];
+};
 
-function prompt(question: string, context: CoachContext, repair = false) {
+function prompt(question: string, context: CoachContext, repair: CoachRepairInstruction | null = null) {
   return [
     {
       role: "system" as const,
@@ -366,7 +379,9 @@ function prompt(question: string, context: CoachContext, repair = false) {
         "Do not recommend adding an already_in_stack item again. Discuss its recorded form, dose, or timing instead when available.",
         "Do not recommend an option whose safety_status is REMOVE. An ALLOW_WITH_NOTE option must retain its supplied safety note.",
         "Use supportive plain language and no shame. Keep the result concise enough for mobile use.",
-        repair ? "The previous candidate failed the quality gate. Be concrete, name supported options when asked, and include a useful next step." : "",
+        repair
+          ? "The previous candidate failed task-success validation. Correct every supplied failed validator, missing requirement, and constraint violation. Do not merely rephrase the previous answer."
+          : "",
         "Return only valid JSON with: intent, direct_answer, options, recommendation, next_step, source_ids.",
         "options is an array of {name, fit: strong|neutral|weak, reason}; use only exact names from evidence_options. recommendation is null or {candidate, reason, trial_period_days, metrics}. source_ids must use only supplied source IDs.",
       ].filter(Boolean).join(" "),
@@ -380,6 +395,7 @@ function prompt(question: string, context: CoachContext, repair = false) {
         current_page: context.page,
         available_sources: context.sources.map(({ id, label, summary }) => ({ id, label, summary })),
         member_context_and_evidence: context.facts,
+        repair_requirements: repair,
       }),
     },
   ];
@@ -482,9 +498,15 @@ function fallbackStructured(question: string, context: CoachContext): Structured
   const safetyByName = new Map(context.preSafety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
   const available = context.evidenceOptions.filter((option) => safetyByName.get(healthItemIdentityKey(option.name))?.decision !== "blocked").slice(0, 3);
   const topic = /\bsleep\b/i.test(question) ? "sleep" : /\benergy|fatigue|tired\b/i.test(question) ? "energy" : "your goal";
-  const directAnswer = available.length
+  const recordedGoal = context.memberContext.goals.saved.value[0]?.label
+    ?? context.memberContext.goals.blueprint.value[0]
+    ?? null;
+  const directAnswerBase = available.length
     ? `Several evidence-informed options may fit ${topic}, but they are useful for different reasons. The best choice depends on your current routine, the outcome you want, and the LVE360 safety checks.`
     : `The available LVE360 evidence options for ${topic} all require a higher level of review based on the information currently saved, so I would not select one as a new experiment yet.`;
+  const directAnswer = recordedGoal
+    ? `${directAnswerBase} Your recorded goal is ${recordedGoal}.`
+    : directAnswerBase;
   const current = available.find((option) => safetyByName.get(healthItemIdentityKey(option.name))?.isCurrent);
   const selected = current ?? available[0] ?? null;
   return {
@@ -590,6 +612,79 @@ function renderAnswer(answer: StructuredCoachAnswer, context: CoachContext, safe
   return lines.join("\n");
 }
 
+function validateRenderedTask(
+  routing: CoachRoutingDecision,
+  question: string,
+  context: CoachContext,
+  answerText: string,
+  structuredAnswer: StructuredCoachAnswer | null,
+  safetyChecked: boolean,
+) {
+  return validateCoachTaskSuccess({
+    route: routing,
+    question,
+    answerText,
+    memberContext: context.memberContext,
+    structuredAnswer,
+    evidenceOptionNames: context.evidenceOptions.map((option) => option.name),
+    safetyChecked,
+    allCandidatesBlocked: Boolean(
+      context.preSafety?.candidates.length
+      && context.preSafety.candidates.every((candidate) => candidate.decision === "blocked"),
+    ),
+  });
+}
+
+function repairInstruction(report: CoachTaskSuccessReport): CoachRepairInstruction {
+  return {
+    failedValidators: report.failedValidators,
+    missingRequirements: report.missingRequirements,
+    constraintViolations: report.constraintViolations,
+  };
+}
+
+function narrowSafeFallback(context: CoachContext) {
+  const sourceIds = context.sources
+    .filter((source) => !source.id.startsWith("evidence_"))
+    .map((source) => source.id);
+  return {
+    answer: "I could not verify a complete, grounded answer to this request, so I will not guess. Your saved information and Routine are unchanged. Review the linked LVE360 record, then try one narrower question.",
+    sourceIds,
+    responseSource: "fallback" as const,
+  };
+}
+
+function diagnosticsFromReport(
+  context: CoachContext,
+  report: CoachTaskSuccessReport,
+  values: {
+    safetyRuleCount: number;
+    recommendationsRemoved: number;
+    regenerationCount: number;
+    evidenceIds: string[];
+    repairReason: CoachDiagnostics["repairReason"];
+    fallbackReason: CoachDiagnostics["fallbackReason"];
+  },
+): CoachDiagnostics {
+  return {
+    intent: context.intent,
+    constraints: context.constraints,
+    qualityScore: report.score,
+    safetyRuleCount: values.safetyRuleCount,
+    recommendationsRemoved: values.recommendationsRemoved,
+    regenerationCount: values.regenerationCount,
+    evidenceIds: values.evidenceIds,
+    taskPassed: report.passed,
+    taskCompleteness: report.completeness,
+    factualCoverage: report.factualCoverage,
+    failedValidators: report.failedValidators,
+    missingRequirementCount: report.missingRequirements.length,
+    constraintViolationCount: report.constraintViolations.length,
+    repairReason: values.repairReason,
+    fallbackReason: values.fallbackReason,
+  };
+}
+
 export async function generateCoachAnswer(userId: string, question: string, context: CoachContext) {
   const routing: CoachRoutingDecision = {
     intent: context.intent,
@@ -602,87 +697,157 @@ export async function generateCoachAnswer(userId: string, question: string, cont
     ?? deterministicTodayStep(question, context)
     ?? deterministicJourneyPattern(question, context);
   if (deterministic) {
+    const taskReport = validateRenderedTask(routing, question, context, deterministic.answer, null, true);
+    if (!taskReport.passed) {
+      const fallback = narrowSafeFallback(context);
+      return {
+        ...fallback,
+        diagnostics: diagnosticsFromReport(context, taskReport, {
+          safetyRuleCount: context.preSafety?.findings.length ?? 0,
+          recommendationsRemoved: 0,
+          regenerationCount: 0,
+          evidenceIds: context.evidenceOptions.map((option) => option.id),
+          repairReason: null,
+          fallbackReason: "deterministic_validation_failed",
+        }),
+      };
+    }
     return {
       ...deterministic,
-      diagnostics: {
-        intent: context.intent,
-        constraints: context.constraints,
-        qualityScore: 100,
+      diagnostics: diagnosticsFromReport(context, taskReport, {
         safetyRuleCount: context.preSafety?.findings.length ?? 0,
         recommendationsRemoved: 0,
         regenerationCount: 0,
         evidenceIds: context.evidenceOptions.map((option) => option.id),
-      } satisfies CoachDiagnostics,
+        repairReason: null,
+        fallbackReason: null,
+      }),
     };
   }
 
   const validSourceIds = new Set(context.sources.map((source) => source.id));
   const allowedNames = new Set(context.evidenceOptions.map((option) => option.name.toLowerCase()));
-  const isSupplementQuestion = supplementQuestion(question, context);
+  const safetyChecked = !context.evidenceOptions.length || Boolean(context.preSafety?.complete);
   let regenerationCount = 0;
-  let proposal: StructuredCoachAnswer | null = null;
-  let generatedByModel = false;
-  for (let attempt = 0; attempt < 2 && !proposal; attempt += 1) {
+  let repairReason: CoachDiagnostics["repairReason"] = null;
+  let fallbackReason: CoachDiagnostics["fallbackReason"] = null;
+  let finalValidated: Awaited<ReturnType<typeof postValidate>> | null = null;
+  let finalRendered = "";
+  let finalReport: CoachTaskSuccessReport | null = null;
+  let responseSource: "ai" | "fallback" = "ai";
+
+  const evaluateProposal = async (proposal: StructuredCoachAnswer) => {
+    const validated = await postValidate(question, context, proposal);
+    const rendered = renderAnswer(validated.answer, context, validated.safety);
+    const report = validateRenderedTask(
+      routing,
+      question,
+      context,
+      rendered,
+      validated.answer,
+      validated.answer.options.length === 0 || Boolean(validated.safety?.complete),
+    );
+    return { validated, rendered, report };
+  };
+
+  let firstProposal: StructuredCoachAnswer | null = null;
+  try {
+    const response = await generateAI({
+      task: "contextual_coach",
+      userId,
+      messages: prompt(question, context),
+      maxTokens: 650,
+      timeoutMs: 20_000,
+      temperature: 0.2,
+    });
+    firstProposal = parseStructuredCoachAnswer(response.text, context.intent, validSourceIds, allowedNames);
+  } catch (error) {
+    fallbackReason = "model_unavailable";
+    console.warn("[coach.v4] model unavailable; using grounded fallback", error);
+  }
+
+  if (firstProposal) {
+    const evaluated = await evaluateProposal(firstProposal);
+    finalValidated = evaluated.validated;
+    finalRendered = evaluated.rendered;
+    finalReport = evaluated.report;
+  } else if (!fallbackReason) {
+    finalReport = validateRenderedTask(routing, question, context, "", null, safetyChecked);
+    repairReason = "parse_failed";
+  }
+
+  if (!fallbackReason && finalReport && !finalReport.passed) {
+    regenerationCount = 1;
+    repairReason ??= "task_validation_failed";
     try {
-      const response = await generateAI({
+      const repairResponse = await generateAI({
         task: "contextual_coach",
         userId,
-        messages: prompt(question, context, attempt > 0),
+        messages: prompt(question, context, repairInstruction(finalReport)),
         maxTokens: 650,
         timeoutMs: 20_000,
-        temperature: 0.2,
+        temperature: 0.1,
       });
-      proposal = parseStructuredCoachAnswer(response.text, context.intent, validSourceIds, allowedNames);
-      if (proposal) generatedByModel = true;
-      if (!proposal && attempt === 0) regenerationCount = 1;
+      const repairedProposal = parseStructuredCoachAnswer(repairResponse.text, context.intent, validSourceIds, allowedNames);
+      if (repairedProposal) {
+        const repaired = await evaluateProposal(repairedProposal);
+        finalValidated = repaired.validated;
+        finalRendered = repaired.rendered;
+        finalReport = repaired.report;
+      } else {
+        fallbackReason = "repair_failed";
+      }
     } catch (error) {
-      console.warn("[coach.v3] model unavailable; using deterministic evidence repair", error);
-      break;
+      fallbackReason = "repair_failed";
+      console.warn("[coach.v4] bounded repair unavailable; using grounded fallback", error);
     }
   }
-  proposal ??= fallbackStructured(question, context);
-  let validated = await postValidate(question, context, proposal);
-  let rendered = renderAnswer(validated.answer, context, validated.safety);
-  let quality: CoachQualityReport = assessCoachAnswerQuality({
-    answer: validated.answer,
-    supplementQuestion: isSupplementQuestion,
-    safetyChecked: !isSupplementQuestion || Boolean(validated.safety?.complete),
-    usedMemberContext: context.intent !== "GENERAL_EDUCATION",
-    allCandidatesBlocked: Boolean(context.preSafety?.candidates.length && context.preSafety.candidates.every((candidate) => candidate.decision === "blocked")),
-  });
-  if (!quality.passed) {
-    regenerationCount = Math.max(regenerationCount, 1);
-    validated = await postValidate(question, context, fallbackStructured(question, context));
-    rendered = renderAnswer(validated.answer, context, validated.safety);
-    quality = assessCoachAnswerQuality({
-      answer: validated.answer,
-      supplementQuestion: isSupplementQuestion,
-      safetyChecked: !isSupplementQuestion || Boolean(validated.safety?.complete),
-      usedMemberContext: context.intent !== "GENERAL_EDUCATION",
-      allCandidatesBlocked: Boolean(context.preSafety?.candidates.length && context.preSafety.candidates.every((candidate) => candidate.decision === "blocked")),
-    });
+
+  if (!finalReport?.passed) {
+    responseSource = "fallback";
+    fallbackReason ??= "repair_failed";
+    const fallback = await evaluateProposal(fallbackStructured(question, context));
+    finalValidated = fallback.validated;
+    finalRendered = fallback.rendered;
+    finalReport = fallback.report;
   }
-  const evidenceIds = validated.answer.options
+
+  if (!finalValidated || !finalReport || !finalReport.passed) {
+    const safe = narrowSafeFallback(context);
+    const report = finalReport ?? validateRenderedTask(routing, question, context, safe.answer, null, safetyChecked);
+    return {
+      ...safe,
+      diagnostics: diagnosticsFromReport(context, report, {
+        safetyRuleCount: context.preSafety?.findings.length ?? 0,
+        recommendationsRemoved: finalValidated?.removed ?? 0,
+        regenerationCount,
+        evidenceIds: [],
+        repairReason,
+        fallbackReason: fallbackReason ?? "repair_failed",
+      }),
+    };
+  }
+
+  const evidenceIds = finalValidated.answer.options
     .map((option) => evidenceOptionByName(context.evidenceOptions, option.name)?.id)
     .filter((id): id is string => Boolean(id));
   const sourceIds = [...new Set([
-    ...validated.answer.sourceIds,
+    ...finalValidated.answer.sourceIds,
     ...evidenceIds,
-    ...(validated.safety?.findings.length && validSourceIds.has("current_routine") ? ["current_routine"] : []),
-    ...(validated.safety?.findings.length && validSourceIds.has("health_profile") ? ["health_profile"] : []),
+    ...(finalValidated.safety?.findings.length && validSourceIds.has("current_routine") ? ["current_routine"] : []),
+    ...(finalValidated.safety?.findings.length && validSourceIds.has("health_profile") ? ["health_profile"] : []),
   ])].filter((id) => validSourceIds.has(id));
   return {
-    answer: rendered,
+    answer: finalRendered,
     sourceIds,
-    responseSource: generatedByModel ? "ai" as const : "fallback" as const,
-    diagnostics: {
-      intent: context.intent,
-      constraints: context.constraints,
-      qualityScore: quality.score,
-      safetyRuleCount: validated.safety?.findings.length ?? 0,
-      recommendationsRemoved: validated.removed,
+    responseSource,
+    diagnostics: diagnosticsFromReport(context, finalReport, {
+      safetyRuleCount: finalValidated.safety?.findings.length ?? 0,
+      recommendationsRemoved: finalValidated.removed,
       regenerationCount,
       evidenceIds,
-    } satisfies CoachDiagnostics,
+      repairReason,
+      fallbackReason,
+    }),
   };
 }

--- a/src/lib/ai/modelConfig.ts
+++ b/src/lib/ai/modelConfig.ts
@@ -75,7 +75,7 @@ const TASK_PROFILES: Record<AiTask, AiTaskProfile> = {
   },
   contextual_coach: {
     capability: "mini",
-    promptVersion: "contextual-coach-v3",
+    promptVersion: "contextual-coach-v4",
     reasoningEffort: "low",
   },
 };

--- a/src/lib/coachIntent.ts
+++ b/src/lib/coachIntent.ts
@@ -6,6 +6,7 @@ import type {
   MemberIntelligenceContext,
   MemberRegimenItemContext,
 } from "./memberContext";
+import { missingContextRequirements } from "./coachTaskValidation.ts";
 import { regimenScheduleLabel } from "./regimenSchedule.ts";
 
 export type DeterministicCoachTaskResult = {
@@ -96,23 +97,7 @@ function safetyReview(context: MemberIntelligenceContext): DeterministicCoachTas
 }
 
 function missingContext(context: MemberIntelligenceContext): DeterministicCoachTaskResult {
-  const gaps: string[] = [];
-  const regimen = [
-    ...context.regimen.medications.value,
-    ...context.regimen.hormones.value,
-    ...context.regimen.supplements.value,
-    ...context.regimen.endocrineActiveSupplements.value,
-  ];
-  const missingDose = regimen.filter((item) => !item.dose?.trim()).map((item) => item.name);
-  const missingTiming = regimen.filter((item) => !item.timing?.trim()).map((item) => item.name);
-  if (missingDose.length) gaps.push(`Add the missing dose for ${missingDose.join(", ")}.`);
-  if (missingTiming.length) gaps.push(`Add the missing timing for ${missingTiming.join(", ")}.`);
-  if (context.healthProfile.status === "missing") gaps.push("Complete the intake health profile so conditions, allergies, procedures, and life-stage context can be checked.");
-  if (context.goals.saved.status === "missing" && context.goals.blueprint.status === "missing") gaps.push("Record at least one current goal so coaching can prioritize the outcome that matters most.");
-  if (context.recentCheckIns.status === "missing") gaps.push("Record a few sleep, energy, or weight check-ins so LVE360 can distinguish a one-day issue from a pattern.");
-  if (context.activePractice.status === "missing") gaps.push("Choose one active weekly practice so daily coaching can support a specific action.");
-  if (context.preferences.status === "missing") gaps.push("Save timezone and reminder preferences so timing guidance matches your day.");
-  const selected = gaps.slice(0, 5);
+  const selected = missingContextRequirements(context).map((requirement) => requirement.label);
   return {
     answer: selected.length
       ? `The most useful missing information is:\n\n${selected.map((item, index) => `${index + 1}. ${item}`).join("\n")}\n\nI only listed fields that are actually absent from your current LVE360 context.`
@@ -157,7 +142,9 @@ function behavioralAdjustment(route: CoachRoutingDecision, context: MemberIntell
   const practice = context.activePractice.value;
   const practiceStep = practice?.minimumVersion
     ? `Use the minimum version of your weekly practice if energy is low: ${practice.minimumVersion}.`
-    : "Choose a lighter version of planned activity if you feel unusually tired.";
+    : practice?.actionLabel
+      ? `Choose a lighter version of your current weekly practice, ${practice.actionLabel}, if you feel unusually tired.`
+      : "Choose a lighter version of planned activity if you feel unusually tired.";
   return {
     answer: `${preserveText} Tomorrow, keep your usual wake time, get outdoor light and gentle movement early in the day, and avoid turning one poor night into an all-or-nothing day. ${practiceStep} In the evening, return to your normal wind-down and record sleep and energy so LVE360 can see whether this was a one-night event or part of a pattern.`,
     sourceIds: ["weekly_practice", "recent_check_ins", "goals", "preferences"],

--- a/src/lib/coachTaskValidation.ts
+++ b/src/lib/coachTaskValidation.ts
@@ -1,0 +1,454 @@
+import type {
+  CoachIntent,
+  CoachRoutingDecision,
+  StructuredCoachAnswer,
+} from "./contextualCoach.ts";
+import type {
+  MemberIntelligenceContext,
+  MemberRegimenItemContext,
+} from "./memberContext.ts";
+import { regimenScheduleLabel } from "./regimenSchedule.ts";
+
+export type CoachTaskValidatorId =
+  | "STRUCTURE"
+  | "REGIMEN_COVERAGE"
+  | "REQUESTED_FIELDS"
+  | "TYPE_EXCLUSIONS"
+  | "SAFETY_FINDINGS"
+  | "SAFETY_REASONING"
+  | "CONSTRAINT_ADHERENCE"
+  | "ACTIVE_PRACTICE_USE"
+  | "REQUESTED_TIME_HORIZON"
+  | "PRIORITY_ALIGNMENT"
+  | "MISSING_CONTEXT_ACCURACY"
+  | "PROGRESS_METRICS"
+  | "CAUSAL_BOUNDARY"
+  | "MEMBER_CONTEXT_USE"
+  | "OUT_OF_SCOPE_BOUNDARY"
+  | "EVIDENCE_COVERAGE"
+  | "REASONING"
+  | "ACTIONABILITY";
+
+export type CoachTaskValidatorResult = {
+  validator: CoachTaskValidatorId;
+  passed: boolean;
+  completeness: number;
+  missingRequirements: string[];
+  constraintViolations: string[];
+};
+
+export type CoachTaskSuccessReport = {
+  intent: CoachIntent;
+  passed: boolean;
+  score: number;
+  completeness: number;
+  factualCoverage: number;
+  validators: CoachTaskValidatorResult[];
+  failedValidators: CoachTaskValidatorId[];
+  missingRequirements: string[];
+  constraintViolations: string[];
+};
+
+export type MissingContextRequirement = {
+  code: string;
+  label: string;
+  matchTerms: string[];
+};
+
+type CoachTaskValidationInput = {
+  route: CoachRoutingDecision;
+  question: string;
+  answerText: string;
+  memberContext: MemberIntelligenceContext;
+  structuredAnswer?: StructuredCoachAnswer | null;
+  evidenceOptionNames?: string[];
+  safetyChecked?: boolean;
+  allCandidatesBlocked?: boolean;
+};
+
+const REGIMEN_LOOKUP_INTENTS = new Set<CoachIntent>([
+  "CURRENT_REGIMEN_LOOKUP",
+  "MEDICATION_LOOKUP",
+  "HORMONE_LOOKUP",
+  "SUPPLEMENT_LOOKUP",
+  "CURRENT_PLAN_LOOKUP",
+]);
+
+const STOP_WORDS = new Set([
+  "about", "after", "again", "because", "before", "being", "current", "deterministic",
+  "information", "possible", "recorded", "review", "routine", "saved", "should", "these",
+  "using", "with", "your",
+]);
+
+function normalized(value: string) {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function containsValue(answer: string, value: string | null | undefined) {
+  const expected = normalized(value ?? "");
+  return Boolean(expected) && normalized(answer).includes(expected);
+}
+
+function ratio(passed: number, total: number) {
+  if (total <= 0) return 1;
+  return Math.max(0, Math.min(1, passed / total));
+}
+
+function result(
+  validator: CoachTaskValidatorId,
+  completeness: number,
+  missingRequirements: string[] = [],
+  constraintViolations: string[] = [],
+): CoachTaskValidatorResult {
+  const bounded = Math.max(0, Math.min(1, completeness));
+  return {
+    validator,
+    passed: bounded === 1 && missingRequirements.length === 0 && constraintViolations.length === 0,
+    completeness: bounded,
+    missingRequirements,
+    constraintViolations,
+  };
+}
+
+function allRegimen(context: MemberIntelligenceContext) {
+  return [
+    ...context.regimen.medications.value,
+    ...context.regimen.hormones.value,
+    ...context.regimen.supplements.value,
+    ...context.regimen.endocrineActiveSupplements.value,
+  ];
+}
+
+function requestedItems(route: CoachRoutingDecision, context: MemberIntelligenceContext) {
+  const kinds = route.requestedRegimenKinds.length
+    ? route.requestedRegimenKinds
+    : route.intent === "MEDICATION_LOOKUP"
+      ? ["medication" as const]
+      : route.intent === "HORMONE_LOOKUP"
+        ? ["hormone" as const]
+        : route.intent === "SUPPLEMENT_LOOKUP" || route.intent === "CURRENT_PLAN_LOOKUP"
+          ? ["supplement" as const, "endocrine_active_supplement" as const]
+          : ["medication" as const, "hormone" as const, "supplement" as const, "endocrine_active_supplement" as const];
+  const requested = new Set(kinds);
+  return {
+    requested: allRegimen(context).filter((item) => requested.has(item.item_kind)),
+    excluded: allRegimen(context).filter((item) => !requested.has(item.item_kind)),
+  };
+}
+
+function fieldRequested(question: string, field: "dose" | "timing" | "schedule") {
+  if (field === "dose") return /\b(?:dose|doses|dosage|how much|strength)\b/i.test(question);
+  if (field === "timing") return /\b(?:timing|time|when|morning|afternoon|evening|night)\b/i.test(question);
+  return /\b(?:schedule|cadence|frequency|how often|daily|weekly|every other)\b/i.test(question);
+}
+
+function fieldCovered(answer: string, item: MemberRegimenItemContext, field: "dose" | "timing" | "schedule") {
+  const itemText = answer
+    .split(/\n+|(?<=[.!?])\s+/)
+    .filter((segment) => containsValue(segment, item.name))
+    .join(" ");
+  if (!itemText) return false;
+  if (field === "dose") return item.dose ? containsValue(itemText, item.dose) : /dose not recorded/i.test(itemText);
+  if (field === "timing") return item.timing ? containsValue(itemText, item.timing) : /timing not recorded/i.test(itemText);
+  if (!item.schedule) return /schedule not recorded/i.test(itemText);
+  return containsValue(itemText, regimenScheduleLabel(item.schedule));
+}
+
+function regimenValidators(input: CoachTaskValidationInput) {
+  const { requested, excluded } = requestedItems(input.route, input.memberContext);
+  const included = requested.filter((item) => containsValue(input.answerText, item.name));
+  const missingNames = requested.filter((item) => !containsValue(input.answerText, item.name));
+  const emptyCovered = requested.length > 0 || /\b(?:none|did not find|no current|not recorded)\b/i.test(input.answerText);
+  const coverage = requested.length ? ratio(included.length, requested.length) : Number(emptyCovered);
+
+  const requestedFields = (["dose", "timing", "schedule"] as const).filter((field) => fieldRequested(input.question, field));
+  const fieldChecks = requested.flatMap((item) => requestedFields.map((field) => ({ item, field })));
+  const missingFields = fieldChecks.filter(({ item, field }) => !fieldCovered(input.answerText, item, field));
+  const fieldCoverage = ratio(fieldChecks.length - missingFields.length, fieldChecks.length);
+
+  const requestedNames = new Set(requested.map((item) => normalized(item.name)));
+  const unexpected = excluded.filter((item) => !requestedNames.has(normalized(item.name)) && containsValue(input.answerText, item.name));
+  return [
+    result("REGIMEN_COVERAGE", coverage, missingNames.map((item) => `regimen_item:${item.item_kind}:${normalized(item.name)}`)),
+    result("REQUESTED_FIELDS", fieldCoverage, missingFields.map(({ item, field }) => `regimen_field:${item.item_kind}:${normalized(item.name)}:${field}`)),
+    result("TYPE_EXCLUSIONS", unexpected.length ? 0 : 1, [], unexpected.map((item) => `unexpected_regimen_type:${item.item_kind}:${normalized(item.name)}`)),
+  ];
+}
+
+function importantWords(value: string) {
+  return normalized(value)
+    .split(" ")
+    .filter((word) => word.length >= 5 && !STOP_WORDS.has(word));
+}
+
+function safetyValidators(input: CoachTaskValidationInput) {
+  const section = input.memberContext.unresolvedSafetyItems;
+  if (section.status === "missing") {
+    const bounded = /\b(?:could not complete|unavailable|try again|not rely)\b/i.test(input.answerText);
+    return [
+      result("SAFETY_FINDINGS", Number(bounded), bounded ? [] : ["safety_evaluation_unavailable"]),
+      result("SAFETY_REASONING", Number(bounded), bounded ? [] : ["safety_limitation_not_explained"]),
+    ];
+  }
+
+  const unique = [...new Map(section.value.map((item) => [
+    `${item.code}|${normalized(item.item)}|${normalized(item.message)}`,
+    item,
+  ])).values()];
+  if (!unique.length) {
+    const noFinding = /\b(?:did not identify|no unresolved|no rule matched)\b/i.test(input.answerText);
+    const limitation = /\b(?:not a guarantee|not absolute|information currently saved|risk[- ]free)\b/i.test(input.answerText);
+    return [
+      result("SAFETY_FINDINGS", Number(noFinding), noFinding ? [] : ["no_findings_result_missing"]),
+      result("SAFETY_REASONING", Number(limitation), limitation ? [] : ["no_findings_limitation_missing"]),
+    ];
+  }
+
+  const surfaced = unique.filter((item) => containsValue(input.answerText, item.item));
+  const explained = unique.filter((item) => {
+    if (!containsValue(input.answerText, item.item)) return false;
+    const words = importantWords(item.message);
+    return words.length === 0 || words.some((word) => normalized(input.answerText).includes(word));
+  });
+  return [
+    result("SAFETY_FINDINGS", ratio(surfaced.length, unique.length), unique.filter((item) => !surfaced.includes(item)).map((item) => `safety_item:${item.code}:${normalized(item.item)}`)),
+    result("SAFETY_REASONING", ratio(explained.length, unique.length), unique.filter((item) => !explained.includes(item)).map((item) => `safety_reason:${item.code}:${normalized(item.item)}`)),
+  ];
+}
+
+function sentences(value: string) {
+  return value.split(/(?<=[.!?])\s+|\n+/).map((item) => item.trim()).filter(Boolean);
+}
+
+function changeViolationFor(items: MemberRegimenItemContext[], kindPattern: RegExp, answer: string) {
+  const change = /\b(?:start|begin|stop|quit|add|remove|increase|decrease|double|halve|change|adjust|skip|replace|switch)\b/i;
+  return sentences(answer).some((sentence) => {
+    if (/\b(?:do not|don't|not changing|without changing|keep|unchanged|remain unchanged|no change)\b/i.test(sentence)) return false;
+    if (!change.test(sentence)) return false;
+    return kindPattern.test(sentence) || items.some((item) => containsValue(sentence, item.name));
+  });
+}
+
+function constraintValidator(input: CoachTaskValidationInput) {
+  const violations: string[] = [];
+  const constraints = input.route.constraints;
+  if (constraints.preserveMedicationPlan && changeViolationFor(input.memberContext.regimen.medications.value, /\b(?:medication|medications|meds|prescription)\b/i, input.answerText)) {
+    violations.push("preserve_medication_plan");
+  }
+  if (constraints.preserveHormonePlan && changeViolationFor(input.memberContext.regimen.hormones.value, /\b(?:hormone|hormones)\b/i, input.answerText)) {
+    violations.push("preserve_hormone_plan");
+  }
+  const supplements = [...input.memberContext.regimen.supplements.value, ...input.memberContext.regimen.endocrineActiveSupplements.value];
+  if (constraints.preserveSupplementPlan && changeViolationFor(supplements, /\b(?:supplement|supplements|vitamin|vitamins|mineral|minerals|stack)\b/i, input.answerText)) {
+    violations.push("preserve_supplement_plan");
+  }
+  return result("CONSTRAINT_ADHERENCE", violations.length ? 0 : 1, [], violations);
+}
+
+function activePracticeValidator(input: CoachTaskValidationInput) {
+  const practice = input.memberContext.activePractice.value;
+  if (!practice) return result("ACTIVE_PRACTICE_USE", 1);
+  const covered = containsValue(input.answerText, practice.actionLabel)
+    || containsValue(input.answerText, practice.minimumVersion)
+    || (input.route.intent === "BEHAVIORAL_COACHING" && /\bweekly practice\b/i.test(input.answerText));
+  return result("ACTIVE_PRACTICE_USE", Number(covered), covered ? [] : ["active_practice_not_used"]);
+}
+
+function timeHorizonValidator(input: CoachTaskValidationInput) {
+  const requested = [
+    /\btomorrow\b/i.test(input.question) ? "tomorrow" : null,
+    /\btoday\b/i.test(input.question) ? "today" : null,
+    /\bthis week\b|\bweekly\b/i.test(input.question) ? "week" : null,
+  ].filter((value): value is string => Boolean(value));
+  const missing = requested.filter((value) => !new RegExp(`\\b${value}`).test(normalized(input.answerText)));
+  return result("REQUESTED_TIME_HORIZON", ratio(requested.length - missing.length, requested.length), missing.map((value) => `time_horizon:${value}`));
+}
+
+function priorityValidator(input: CoachTaskValidationInput) {
+  const practice = input.memberContext.activePractice.value;
+  if (practice?.actionLabel) {
+    const covered = containsValue(input.answerText, practice.actionLabel);
+    return result("PRIORITY_ALIGNMENT", Number(covered), covered ? [] : ["active_practice_priority_missing"]);
+  }
+  const acknowledgesGap = /\b(?:no active practice|choose one|start with one)\b/i.test(input.answerText);
+  return result("PRIORITY_ALIGNMENT", Number(acknowledgesGap), acknowledgesGap ? [] : ["no_active_practice_not_acknowledged"]);
+}
+
+export function missingContextRequirements(context: MemberIntelligenceContext): MissingContextRequirement[] {
+  const requirements: MissingContextRequirement[] = [];
+  const regimen = allRegimen(context);
+  for (const item of regimen.filter((candidate) => !candidate.dose?.trim())) {
+    requirements.push({
+      code: `regimen:${normalized(item.name)}:dose`,
+      label: `Add the missing dose for ${item.name}.`,
+      matchTerms: [item.name, "dose"],
+    });
+  }
+  for (const item of regimen.filter((candidate) => !candidate.timing?.trim())) {
+    requirements.push({
+      code: `regimen:${normalized(item.name)}:timing`,
+      label: `Add the missing timing for ${item.name}.`,
+      matchTerms: [item.name, "timing"],
+    });
+  }
+  if (context.healthProfile.status === "missing") requirements.push({ code: "health_profile", label: "Complete the intake health profile.", matchTerms: ["health profile"] });
+  if (context.goals.saved.status === "missing" && context.goals.blueprint.status === "missing") requirements.push({ code: "goals", label: "Record at least one current goal.", matchTerms: ["goal"] });
+  if (context.recentCheckIns.status === "missing") requirements.push({ code: "recent_check_ins", label: "Record a few sleep, energy, or weight check-ins.", matchTerms: ["check-ins", "check ins"] });
+  if (context.activePractice.status === "missing") requirements.push({ code: "active_practice", label: "Choose one active weekly practice.", matchTerms: ["weekly practice"] });
+  if (context.preferences.status === "missing") requirements.push({ code: "preferences", label: "Save timezone and reminder preferences.", matchTerms: ["preferences", "timezone"] });
+  return requirements.slice(0, 5);
+}
+
+function missingContextValidator(input: CoachTaskValidationInput) {
+  const requirements = missingContextRequirements(input.memberContext);
+  if (!requirements.length) {
+    const complete = /\b(?:substantially complete|no important information is missing|core context is complete)\b/i.test(input.answerText);
+    return result("MISSING_CONTEXT_ACCURACY", Number(complete), complete ? [] : ["complete_context_not_acknowledged"]);
+  }
+  const covered = requirements.filter((requirement) => requirement.code.startsWith("regimen:")
+    ? requirement.matchTerms.every((term) => containsValue(input.answerText, term))
+    : requirement.matchTerms.some((term) => containsValue(input.answerText, term)));
+  const violations: string[] = [];
+  if (input.memberContext.healthProfile.status !== "missing" && /health profile[^.\n]{0,50}\b(?:missing|incomplete|not recorded)\b/i.test(input.answerText)) violations.push("existing_health_profile_labeled_missing");
+  if ((input.memberContext.goals.saved.value.length || input.memberContext.goals.blueprint.value.length) && /\bgoals?[^.\n]{0,50}\b(?:missing|not recorded|none)\b/i.test(input.answerText)) violations.push("existing_goals_labeled_missing");
+  if (input.memberContext.activePractice.value && /\b(?:weekly|active) practice[^.\n]{0,50}\b(?:missing|not recorded|none)\b/i.test(input.answerText)) violations.push("existing_practice_labeled_missing");
+  const completeness = ratio(covered.length, requirements.length);
+  return result(
+    "MISSING_CONTEXT_ACCURACY",
+    violations.length ? Math.min(completeness, 0.5) : completeness,
+    requirements.filter((requirement) => !covered.includes(requirement)).map((requirement) => requirement.code),
+    violations,
+  );
+}
+
+function progressValidators(input: CoachTaskValidationInput) {
+  const requestedMetrics = [
+    /\bsleep\b/i.test(input.question) ? "sleep" : null,
+    /\benergy\b/i.test(input.question) ? "energy" : null,
+    /\bweight\b/i.test(input.question) ? "weight" : null,
+  ].filter((value): value is string => Boolean(value));
+  const missing = requestedMetrics.filter((metric) => !containsValue(input.answerText, metric));
+  const metricsResult = result(
+    "PROGRESS_METRICS",
+    ratio(requestedMetrics.length - missing.length, requestedMetrics.length),
+    missing.map((metric) => `progress_metric:${metric}`),
+  );
+  const comparisonRequested = /\b(?:compare|trend|pattern|change|better|worse|improv)\b/i.test(input.question);
+  const bounded = !comparisonRequested || /\b(?:observation|not proof|does not prove|cannot show caus|association|pattern)\b/i.test(input.answerText);
+  return [
+    metricsResult,
+    result("CAUSAL_BOUNDARY", Number(bounded), bounded ? [] : ["causal_limit_missing"]),
+    activePracticeValidator(input),
+  ];
+}
+
+function outOfScopeValidator(input: CoachTaskValidationInput) {
+  const boundary = /\b(?:focused on|cannot help with|outside|unrelated|health|wellness|routine|goals)\b/i.test(input.answerText);
+  const answeredTrivia = /\bparis\b/i.test(input.answerText) && /\bcapital of france\b/i.test(input.question);
+  return result("OUT_OF_SCOPE_BOUNDARY", boundary && !answeredTrivia ? 1 : 0, boundary ? [] : ["out_of_scope_boundary_missing"], answeredTrivia ? ["out_of_scope_answered"] : []);
+}
+
+function evidenceValidators(input: CoachTaskValidationInput, requestedCount = 2) {
+  const allowed = input.evidenceOptionNames ?? [];
+  const options = input.structuredAnswer?.options ?? [];
+  const requiredCount = Math.min(requestedCount, allowed.length);
+  const validOptions = options.filter((option) => allowed.some((name) => normalized(name) === normalized(option.name)));
+  const blockedExplanation = input.allCandidatesBlocked === true
+    && /\b(?:safety|review|would not select|would not start|blocked)\b/i.test(input.answerText);
+  const enough = requiredCount === 0 || validOptions.length >= requiredCount || blockedExplanation;
+  const reasoned = blockedExplanation || (validOptions.length > 0 && validOptions.every((option) => option.reason.trim().length >= 12));
+  return [
+    result("EVIDENCE_COVERAGE", enough ? 1 : ratio(validOptions.length, requiredCount), enough ? [] : ["insufficient_grounded_options"]),
+    result("REASONING", Number(reasoned), reasoned ? [] : ["option_reasoning_missing"]),
+  ];
+}
+
+function memberContextValidator(input: CoachTaskValidationInput) {
+  const context = input.memberContext;
+  const values = [
+    ...context.goals.saved.value.map((goal) => goal.label),
+    ...context.goals.blueprint.value,
+    context.activePractice.value?.actionLabel ?? null,
+    context.activePractice.value?.minimumVersion ?? null,
+    ...allRegimen(context).map((item) => item.name),
+    ...(context.healthProfile.value?.conditions ?? []),
+    ...(context.blueprint.value?.priorities ?? []).map((priority) => priority.label),
+  ].filter((value): value is string => Boolean(value?.trim()));
+  if (!values.length) return result("MEMBER_CONTEXT_USE", 1);
+  const sourceIds = input.structuredAnswer?.sourceIds ?? [];
+  const groundedSource = sourceIds.some((id) => [
+    "current_routine", "health_profile", "goals", "recent_check_ins", "current_blueprint", "weekly_practice",
+  ].includes(id));
+  const exactValue = values.some((value) => containsValue(input.answerText, value));
+  const memberLanguage = /\b(?:your|you|recorded|current|recent|already)\b/i.test(input.answerText);
+  const passed = exactValue || (groundedSource && memberLanguage);
+  return result("MEMBER_CONTEXT_USE", Number(passed), passed ? [] : ["relevant_member_context_not_used"]);
+}
+
+function generalValidators(input: CoachTaskValidationInput) {
+  const structured = input.structuredAnswer;
+  const hasReason = Boolean(structured?.recommendation?.reason)
+    || Boolean(structured?.options.some((option) => option.reason.length >= 12))
+    || input.answerText.trim().length >= 80;
+  const actionable = Boolean(structured?.nextStep?.trim().length && structured.nextStep.trim().length >= 8)
+    || /\b(?:next step|try|review|record|choose|track|keep)\b/i.test(input.answerText);
+  return [
+    result("REASONING", Number(hasReason), hasReason ? [] : ["reasoning_missing"]),
+    result("ACTIONABILITY", Number(actionable), actionable ? [] : ["actionable_next_step_missing"]),
+  ];
+}
+
+export function validateCoachTaskSuccess(input: CoachTaskValidationInput): CoachTaskSuccessReport {
+  const validators: CoachTaskValidatorResult[] = [];
+  const structurePass = input.answerText.trim().length >= 12
+    && input.answerText.length <= 6000
+    && !/^\s*[{[]/.test(input.answerText)
+    && !/```/.test(input.answerText);
+  validators.push(result("STRUCTURE", Number(structurePass), structurePass ? [] : ["readable_bounded_answer_required"]));
+
+  if (REGIMEN_LOOKUP_INTENTS.has(input.route.intent)) validators.push(...regimenValidators(input));
+  else if (input.route.intent === "SAFETY_REVIEW") validators.push(...safetyValidators(input));
+  else if (input.route.intent === "BEHAVIORAL_COACHING") validators.push(activePracticeValidator(input), timeHorizonValidator(input));
+  else if (input.route.intent === "PRIORITIZATION") validators.push(priorityValidator(input));
+  else if (input.route.intent === "MISSING_CONTEXT") validators.push(missingContextValidator(input));
+  else if (input.route.intent === "PROGRESS_COACHING") validators.push(...progressValidators(input));
+  else if (input.route.intent === "OUT_OF_SCOPE") validators.push(outOfScopeValidator(input));
+  else if (["EVIDENCE_COMPARISON", "OPTION_COMPARISON"].includes(input.route.intent)) validators.push(...evidenceValidators(input));
+  else if (input.route.intent === "PERSONALIZED_RECOMMENDATION") {
+    validators.push(memberContextValidator(input), ...generalValidators(input));
+    if (input.evidenceOptionNames?.length) validators.push(...evidenceValidators(input, 1));
+  }
+  else validators.push(...generalValidators(input));
+
+  validators.push(constraintValidator(input));
+  if (input.safetyChecked === false) validators.push(result("SAFETY_FINDINGS", 0, ["required_safety_check_incomplete"]));
+
+  const missingRequirements = [...new Set(validators.flatMap((item) => item.missingRequirements))];
+  const constraintViolations = [...new Set(validators.flatMap((item) => item.constraintViolations))];
+  const failedValidators = validators.filter((item) => !item.passed).map((item) => item.validator);
+  const completeness = validators.reduce((sum, item) => sum + item.completeness, 0) / validators.length;
+  const factualValidators = validators.filter((item) => [
+    "REGIMEN_COVERAGE", "REQUESTED_FIELDS", "TYPE_EXCLUSIONS", "SAFETY_FINDINGS",
+    "SAFETY_REASONING", "PRIORITY_ALIGNMENT", "MISSING_CONTEXT_ACCURACY", "PROGRESS_METRICS",
+    "CAUSAL_BOUNDARY", "MEMBER_CONTEXT_USE", "EVIDENCE_COVERAGE",
+  ].includes(item.validator));
+  const factualCoverage = factualValidators.length
+    ? factualValidators.reduce((sum, item) => sum + item.completeness, 0) / factualValidators.length
+    : completeness;
+  return {
+    intent: input.route.intent,
+    passed: failedValidators.length === 0,
+    score: Math.round(completeness * 100),
+    completeness: Number(completeness.toFixed(3)),
+    factualCoverage: Number(factualCoverage.toFixed(3)),
+    validators,
+    failedValidators,
+    missingRequirements,
+    constraintViolations,
+  };
+}

--- a/src/lib/contextualCoach.ts
+++ b/src/lib/contextualCoach.ts
@@ -1,4 +1,4 @@
-export const COACH_PROMPT_VERSION = "contextual-coach-v3";
+export const COACH_PROMPT_VERSION = "contextual-coach-v4";
 
 export type CoachIntent =
   | "GENERAL_EDUCATION"
@@ -314,6 +314,10 @@ export function parseStructuredCoachAnswer(
   }
 }
 
+/**
+ * @deprecated PR107 compatibility helper. Production coaching uses
+ * validateCoachTaskSuccess so the score reflects the requested job.
+ */
 export function assessCoachAnswerQuality(input: {
   answer: StructuredCoachAnswer;
   supplementQuestion: boolean;


### PR DESCRIPTION
## Purpose

Replace Ask LVE360's shallow answer-shape score with deterministic, intent-specific task-success validation.

This is PR110 in the Trust-to-Intelligence program and builds on PR109's intent-first routing and canonical retrieval.

## Root cause

The previous production gate awarded points for response form:

- non-empty direct answer
- some reasoning
- a next step
- a completed safety check

Those signals did not prove that the requested job was completed. A fluent response could omit saved medications, answer with the wrong item type, ignore an explicit "without changing medications or supplements" constraint, or miss a deterministic safety finding and still receive `quality_score = 100`.

## What changed

- Adds intent-specific validators for:
  - complete regimen coverage
  - requested dose, timing, and schedule fields
  - exclusion of unrequested regimen types
  - deterministic safety findings and reasons
  - explicit medication, hormone, and supplement preserve-plan constraints
  - active weekly practice and requested time horizon
  - prioritization alignment
  - actual missing context without false missing-data claims
  - progress metrics and bounded causal language
  - grounded evidence coverage and reasoning
  - personalized member-context use
  - out-of-scope product boundaries
- Derives the existing numeric quality score from measured validator completeness.
- Validates deterministic answers before display instead of assigning them an automatic 100.
- Allows one targeted regeneration with failed validator codes and requirements.
- Uses a grounded deterministic fallback after a failed repair.
- Returns a narrow non-guessing fallback and records the turn as failed if the task still cannot be completed.
- Emits privacy-safe validation diagnostics without logging the question, regimen names, or health facts.
- Advances coaching prompt telemetry to `contextual-coach-v4`.

## Observable behavior

Existing database fields remain the durable production signals:

- `quality_score`
- `regeneration_count`
- `response_source`
- `generation_status`

Server diagnostics additionally report task completion, factual coverage, failed validator IDs, counts of missing requirements and constraint violations, and repair/fallback reason codes.

## Verification

Passed:

- `npm.cmd run qa:pr110`
- `npm.cmd run qa:pr109`
- `npm.cmd run qa:pr108`
- `npm.cmd run qa:pr107`
- `npm.cmd run qa:current-regimen`
- `npm.cmd run qa:safety-engine`
- `npm.cmd run typecheck`
- `git diff --check`

PR110's suite includes the six PR109 production prompts plus deliberate wrong answers for every important validator. A wrong medication lookup and a preserve-plan violation both fail and cannot score 100.

The Next.js production build compiled successfully and completed lint/type validation. Static prerender then stopped at `/login` because this local checkout intentionally lacks the launch Supabase and other production secrets. Vercel Preview remains the runtime build authority.

## Database and migration impact

None.

This PR reuses existing coaching-turn columns. Detailed validator results remain in privacy-safe server diagnostics, so Preview and Production are schema-compatible.

## Safety and privacy

- Medication and hormone mutation boundaries are unchanged.
- Explicit regimen exclusions are hard validation failures.
- Safety-review answers must surface current deterministic findings and reasons.
- Failed repair paths do not display a polished answer that did not complete the task.
- Validation logs contain identifiers and counts only, not member questions or health facts.
- No saved records are mutated by coaching or validation.

## Risks and rollback

The main risk is over-strict validation causing a safe fallback more often than necessary. The validator IDs and fallback reason make that visible in logs and the existing coaching-turn fields.

Rollback: revert commit `584b41c`. No database rollback is required.

## Not included

- safety provenance or nutrient unit normalization (PR111)
- Today maintenance hierarchy (PR112)
- goal/practice schema changes (PR113)
- recommendation-to-action mutations (PR114)
- adaptive weekly synthesis (PR115)
