### PR TITLE
PR111: Make safety rules unit-aware, evidence-grounded, and auditable

### DIFF
--- a/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
+++ b/app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx
@@ -237,7 +237,7 @@ export default function BlueprintWorkspaceClient({
         item.proposal.id === itemId ? { ...item, decision: data.decision } : item
       ));
       const statusMessage = decision === "clinician_review"
-        ? "Marked for a clinician or pharmacist conversation."
+        ? "Marked for a clinician or healthcare provider conversation."
         : decision === "deferred"
           ? "Moved out of your active ideas for now."
           : decision === "dismissed"

--- a/app/(app)/blueprints/[stackId]/page.tsx
+++ b/app/(app)/blueprints/[stackId]/page.tsx
@@ -15,6 +15,9 @@ import { regimenToLedger } from "@/lib/currentRegimenModel";
 import { canonicalRegimenTiming } from "@/lib/regimenSchedule";
 import { extractBlueprintGoalNames } from "@/lib/recommendationDecision";
 import { getStackRecommendationDecisions } from "@/lib/recommendationDecisionData";
+import { getMemberIntelligenceContext } from "@/lib/memberContextData";
+import { applySafetyChecks } from "@/lib/safetyCheck";
+import { applySafetyEvaluationToMarkdown } from "@/lib/safetyEngine";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
 import BlueprintWorkspaceClient from "./BlueprintWorkspaceClient";
@@ -58,10 +61,35 @@ export default async function BlueprintPage({ params }: PageProps) {
   if (historyError) throw historyError;
   if (!submission) notFound();
 
-  const markdown = blueprintMarkdownFromStack(stack);
-  const report = parseBlueprintReport(markdown);
+  const storedMarkdown = blueprintMarkdownFromStack(stack);
   await ensureCurrentRegimen(user.id, submission.id, submission);
   const regimen = await getCurrentRegimen(user.id);
+  const latestId = history?.[0]?.id ?? stack.id;
+  let markdown = storedMarkdown;
+  if (latestId === stack.id) {
+    const memberContext = await getMemberIntelligenceContext(user.id);
+    const profile = memberContext.healthProfile.value;
+    const liveSafety = await applySafetyChecks(
+      {
+        medications: memberContext.regimen.medications.value.map((item) => item.name),
+        conditions: profile?.conditions ?? [],
+        allergies: profile?.allergies ?? [],
+        procedures: profile?.procedures ?? [],
+        pregnant: profile?.pregnant ?? null,
+      },
+      [
+        ...memberContext.regimen.supplements.value,
+        ...memberContext.regimen.endocrineActiveSupplements.value,
+      ].map((item) => ({
+        name: item.name,
+        dose: item.dose,
+        is_current: true,
+        instruction_authority: item.instruction_authority,
+      })),
+    );
+    markdown = applySafetyEvaluationToMarkdown(storedMarkdown, liveSafety);
+  }
+  const report = parseBlueprintReport(markdown);
   const recommendations = await getStackRecommendationDecisions(
     user.id,
     stack.id,
@@ -86,7 +114,6 @@ export default async function BlueprintPage({ params }: PageProps) {
   const stale = versioningReady
     ? !stack.input_snapshot_hash || stack.input_snapshot_hash !== currentInputHash
     : false;
-  const latestId = history?.[0]?.id ?? stack.id;
   const currentVersionIndex = (history ?? []).findIndex((version) => version.id === stack.id);
   const previousStack = (history ?? []).find((version) => version.id === stack.supersedes_stack_id)
     ?? (currentVersionIndex >= 0 ? history?.[currentVersionIndex + 1] : null)
@@ -98,7 +125,7 @@ export default async function BlueprintPage({ params }: PageProps) {
         currentCreatedAt: stack.created_at,
         generationReason: stack.generation_reason,
         previousMarkdown: blueprintMarkdownFromStack(previousStack),
-        currentMarkdown: markdown,
+        currentMarkdown: storedMarkdown,
       })
     : null;
 

--- a/app/(app)/routine/RoutineClient.tsx
+++ b/app/(app)/routine/RoutineClient.tsx
@@ -258,7 +258,7 @@ export default function RoutineClient({
       if (!response.ok || !body?.ok) throw new Error(body?.error ?? "recommendation_decision_failed");
       await refreshRoutine();
       const message = decision === "clinician_review"
-        ? `${item.name} is marked for clinician or pharmacist review.`
+        ? `${item.name} is marked for clinician or healthcare provider review.`
         : decision === "deferred"
           ? `${item.name} was moved out of your active ideas for now.`
           : decision === "dismissed"
@@ -635,7 +635,7 @@ function IdeasSection({
                     <strong>Check what you already take:</strong> Your current routine includes {item.recommendation_overlaps.join(", ")}. Review the ingredient label before adding another source.
                   </p>
                 ) : null}
-                {clinicianReview ? <p className="mt-3 flex items-start rounded-xl bg-amber-100 p-3 text-sm font-semibold text-amber-900"><AlertTriangle className="mr-2 mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> Clinician or pharmacist review is recommended before adding this.</p> : null}
+                {clinicianReview ? <p className="mt-3 flex items-start rounded-xl bg-amber-100 p-3 text-sm font-semibold text-amber-900"><AlertTriangle className="mr-2 mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> Clinician or healthcare provider review is recommended before adding this.</p> : null}
                 <div className="mt-4 grid gap-2 sm:grid-cols-2">
                   <button
                     type="button"
@@ -689,7 +689,7 @@ function EditRoutineDialog({ item, saving, onClose, onSave }: { item: RoutineIte
     <DialogShell title={prescribedItem ? `Record a prescribed change for ${item.name}` : `Update ${item.name}`} onClose={onClose}>
       <p className="text-sm leading-6 text-slate-600">
         {prescribedItem
-          ? "Use this only to record a change you received from your clinician, pharmacist, or current prescription label. LVE360 is not changing or recommending your prescription."
+          ? "Use this only to record a change you received from your clinician, healthcare provider, or current prescription label. LVE360 is not changing or recommending your prescription."
           : "Record what you currently do. This does not create a medical instruction or replace a product label."}
       </p>
       <RoutineCopilotPanel
@@ -791,7 +791,7 @@ function AddPrescribedItemDialog({ kind, onClose, onAdded }: { kind: "medication
   return (
     <DialogShell title={`Add a prescribed ${label}`} onClose={onClose}>
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-950">
-        Record only what you currently take based on your clinician, pharmacist, or prescription label. This does not ask LVE360 to recommend a {label} or dose.
+        Record only what you currently take based on your clinician, healthcare provider, or prescription label. This does not ask LVE360 to recommend a {label} or dose.
       </div>
       <RoutineCopilotPanel
         kind={kind}

--- a/app/(app)/routine/page.tsx
+++ b/app/(app)/routine/page.tsx
@@ -16,7 +16,7 @@ export default async function RoutinePage() {
         <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#8DE5D5]">Routine</p>
         <h1 className="mt-2 text-3xl font-extrabold tracking-tight sm:text-4xl">Organize what you take and when</h1>
         <p className="mt-3 max-w-3xl text-base leading-7 text-slate-200">
-          Keep your reported prescriptions, hormones, supplements, and timing in one place. Routine records your choices. It does not replace your prescriber, pharmacist, or product label.
+          Keep your reported prescriptions, hormones, supplements, and timing in one place. Routine records your choices. It does not replace your clinician, healthcare provider, or product label.
         </p>
       </header>
 

--- a/app/(app)/routine/print/page.tsx
+++ b/app/(app)/routine/print/page.tsx
@@ -80,7 +80,7 @@ export default async function RoutinePrintPage() {
       </div>
 
       <section className="mt-8 break-inside-avoid border-t border-slate-300 pt-5">
-        <h2 className="text-lg font-bold text-[#041B2D]">Clinician or pharmacist notes</h2>
+        <h2 className="text-lg font-bold text-[#041B2D]">Clinician or healthcare provider notes</h2>
         <div className="mt-3 h-28 border-b border-dashed border-slate-400" />
         <div className="mt-4 h-10 border-b border-dashed border-slate-400" />
       </section>

--- a/app/medical-disclaimer/page.tsx
+++ b/app/medical-disclaimer/page.tsx
@@ -20,7 +20,7 @@ export default function MedicalDisclaimerPage() {
       <section>
         <h2>Not a medical professional relationship</h2>
         <p>
-          Using LVE360 does not create a physician-patient, pharmacist-patient, therapist-client, or
+          Using LVE360 does not create a physician-patient, clinician-patient, therapist-client, or
           other healthcare professional relationship. LVE360 does not diagnose, treat, cure, prevent,
           or manage any disease or medical condition.
         </p>
@@ -40,7 +40,7 @@ export default function MedicalDisclaimerPage() {
           Supplements can cause side effects and may interact with medications, procedures, health
           conditions, pregnancy, nursing, allergies, or each other. Do not start, stop, or change a
           medication or prescribed treatment based on LVE360. Discuss supplement changes with a
-          qualified clinician or pharmacist when appropriate.
+          qualified clinician or healthcare provider when appropriate.
         </p>
       </section>
 

--- a/app/onboarding/OnboardingHandoffClient.tsx
+++ b/app/onboarding/OnboardingHandoffClient.tsx
@@ -165,7 +165,7 @@ export default function OnboardingHandoffClient() {
       </div>
 
       <p className="mt-8 border-t border-slate-100 pt-5 text-xs leading-5 text-slate-500">
-        This setup is for lifestyle practices only. Supplement and medication changes remain in your Blueprint for clinician or pharmacist review.
+        This setup is for lifestyle practices only. Supplement and medication changes remain in your Blueprint for clinician or healthcare provider review.
       </p>
     </Shell>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,7 +124,7 @@ export default function Home() {
         <h2 className="text-3xl font-bold text-[#041b2d]">A healthier life is built from small choices repeated.</h2>
         <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">Start with a free, personalized Blueprint. Choose one meaningful action. Build a week you can repeat.</p>
         <button onClick={openIntake} className="mt-8 rounded-xl bg-violet-600 px-6 py-3.5 font-semibold text-white shadow-lg shadow-violet-700/20 transition hover:bg-violet-700">Start your free Blueprint</button>
-        <p className="mx-auto mt-5 max-w-xl text-xs leading-5 text-slate-500">LVE360 provides educational wellness information, not medical diagnosis or treatment. Consult a qualified clinician or pharmacist for medical decisions.</p>
+        <p className="mx-auto mt-5 max-w-xl text-xs leading-5 text-slate-500">LVE360 provides educational wellness information, not medical diagnosis or treatment. Consult a qualified clinician or healthcare provider for medical decisions.</p>
       </section>
 
       <AnimatePresence>{showIntake && <IntakeModal onClose={() => setShowIntake(false)} />}</AnimatePresence>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -92,7 +92,7 @@ export default function Pricing() {
           {[
             ["A focused loop", "A clear weekly practice, a lightweight check-in, and a review of progress. It is not an endless list of tasks."],
             ["A grounded second look", "Organize your stack and questions so you can make better-informed decisions and know when to involve a clinician."],
-            ["Not medical care", "LVE360 is educational wellness guidance. It does not diagnose, treat, or replace a clinician or pharmacist."],
+            ["Not medical care", "LVE360 is educational wellness guidance. It does not diagnose, treat, or replace a clinician or healthcare provider."],
           ].map(([title, description]) => (
             <article key={title} className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
               <h3 className="font-bold text-[#041b2d]">{title}</h3>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -31,7 +31,7 @@ export default function TermsPage() {
           LVE360 organizes information about wellness goals, routines, supplements, medications,
           and lifestyle practices. It provides educational information and planning tools. It does
           not provide medical care, diagnosis, treatment, prescribing, emergency services, or a
-          substitute for a physician, pharmacist, dietitian, therapist, or other qualified
+          substitute for a physician, clinician, dietitian, therapist, or other qualified
           professional.
         </p>
         <p>

--- a/docs/safety-integrity.md
+++ b/docs/safety-integrity.md
@@ -1,0 +1,50 @@
+# LVE360 Safety Integrity
+
+PR111 makes the deterministic safety layer unit-aware, evidence-grounded, and auditable. It remains educational wellness support and does not diagnose, prescribe, or instruct a member to change medication or hormone treatment.
+
+## Rule provenance
+
+Every interaction and rule can record:
+
+- source label, URL, and source type
+- source or label date and LVE360 review date
+- exact ingredient or formulation assessed
+- proposed interaction mechanism
+- severity rationale and confidence
+- member-facing qualification
+- rule version and review status
+
+Legacy rows remain in place with `provenance_status = unreviewed`, `confidence = unknown`, and `rule_version = legacy-v1` until they are curated. Missing evidence is shown as missing rather than inferred.
+
+The migration also adds the `updated_at` column expected by the pre-existing update triggers on both safety tables. This repairs the prior trigger/schema mismatch and preserves automatic audit timestamps.
+
+## Dose comparison
+
+The engine safely normalizes mass units across mcg, mg, and g. Vitamin D also supports the authoritative conversion of 1 mcg to 40 IU. A recorded 5,000 IU dose therefore compares as 125 mcg against the 100 mcg adult upper-intake threshold. Unsupported units are never guessed; the member receives a review note asking them to confirm the label.
+
+## Thyroid-medication review
+
+- Plain Vitamin D3 no longer creates a general thyroid-spacing warning.
+- A Lactobacillus/Bifidobacterium probiotic blend no longer creates a general thyroid-spacing warning. Its separate antibiotic and immune-context cautions remain available.
+- Magnesium remains a timing-review item. The evidence qualification explains that direct trial evidence studied citrate and aspartate formulations, so exact product guidance should come from the prescription label or pharmacist.
+- The engine does not invent a four-hour interval when a rule has no interval.
+- A specific ingredient finding suppresses a duplicate generic spacing message.
+
+## Clinician-directed regimens
+
+A proposed dose above a structured upper-intake threshold remains blocked pending review. A current dose explicitly recorded as clinician- or pharmacist-directed becomes a review finding instead. The message tells the member to confirm total intake, rationale, and monitoring with the overseeing professional and not to change the regimen from the app warning alone.
+
+## Member-facing explanation
+
+Each finding now identifies urgency, what to do, why it appeared, evidence source, confidence, rule version, and important uncertainty. Ask LVE360 receives the same evidence metadata for deterministic safety answers.
+
+## Verification
+
+Run:
+
+```powershell
+npm.cmd run qa:safety-engine
+npm.cmd run qa:pr111
+npm.cmd run typecheck
+npm.cmd run build
+```

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "qa:pr108": "node --experimental-strip-types src/_tests_/pr108MemberContext.assert.ts && node src/_tests_/pr108Architecture.assert.mjs",
     "qa:pr109": "node --experimental-strip-types src/_tests_/pr109IntentRouting.assert.ts && node src/_tests_/pr109Architecture.assert.mjs",
     "qa:pr110": "node --experimental-strip-types src/_tests_/pr110TaskSuccess.assert.ts && node src/_tests_/pr110Architecture.assert.mjs",
+    "qa:pr111": "node --experimental-strip-types src/_tests_/pr111SafetyIntegrity.assert.ts && node src/_tests_/pr111Architecture.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr111Architecture.assert.mjs
+++ b/src/_tests_/pr111Architecture.assert.mjs
@@ -6,6 +6,8 @@ const loader = readFileSync("src/lib/safetyCheck.ts", "utf8");
 const memberData = readFileSync("src/lib/memberContextData.ts", "utf8");
 const coachData = readFileSync("src/lib/ai/contextualCoachData.ts", "utf8");
 const coachIntent = readFileSync("src/lib/coachIntent.ts", "utf8");
+const coachValidation = readFileSync("src/lib/coachTaskValidation.ts", "utf8");
+const blueprintPage = readFileSync("app/(app)/blueprints/[stackId]/page.tsx", "utf8");
 const migration = readFileSync("supabase/migrations/20260815135335_safety_provenance_unit_normalization.sql", "utf8");
 
 for (const field of [
@@ -44,5 +46,12 @@ assert.match(engine, /Confidence:/);
 assert.match(memberData, /instruction_authority: item\.instruction_authority/);
 assert.match(coachData, /instruction_authority: current\?\.instruction_authority/);
 assert.match(coachIntent, /item\.evidence\.confidence/);
+assert.match(coachData, /deterministicNamedSafetyAnswer/);
+assert.match(coachData, /namedCurrentSupplements/);
+assert.match(coachData, /namedSafetyCandidateKeys/);
+assert.match(coachData, /GENERIC_REGIMEN_WORDS/, "Named-item matching must not broaden Vitamin D to every vitamin or magnesium form.");
+assert.match(coachValidation, /namedRegimen/, "Safety validation must be scoped to the regimen items the member actually named.");
+assert.match(blueprintPage, /applySafetyEvaluationToMarkdown/, "The latest Blueprint must overlay a fresh deterministic safety review.");
+assert.match(blueprintPage, /if \(latestId === stack\.id\)/, "Historical Blueprint versions must remain historical snapshots.");
 
 console.log("PR111 safety provenance architecture checks passed.");

--- a/src/_tests_/pr111Architecture.assert.mjs
+++ b/src/_tests_/pr111Architecture.assert.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const engine = readFileSync("src/lib/safetyEngine.ts", "utf8");
+const loader = readFileSync("src/lib/safetyCheck.ts", "utf8");
+const memberData = readFileSync("src/lib/memberContextData.ts", "utf8");
+const coachData = readFileSync("src/lib/ai/contextualCoachData.ts", "utf8");
+const coachIntent = readFileSync("src/lib/coachIntent.ts", "utf8");
+const migration = readFileSync("supabase/migrations/20260815135335_safety_provenance_unit_normalization.sql", "utf8");
+
+for (const field of [
+  "source_label",
+  "source_type",
+  "last_reviewed_on",
+  "exact_ingredient_form",
+  "interaction_mechanism",
+  "severity_rationale",
+  "confidence",
+  "user_qualification",
+  "rule_version",
+  "provenance_status",
+]) {
+  assert.match(migration, new RegExp(`add column if not exists ${field}`), `${field} must be additive and migration-managed.`);
+  assert.match(loader, new RegExp(`"${field}"`), `${field} must be loaded into deterministic evaluations.`);
+}
+
+assert.match(migration, /where lower\(ingredient\) = 'vitamin d3'/);
+assert.match(migration, /where lower\(ingredient\) = 'probiotic \(lacto\/bifido blend\)'/);
+assert.match(migration, /set binds_thyroid_meds = false/);
+assert.match(migration, /provenance_status = 'reviewed'/);
+assert.match(migration, /default 'unreviewed'/, "Legacy rows must remain explicit rather than receiving fabricated provenance.");
+assert.match(migration, /add column if not exists updated_at timestamptz default now\(\)/, "The migration must repair the existing update-trigger/schema mismatch.");
+
+assert.match(engine, /dose\.amount \/ 40/);
+assert.match(engine, /dose\.amount \* 40/);
+assert.match(engine, /dose_unit_not_comparable/);
+assert.match(engine, /instruction_authority/);
+assert.doesNotMatch(engine, /sep_hours_thyroid \?\? 4/, "The engine must not invent a four-hour interval when no interval is recorded.");
+assert.match(engine, /clinicianDirectedException/);
+assert.match(engine, /Do not change it from this app warning alone/);
+assert.match(engine, /Why this appeared:/);
+assert.match(engine, /Confidence:/);
+
+assert.match(memberData, /instruction_authority: item\.instruction_authority/);
+assert.match(coachData, /instruction_authority: current\?\.instruction_authority/);
+assert.match(coachIntent, /item\.evidence\.confidence/);
+
+console.log("PR111 safety provenance architecture checks passed.");

--- a/src/_tests_/pr111SafetyIntegrity.assert.ts
+++ b/src/_tests_/pr111SafetyIntegrity.assert.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import {
+  evaluateSafetyCandidates,
+  safetySectionFromEvaluation,
+  type InteractionRow,
+  type SafetyCandidate,
+  type SafetyRuleRow,
+} from "../lib/safetyEngine.ts";
+
+const vitaminDSource = {
+  source_label: "NIH Office of Dietary Supplements: Vitamin D Fact Sheet for Health Professionals",
+  source_url: "https://ods.od.nih.gov/factsheets/VitaminD-HealthProfessional/",
+  source_type: "government_reference",
+  exact_ingredient_form: "Vitamin D3 (cholecalciferol)",
+  interaction_mechanism: "1 mcg vitamin D equals 40 IU.",
+  severity_rationale: "Amounts above the adult UL require review.",
+  confidence: "high",
+  user_qualification: "A clinician-directed regimen may require a different monitored plan.",
+  rule_version: "safety-data-v2",
+  provenance_status: "reviewed",
+} as const;
+
+const interactions: InteractionRow[] = [
+  { ingredient: "Vitamin D3", binds_thyroid_meds: false, ...vitaminDSource },
+  {
+    ingredient: "Probiotic (Lacto/Bifido blend)",
+    binds_thyroid_meds: false,
+    antibiotics_interaction: true,
+    immunocompromised_caution: true,
+    source_label: "NCCIH: Probiotics, What Do We Know?",
+    source_url: "https://www.nccih.nih.gov/health/probiotics-usefulness-and-safety",
+    source_type: "government_reference",
+    exact_ingredient_form: "Lactobacillus/Bifidobacterium blend; strain details not recorded",
+    confidence: "moderate",
+    provenance_status: "reviewed",
+    rule_version: "safety-data-v2",
+  },
+  {
+    ingredient: "Magnesium (glycinate)",
+    binds_thyroid_meds: true,
+    sep_hours_thyroid: 4,
+    source_label: "ThyroMag Trial",
+    source_url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC12605969/",
+    source_type: "peer_reviewed",
+    exact_ingredient_form: "Magnesium (glycinate)",
+    interaction_mechanism: "Concurrent magnesium can reduce levothyroxine absorption; evidence varies by formulation.",
+    confidence: "moderate",
+    user_qualification: "The direct trial studied citrate and aspartate, not glycinate.",
+    provenance_status: "reviewed",
+    rule_version: "safety-data-v2",
+  },
+  { ingredient: "Omega-3", anticoagulants_bleeding_risk: true },
+];
+
+const vitaminDRule: SafetyRuleRow = {
+  rule_id: "UL_VITAMIN_D_Adults",
+  rule_type: "UL",
+  entity_a_name: "Vitamin D3",
+  max_daily_amount: 100,
+  unit: "mcg",
+  message: "The adult upper intake level is 100 mcg (4,000 IU) daily.",
+  ...vitaminDSource,
+};
+
+const evaluateVitaminD = (candidate: SafetyCandidate, rule: SafetyRuleRow = vitaminDRule) => evaluateSafetyCandidates(
+  {},
+  [candidate],
+  { interactions, rules: [rule] },
+);
+
+assert.equal(evaluateVitaminD({ name: "Vitamin D3", dose: "5000 IU", is_current: false }).status, "blocked", "5,000 IU must compare against 100 mcg and exceed the adult UL.");
+assert.equal(evaluateVitaminD({ name: "Vitamin D3", dose: "4000 IU", is_current: false }).status, "clear", "4,000 IU must equal, not exceed, 100 mcg.");
+assert.equal(evaluateVitaminD(
+  { name: "Vitamin D3", dose: "125 mcg", is_current: false },
+  { ...vitaminDRule, max_daily_amount: 4_000, unit: "IU" },
+).status, "blocked", "125 mcg must compare as 5,000 IU when the rule is stored in IU.");
+
+const unsupported = evaluateVitaminD({ name: "Vitamin D3", dose: "5000 USP", is_current: false });
+assert.equal(unsupported.status, "review", "Unsupported units must not be guessed or silently cleared.");
+assert.equal(unsupported.findings[0]?.code, "dose_unit_not_comparable");
+assert.match(unsupported.findings[0]?.message ?? "", /did not guess a conversion/i);
+
+const thyroidVitaminD = evaluateSafetyCandidates(
+  { medications: ["Levothyroxine"] },
+  [{ name: "Vitamin D3", dose: "2000 IU", is_current: true }],
+  { interactions, rules: [vitaminDRule] },
+);
+assert.equal(thyroidVitaminD.status, "clear", "Plain Vitamin D3 must not create a thyroid-spacing false positive.");
+
+const thyroidProbiotic = evaluateSafetyCandidates(
+  { medications: ["Levothyroxine"] },
+  [{ name: "Probiotic (Lacto/Bifido blend)", is_current: true }],
+  { interactions, rules: [] },
+);
+assert.equal(thyroidProbiotic.status, "clear", "A probiotic blend must not create a general thyroid-spacing false positive.");
+
+const immuneProbiotic = evaluateSafetyCandidates(
+  { conditions: ["Immunocompromised"] },
+  [{ name: "Probiotic (Lacto/Bifido blend)", is_current: true }],
+  { interactions, rules: [] },
+);
+assert.equal(immuneProbiotic.findings[0]?.code, "immune_caution", "Correcting the thyroid flag must not erase the evidence-backed immune-context review.");
+
+const magnesium = evaluateSafetyCandidates(
+  { medications: ["Levothyroxine"] },
+  [{ name: "Magnesium glycinate", dose: "200 mg elemental magnesium", is_current: true }],
+  {
+    interactions,
+    rules: [{
+      rule_type: "SPACING",
+      entity_a_name: "Levothyroxine",
+      message: "Separate magnesium from levothyroxine by at least 4 hours.",
+    }],
+  },
+);
+assert.equal(magnesium.findings.length, 1, "One underlying magnesium timing concern must render once.");
+assert.equal(magnesium.findings[0]?.evidence?.confidence, "moderate");
+assert.match(magnesium.findings[0]?.evidence?.qualification ?? "", /not glycinate/i, "Form-specific uncertainty must remain visible.");
+
+const multiple = evaluateSafetyCandidates(
+  { medications: ["Eliquis"], procedures: ["Surgery next week"] },
+  [{ name: "Omega-3", is_current: false }],
+  { interactions, rules: [] },
+);
+assert.equal(multiple.findings.length, 2, "Distinct bleeding and procedure findings must both remain available.");
+
+const clinicianDirected = evaluateVitaminD({
+  name: "Vitamin D3",
+  dose: "5000 IU",
+  is_current: true,
+  instruction_authority: "clinician",
+});
+assert.equal(clinicianDirected.status, "review", "A clinician-directed current dose above the general UL must be reviewed, not app-blocked.");
+assert.match(clinicianDirected.findings[0]?.message ?? "", /Do not change it from this app warning alone/i);
+
+const section = safetySectionFromEvaluation(clinicianDirected);
+assert.match(section, /What to do:/);
+assert.match(section, /Why this appeared:/);
+assert.match(section, /Confidence: high/);
+assert.match(section, /NIH Office of Dietary Supplements/);
+assert.match(section, /Important context:/);
+
+console.log("PR111 unit-aware, evidence-grounded safety scenarios passed.");

--- a/src/_tests_/pr111SafetyIntegrity.assert.ts
+++ b/src/_tests_/pr111SafetyIntegrity.assert.ts
@@ -6,6 +6,7 @@ import {
   type SafetyCandidate,
   type SafetyRuleRow,
 } from "../lib/safetyEngine.ts";
+import { classifyCoachRequest } from "../lib/contextualCoach.ts";
 
 const vitaminDSource = {
   source_label: "NIH Office of Dietary Supplements: Vitamin D Fact Sheet for Health Professionals",
@@ -68,7 +69,12 @@ const evaluateVitaminD = (candidate: SafetyCandidate, rule: SafetyRuleRow = vita
   { interactions, rules: [rule] },
 );
 
-assert.equal(evaluateVitaminD({ name: "Vitamin D3", dose: "5000 IU", is_current: false }).status, "blocked", "5,000 IU must compare against 100 mcg and exceed the adult UL.");
+const vitaminD5000 = evaluateVitaminD({ name: "Vitamin D3", dose: "5000 IU", is_current: false });
+assert.equal(vitaminD5000.status, "blocked", "5,000 IU must compare against 100 mcg and exceed the adult UL.");
+assert.equal(vitaminD5000.findings[0]?.doseComparison?.recordedDose, "5000 IU");
+assert.equal(vitaminD5000.findings[0]?.doseComparison?.normalizedAmount, 125);
+assert.equal(vitaminD5000.findings[0]?.doseComparison?.normalizedUnit, "mcg");
+assert.equal(vitaminD5000.findings[0]?.doseComparison?.thresholdInRecordedUnit, 4_000, "The deterministic answer must say 5,000 IU is above 4,000 IU, never below it.");
 assert.equal(evaluateVitaminD({ name: "Vitamin D3", dose: "4000 IU", is_current: false }).status, "clear", "4,000 IU must equal, not exceed, 100 mcg.");
 assert.equal(evaluateVitaminD(
   { name: "Vitamin D3", dose: "125 mcg", is_current: false },
@@ -139,5 +145,13 @@ assert.match(section, /Why this appeared:/);
 assert.match(section, /Confidence: high/);
 assert.match(section, /NIH Office of Dietary Supplements/);
 assert.match(section, /Important context:/);
+
+for (const question of [
+  "Is my current Vitamin D dose above the general upper-intake threshold?",
+  "Review magnesium glycinate with my thyroid medication.",
+  "Do I need to separate Vitamin D or my probiotic from levothyroxine?",
+]) {
+  assert.equal(classifyCoachRequest(question).intent, "SAFETY_REVIEW", `Screenshot regression must use the deterministic safety path: ${question}`);
+}
 
 console.log("PR111 unit-aware, evidence-grounded safety scenarios passed.");

--- a/src/_tests_/safetyEngine.assert.ts
+++ b/src/_tests_/safetyEngine.assert.ts
@@ -126,6 +126,6 @@ const groupedSafety = evaluateSafetyCandidates(
 const groupedSection = applySafetyEvaluationToMarkdown(report, groupedSafety);
 assert.equal((groupedSection.match(/Clinician review: Magnesium Glycinate:/g) ?? []).length, 1, "Distinct concerns for one item should render under one heading");
 assert.match(groupedSection, /thyroid medication by at least 4 hours/);
-assert.match(groupedSection, /calcium, iron, and magnesium supplements/);
+assert.doesNotMatch(groupedSection, /calcium, iron, and magnesium supplements/, "A specific evidence-backed finding must suppress the duplicate generic spacing rule.");
 
 console.log("Safety engine assertions passed.");

--- a/src/components/intake/IntakeEmbed.tsx
+++ b/src/components/intake/IntakeEmbed.tsx
@@ -85,7 +85,7 @@ export function IntakePrivacyNotice() {
     <div className="border-b border-slate-200 bg-slate-50 px-6 py-4 pr-14 text-sm leading-6 text-slate-600">
       <p>
         <strong className="text-slate-900">Why we ask:</strong> Your answers help create your
-        personalized Blueprint and identify items that may need clinician or pharmacist review.
+        personalized Blueprint and identify items that may need clinician or healthcare provider review.
       </p>
       <p className="mt-1">
         We use this information to provide your LVE360 experience. We do not sell your health

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -36,6 +36,7 @@ export type CoachContext = {
   evidenceOptions: CoachEvidenceOption[];
   safetyContext: SafetyContext;
   preSafety: AppliedSafetyResult | null;
+  namedSafetyCandidateKeys: string[];
 };
 
 export type CoachDiagnostics = {
@@ -93,6 +94,30 @@ function regimenItems(context: MemberIntelligenceContext): MemberRegimenItemCont
 
 function supplementItems(context: MemberIntelligenceContext) {
   return [...context.regimen.supplements.value, ...context.regimen.endocrineActiveSupplements.value];
+}
+
+function searchableText(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+const GENERIC_REGIMEN_WORDS = new Set(["vitamin", "magnesium", "omega", "supplement", "medication", "hormone"]);
+
+function questionNamesRegimenItem(question: string, name: string) {
+  const query = searchableText(question);
+  const item = searchableText(name);
+  const identity = healthItemIdentityKey(name).replace(/-/g, " ");
+  const firstWord = item.split(" ")[0];
+  return Boolean(item && query.includes(item))
+    || Boolean(identity && query.includes(identity))
+    || Boolean(firstWord.length >= 5 && !GENERIC_REGIMEN_WORDS.has(firstWord) && query.includes(firstWord));
+}
+
+function namedCurrentSupplements(question: string, context: MemberIntelligenceContext) {
+  return supplementItems(context).filter((item) => questionNamesRegimenItem(question, item.name));
+}
+
+function isSafetySensitiveQuestion(question: string) {
+  return /\b(?:safe|safety|interact|interaction|contraindicat|conflict|warning|separat|spacing|thyroid|levothyroxine|upper[- ]?intake|upper limit|threshold|review)\b/i.test(question);
 }
 
 function explicitlyNamedEvidenceOption(question: string, options: CoachEvidenceOption[]) {
@@ -294,6 +319,7 @@ export async function buildCoachContext(
     ? recentTurns.map((turn) => `${turn.question} ${turn.answer}`).join(" ").slice(0, 1200)
     : "";
   const evidenceOptions = needsEvidence ? retrieveCoachEvidence(`${question} ${followUpContext}`.trim()) : [];
+  const namedCurrent = namedCurrentSupplements(question, memberContext);
   const profile = memberContext.healthProfile.value;
   const safetyContext: SafetyContext = {
     medications: memberContext.regimen.medications.value.map((item) => item.name),
@@ -302,16 +328,32 @@ export async function buildCoachContext(
     procedures: profile?.procedures ?? [],
     pregnant: profile?.pregnant ?? null,
   };
-  const preSafety = needsEvidence && evidenceOptions.length
-    ? await applySafetyChecks(safetyContext, evidenceOptions.map((option) => {
+  const safetyCandidates = new Map<string, {
+    name: string;
+    dose: string | null;
+    is_current: boolean;
+    instruction_authority: string | null;
+  }>();
+  for (const option of evidenceOptions) {
       const current = supplementItems(memberContext).find((item) => healthItemIdentityKey(item.name) === healthItemIdentityKey(option.name));
-      return {
+      safetyCandidates.set(healthItemIdentityKey(option.name), {
         name: option.name,
         dose: current?.dose ?? option.doseGuidance?.startingDose ?? null,
         is_current: Boolean(current),
         instruction_authority: current?.instruction_authority ?? null,
-      };
-    }))
+      });
+  }
+  for (const current of namedCurrent) {
+    safetyCandidates.set(healthItemIdentityKey(current.name), {
+      name: current.name,
+      dose: current.dose,
+      is_current: true,
+      instruction_authority: current.instruction_authority,
+    });
+  }
+  const shouldRunNamedSafety = isSafetySensitiveQuestion(question) && namedCurrent.length > 0;
+  const preSafety = (needsEvidence && evidenceOptions.length) || shouldRunNamedSafety
+    ? await applySafetyChecks(safetyContext, [...safetyCandidates.values()])
     : null;
   const safetyByName = new Map(preSafety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
   facts.evidence_options = evidenceOptions.map((option) => {
@@ -340,6 +382,18 @@ export async function buildCoachContext(
       href: option.citationUrl,
     });
   }
+  for (const candidate of preSafety?.candidates ?? []) {
+    const evidence = candidate.evidence;
+    if (!evidence?.sourceUrl || !evidence.sourceLabel) continue;
+    const id = `safety_${healthItemIdentityKey(candidate.name)}`;
+    if (sources.some((source) => source.id === id)) continue;
+    sources.push({
+      id,
+      label: evidence.sourceLabel,
+      summary: `${candidate.name} safety rule. Confidence: ${evidence.confidence}.`,
+      href: evidence.sourceUrl,
+    });
+  }
 
   return {
     page,
@@ -352,6 +406,7 @@ export async function buildCoachContext(
     evidenceOptions,
     safetyContext,
     preSafety,
+    namedSafetyCandidateKeys: namedCurrent.map((item) => healthItemIdentityKey(item.name)),
   };
 }
 
@@ -579,7 +634,7 @@ async function postValidate(question: string, context: CoachContext, answer: Str
         directAnswer: `I would not start a new supplement from this answer alone. ${recommendation.candidate} is an evidence-informed option to discuss with a qualified professional, but LVE360 flagged a safety review before any new start.`,
         options,
         recommendation,
-        nextStep: `Review ${recommendation.candidate} and the safety note above with your clinician or pharmacist before starting it. Keep your saved Routine unchanged until that review is complete.`,
+        nextStep: `Review ${recommendation.candidate} and the safety note above with your clinician or healthcare provider before starting it. Keep your saved Routine unchanged until that review is complete.`,
       }
     : { ...answer, options, recommendation };
   return { answer: reviewedAnswer, safety, removed: answer.options.length - options.length };
@@ -689,13 +744,78 @@ function diagnosticsFromReport(
   };
 }
 
+function formatSafetyNumber(value: number) {
+  return Number.isInteger(value) ? value.toLocaleString("en-US") : Number(value.toFixed(2)).toLocaleString("en-US");
+}
+
+function evidenceDetail(candidate: AppliedSafetyResult["candidates"][number]) {
+  const evidence = candidate.findings.find((finding) => finding.evidence?.provenanceStatus === "reviewed")?.evidence
+    ?? candidate.evidence;
+  if (!evidence) return "Evidence provenance for this exact item is not yet fully reviewed.";
+  const qualification = evidence.qualification ? ` Important context: ${evidence.qualification}` : "";
+  return `Evidence: ${evidence.sourceLabel ?? "LVE360 structured safety rule"}. Confidence: ${evidence.confidence}.${qualification}`;
+}
+
+function deterministicNamedSafetyAnswer(question: string, context: CoachContext) {
+  if (!isSafetySensitiveQuestion(question) || !context.preSafety?.complete || !context.namedSafetyCandidateKeys.length) return null;
+  const named = new Set(context.namedSafetyCandidateKeys);
+  const candidates = context.preSafety.candidates.filter((candidate) => named.has(healthItemIdentityKey(candidate.name)));
+  if (!candidates.length) return null;
+  const sourceIds = [
+    "current_routine",
+    "health_profile",
+    ...candidates.map((candidate) => `safety_${healthItemIdentityKey(candidate.name)}`),
+  ].filter((id) => context.sources.some((source) => source.id === id));
+
+  if (/\b(?:upper[- ]?intake|upper limit|threshold|above the general)\b/i.test(question)) {
+    const candidate = candidates.find((item) => item.findings.some((finding) => finding.code === "upper_limit"));
+    const finding = candidate?.findings.find((item) => item.code === "upper_limit");
+    if (candidate && finding?.doseComparison) {
+      const comparison = finding.doseComparison;
+      const threshold = comparison.thresholdInRecordedUnit != null && comparison.recordedUnit
+        ? `${formatSafetyNumber(comparison.thresholdInRecordedUnit)} ${comparison.recordedUnit.toUpperCase()}`
+        : `${formatSafetyNumber(comparison.thresholdAmount)} ${comparison.thresholdUnit}`;
+      const equivalent = comparison.thresholdInRecordedUnit != null
+        && comparison.recordedUnit !== comparison.thresholdUnit
+        ? ` (${formatSafetyNumber(comparison.thresholdAmount)} ${comparison.thresholdUnit})`
+        : "";
+      return {
+        answer: `Yes. Your current ${candidate.name} dose is recorded as ${comparison.recordedDose}. The general adult upper-intake threshold in LVE360's reviewed rule is ${threshold}${equivalent}, so the recorded dose is above that general threshold.\n\n${finding.message}\n\n${evidenceDetail(candidate)}`,
+        sourceIds,
+        responseSource: "deterministic" as const,
+      };
+    }
+  }
+
+  if (/\b(?:thyroid|levothyroxine|separat|spacing|interact|interaction|review)\b/i.test(question)) {
+    const lines = candidates.map((candidate) => {
+      const timingFindings = candidate.findings.filter((finding) => ["thyroid_spacing", "medication_spacing"].includes(finding.code));
+      if (timingFindings.length) {
+        return `- ${candidate.name}: ${timingFindings.map((finding) => finding.message).join(" ")} ${evidenceDetail(candidate)}`;
+      }
+      if (candidate.evidence?.provenanceStatus === "reviewed") {
+        return `- ${candidate.name}: LVE360's reviewed structured rule did not identify a general requirement to separate this recorded form from thyroid medication. ${evidenceDetail(candidate)}`;
+      }
+      return `- ${candidate.name}: LVE360 did not identify a thyroid-spacing rule, but provenance for this exact form is incomplete, so this is not a clearance.`;
+    });
+    const hasTimingFinding = candidates.some((candidate) => candidate.findings.some((finding) => ["thyroid_spacing", "medication_spacing"].includes(finding.code)));
+    return {
+      answer: `${hasTimingFinding ? "Here is the current deterministic timing review" : "LVE360 did not identify a general thyroid-spacing requirement for the exact Routine items you named"}:\n\n${lines.join("\n")}\n\nThis is not a guarantee that every product or circumstance is risk-free. Keep prescription instructions unchanged and confirm any conflicting product label or new clinical circumstance with your clinician or healthcare provider.`,
+      sourceIds,
+      responseSource: "deterministic" as const,
+    };
+  }
+  return null;
+}
+
 export async function generateCoachAnswer(userId: string, question: string, context: CoachContext) {
   const routing: CoachRoutingDecision = {
     intent: context.intent,
     constraints: context.constraints,
     requestedRegimenKinds: context.requestedRegimenKinds,
   };
-  const deterministic = deterministicCoachTask(routing, context.memberContext, question)
+  const deterministic = deterministicNamedSafetyAnswer(question, context)
+    ?? deterministicCoachTask(routing, context.memberContext, question)
     ?? deterministicRecordMutation(question, context)
     ?? deterministicPlanLookup(question, context)
     ?? deterministicTodayStep(question, context)

--- a/src/lib/ai/contextualCoachData.ts
+++ b/src/lib/ai/contextualCoachData.ts
@@ -105,11 +105,6 @@ function explicitlyNamedEvidenceOption(question: string, options: CoachEvidenceO
   }) ?? null;
 }
 
-function isCurrentSupplement(name: string, context: MemberIntelligenceContext) {
-  const identity = healthItemIdentityKey(name);
-  return supplementItems(context).some((item) => healthItemIdentityKey(item.name) === identity);
-}
-
 export async function buildCoachContext(
   userId: string,
   page: CoachPage,
@@ -308,11 +303,15 @@ export async function buildCoachContext(
     pregnant: profile?.pregnant ?? null,
   };
   const preSafety = needsEvidence && evidenceOptions.length
-    ? await applySafetyChecks(safetyContext, evidenceOptions.map((option) => ({
-      name: option.name,
-      dose: option.doseGuidance?.startingDose ?? null,
-      is_current: isCurrentSupplement(option.name, memberContext),
-    })))
+    ? await applySafetyChecks(safetyContext, evidenceOptions.map((option) => {
+      const current = supplementItems(memberContext).find((item) => healthItemIdentityKey(item.name) === healthItemIdentityKey(option.name));
+      return {
+        name: option.name,
+        dose: current?.dose ?? option.doseGuidance?.startingDose ?? null,
+        is_current: Boolean(current),
+        instruction_authority: current?.instruction_authority ?? null,
+      };
+    }))
     : null;
   const safetyByName = new Map(preSafety?.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]) ?? []);
   facts.evidence_options = evidenceOptions.map((option) => {
@@ -534,7 +533,12 @@ async function postValidate(question: string, context: CoachContext, answer: Str
     const identity = healthItemIdentityKey(option.name);
     const current = routine.find((item) => healthItemIdentityKey(String(item.name ?? "")) === identity
       && ["supplement", "endocrine_active_supplement"].includes(String(item.kind ?? "")));
-    return { name: option.name, dose: current?.dose ? String(current.dose) : evidence?.doseGuidance?.startingDose ?? null, is_current: Boolean(current) };
+    return {
+      name: option.name,
+      dose: current?.dose ? String(current.dose) : evidence?.doseGuidance?.startingDose ?? null,
+      is_current: Boolean(current),
+      instruction_authority: current?.instruction_authority ? String(current.instruction_authority) : null,
+    };
   });
   const safety = await applySafetyChecks(context.safetyContext, candidates);
   const decisions = new Map(safety.candidates.map((candidate) => [healthItemIdentityKey(candidate.name), candidate]));

--- a/src/lib/coachIntent.ts
+++ b/src/lib/coachIntent.ts
@@ -88,7 +88,11 @@ function safetyReview(context: MemberIntelligenceContext): DeterministicCoachTas
   }
   const rank = { danger: 0, warning: 1, info: 2 } as const;
   const findings = unique.sort((left, right) => rank[left.severity] - rank[right.severity]);
-  const lines = findings.map((item, index) => `${index + 1}. ${item.item}: ${item.message}`);
+  const lines = findings.map((item, index) => {
+    const source = item.evidence.sourceLabel ?? (item.evidence.provenanceStatus === "reviewed" ? "Reviewed LVE360 rule" : "Legacy rule with incomplete provenance");
+    const qualification = item.evidence.qualification ? ` Important context: ${item.evidence.qualification}` : "";
+    return `${index + 1}. ${item.item}: ${item.message}\n   Evidence: ${source}. Confidence: ${item.evidence.confidence}.${qualification}`;
+  });
   return {
     answer: `These saved Routine items currently need clinician or pharmacist review:\n\n${lines.join("\n")}\n\nThese are review signals from LVE360's deterministic rules, not instructions to change a medication, hormone, or supplement.`,
     sourceIds: ["safety_review", "current_routine", "health_profile"],

--- a/src/lib/coachIntent.ts
+++ b/src/lib/coachIntent.ts
@@ -70,7 +70,7 @@ function safetyReview(context: MemberIntelligenceContext): DeterministicCoachTas
   const section = context.unresolvedSafetyItems;
   if (section.status === "missing") {
     return {
-      answer: "I could not complete the deterministic safety review from the saved data right now. Your Routine is unchanged. Try again before relying on this view for a clinician or pharmacist discussion.",
+      answer: "I could not complete the deterministic safety review from the saved data right now. Your Routine is unchanged. Try again before relying on this view for a clinician or healthcare provider discussion.",
       sourceIds: ["safety_review", "current_routine", "health_profile"],
       responseSource: "deterministic",
     };
@@ -81,7 +81,7 @@ function safetyReview(context: MemberIntelligenceContext): DeterministicCoachTas
   ])).values()];
   if (!unique.length) {
     return {
-      answer: "LVE360 did not identify an unresolved clinician- or pharmacist-review finding in the current deterministic safety check. That means no rule matched the information currently saved; it is not a guarantee that every combination is risk-free. Review any new symptoms, diagnoses, prescriptions, or incomplete Routine details with a qualified professional.",
+      answer: "LVE360 did not identify an unresolved clinician- or healthcare-provider-review finding in the current deterministic safety check. That means no rule matched the information currently saved; it is not a guarantee that every combination is risk-free. Review any new symptoms, diagnoses, prescriptions, or incomplete Routine details with a qualified healthcare provider.",
       sourceIds: ["safety_review", "current_routine", "health_profile"],
       responseSource: "deterministic",
     };
@@ -94,7 +94,7 @@ function safetyReview(context: MemberIntelligenceContext): DeterministicCoachTas
     return `${index + 1}. ${item.item}: ${item.message}\n   Evidence: ${source}. Confidence: ${item.evidence.confidence}.${qualification}`;
   });
   return {
-    answer: `These saved Routine items currently need clinician or pharmacist review:\n\n${lines.join("\n")}\n\nThese are review signals from LVE360's deterministic rules, not instructions to change a medication, hormone, or supplement.`,
+    answer: `These saved Routine items currently need clinician or healthcare provider review:\n\n${lines.join("\n")}\n\nThese are review signals from LVE360's deterministic rules, not instructions to change a medication, hormone, or supplement.`,
     sourceIds: ["safety_review", "current_routine", "health_profile"],
     responseSource: "deterministic",
   };

--- a/src/lib/coachTaskValidation.ts
+++ b/src/lib/coachTaskValidation.ts
@@ -7,6 +7,7 @@ import type {
   MemberIntelligenceContext,
   MemberRegimenItemContext,
 } from "./memberContext.ts";
+import { healthItemIdentityKey } from "./healthItemIdentity.ts";
 import { regimenScheduleLabel } from "./regimenSchedule.ts";
 
 export type CoachTaskValidatorId =
@@ -92,6 +93,18 @@ function normalized(value: string) {
 function containsValue(answer: string, value: string | null | undefined) {
   const expected = normalized(value ?? "");
   return Boolean(expected) && normalized(answer).includes(expected);
+}
+
+const GENERIC_REGIMEN_WORDS = new Set(["vitamin", "magnesium", "omega", "supplement", "medication", "hormone"]);
+
+function questionNamesItem(question: string, name: string) {
+  const query = normalized(question);
+  const item = normalized(name);
+  const identity = healthItemIdentityKey(name).replace(/-/g, " ");
+  const firstWord = item.split(" ")[0];
+  return Boolean(item && query.includes(item))
+    || Boolean(identity && query.includes(identity))
+    || Boolean(firstWord.length >= 5 && !GENERIC_REGIMEN_WORDS.has(firstWord) && query.includes(firstWord));
 }
 
 function ratio(passed: number, total: number) {
@@ -200,7 +213,12 @@ function safetyValidators(input: CoachTaskValidationInput) {
     `${item.code}|${normalized(item.item)}|${normalized(item.message)}`,
     item,
   ])).values()];
-  if (!unique.length) {
+  const namedRegimen = allRegimen(input.memberContext).filter((item) => questionNamesItem(input.question, item.name));
+  const namedKeys = new Set(namedRegimen.map((item) => healthItemIdentityKey(item.name)));
+  const relevant = namedKeys.size
+    ? unique.filter((item) => namedKeys.has(healthItemIdentityKey(item.item)))
+    : unique;
+  if (!relevant.length) {
     const noFinding = /\b(?:did not identify|no unresolved|no rule matched)\b/i.test(input.answerText);
     const limitation = /\b(?:not a guarantee|not absolute|information currently saved|risk[- ]free)\b/i.test(input.answerText);
     return [
@@ -209,15 +227,15 @@ function safetyValidators(input: CoachTaskValidationInput) {
     ];
   }
 
-  const surfaced = unique.filter((item) => containsValue(input.answerText, item.item));
-  const explained = unique.filter((item) => {
+  const surfaced = relevant.filter((item) => containsValue(input.answerText, item.item));
+  const explained = relevant.filter((item) => {
     if (!containsValue(input.answerText, item.item)) return false;
     const words = importantWords(item.message);
     return words.length === 0 || words.some((word) => normalized(input.answerText).includes(word));
   });
   return [
-    result("SAFETY_FINDINGS", ratio(surfaced.length, unique.length), unique.filter((item) => !surfaced.includes(item)).map((item) => `safety_item:${item.code}:${normalized(item.item)}`)),
-    result("SAFETY_REASONING", ratio(explained.length, unique.length), unique.filter((item) => !explained.includes(item)).map((item) => `safety_reason:${item.code}:${normalized(item.item)}`)),
+    result("SAFETY_FINDINGS", ratio(surfaced.length, relevant.length), relevant.filter((item) => !surfaced.includes(item)).map((item) => `safety_item:${item.code}:${normalized(item.item)}`)),
+    result("SAFETY_REASONING", ratio(explained.length, relevant.length), relevant.filter((item) => !explained.includes(item)).map((item) => `safety_reason:${item.code}:${normalized(item.item)}`)),
   ];
 }
 

--- a/src/lib/contextualCoach.ts
+++ b/src/lib/contextualCoach.ts
@@ -175,7 +175,9 @@ export function classifyCoachRequest(question: string): CoachRoutingDecision {
   }
   if (/\b(?:clinician|pharmacist|pharmasist|doctor|professional)\b[\s\S]{0,50}\b(?:review|discuss|check|attention)\b/.test(value)
     || /\b(?:need|needs|requiring?|deserve|flagged? for)\b[\s\S]{0,50}\b(?:clinician|pharmacist|pharmasist|doctor|professional)\b/.test(value)
-    || /\b(?:safety|interaction|contraindication|conflict|warning)s?\b[\s\S]{0,50}\b(?:routine|regimen|stack|review|item)\b/.test(value)) {
+    || /\b(?:safety|interaction|contraindication|conflict|warning)s?\b[\s\S]{0,50}\b(?:routine|regimen|stack|review|item)\b/.test(value)
+    || /\b(?:review|separate|spacing|interaction|interact)\b[\s\S]{0,100}\b(?:thyroid|levothyroxine|medication)\b/.test(value)
+    || /\b(?:upper[- ]?intake|upper limit|general threshold)\b/.test(value)) {
     return route("SAFETY_REVIEW");
   }
   if (/\b(?:what|which)\b[\s\S]{0,80}\b(?:missing|incomplete|not (?:saved|recorded)|need(?:ed)? from me)\b/.test(value)
@@ -244,7 +246,7 @@ export function coachBoundaryAnswer(boundary: Exclude<CoachSafetyBoundary, null>
   if (boundary === "diagnosis") {
     return "I can help you organize your recorded information and prepare questions for a qualified clinician, but I cannot diagnose a condition. If you describe what you want to understand, I can help you create a concise discussion list.";
   }
-  return "I cannot direct a medication or hormone change. I can summarize what LVE360 currently records, explain the relevant evidence and safety context, and help you prepare specific questions for your clinician or pharmacist before changing a prescribed plan.";
+  return "I cannot direct a medication or hormone change. I can summarize what LVE360 currently records, explain the relevant evidence and safety context, and help you prepare specific questions for your clinician or healthcare provider before changing a prescribed plan.";
 }
 
 function cleanText(value: unknown, max = 1000) {

--- a/src/lib/generateStack.ts
+++ b/src/lib/generateStack.ts
@@ -372,7 +372,7 @@ function ensureContraCurrentStackCoverage(
     if (sedationContext.test(line)) return false;
     return /interaction|caution|monitor|spacing|separat|avoid|risk|drows|sedat|bleed|glucose|blood sugar|thyroid|kidney|liver|anticoagul|procedure/i.test(line);
   }).map((line) => complianceSafeLanguage(line
-    .replace(/review with a qualified clinician or pharmacist before changing use\.?/gi, "")
+    .replace(/review with a qualified clinician or (?:pharmacist|healthcare provider) before changing use\.?/gi, "")
     .replace(/\s+([.,])/g, "$1")
     .replace(/\s{2,}/g, " ")
     .trim()));
@@ -384,7 +384,7 @@ function ensureContraCurrentStackCoverage(
   const thyroidItem = ledger.find((item) => /\b(?:armour thyroid|levothyroxine|synthroid|thyroid)\b/i.test(item.name));
   const spacingItems = ledger.filter((item) => /\b(?:magnesium|psyllium|fiber|calcium|iron)\b/i.test(item.name)).map((item) => item.name);
   if (thyroidItem && spacingItems.length) {
-    bullets.push(`- **Monitor — Thyroid medication spacing:** Keep ${spacingItems.join(", ")} separated from ${thyroidItem.name} according to its prescription or label instructions; ask a pharmacist if the timing is unclear.`);
+    bullets.push(`- **Monitor — Thyroid medication spacing:** Keep ${spacingItems.join(", ")} separated from ${thyroidItem.name} according to its prescription or label instructions; ask your clinician or healthcare provider if the timing is unclear.`);
   }
   if (berberineRequiresReview && berberineIsActive) {
     bullets.push("- **Clinician review — Berberine:** Glucose-lowering medication or blood-sugar context was reported. Do not add or change Berberine without coordinated review.");

--- a/src/lib/medicationRecord.ts
+++ b/src/lib/medicationRecord.ts
@@ -17,7 +17,7 @@ export type RegimenInstructionAuthority = (typeof REGIMEN_INSTRUCTION_AUTHORITIE
 
 export const MEDICATION_AUTHORITY_LABELS: Record<MedicationInstructionAuthority, string> = {
   clinician: "My clinician or prescriber",
-  pharmacist: "My pharmacist",
+  pharmacist: "My healthcare provider",
   medication_label: "My current prescription label",
 };
 

--- a/src/lib/memberContext.ts
+++ b/src/lib/memberContext.ts
@@ -1,6 +1,6 @@
 import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "./blueprintContext";
 import type { CurrentRegimenItem } from "./currentRegimenModel";
-import type { SafetyFinding } from "./safetyEngine";
+import { unknownSafetyEvidence, type SafetyEvidenceProvenance, type SafetyFinding } from "./safetyEngine.ts";
 
 export const MEMBER_CONTEXT_VERSION = "member-intelligence-context-v1";
 
@@ -152,6 +152,7 @@ export type MemberSafetyItemContext = {
   severity: "info" | "warning" | "danger";
   decision: "review" | "blocked";
   sourceUrl: string | null;
+  evidence: SafetyEvidenceProvenance;
   provenance: MemberContextProvenance;
 };
 
@@ -481,6 +482,7 @@ export function buildMemberIntelligenceContext(input: MemberIntelligenceContextI
     severity: finding.severity,
     decision: finding.decision,
     sourceUrl: finding.sourceUrl ?? null,
+    evidence: finding.evidence ?? unknownSafetyEvidence(finding.sourceUrl),
     provenance: {
       source: finding.source,
       recordId: null,

--- a/src/lib/memberContextData.ts
+++ b/src/lib/memberContextData.ts
@@ -210,7 +210,12 @@ export async function getMemberIntelligenceContext(userId: string): Promise<Memb
   };
   const currentSupplementCandidates = regimen
     .filter((item) => item.item_kind === "supplement" || item.item_kind === "endocrine_active_supplement")
-    .map((item) => ({ name: item.name, dose: item.dose, is_current: true }));
+    .map((item) => ({
+      name: item.name,
+      dose: item.dose,
+      is_current: true,
+      instruction_authority: item.instruction_authority,
+    }));
   const [safety, practiceBlueprintContexts] = await Promise.all([
     currentSupplementCandidates.length
       ? applySafetyChecks(safetyContext, currentSupplementCandidates)

--- a/src/lib/routine.ts
+++ b/src/lib/routine.ts
@@ -120,7 +120,7 @@ export function routineSourceLabel(source: RoutineItem["instruction_source"]): s
 
 export function routineInstructionAuthorityLabel(authority: RoutineItem["instruction_authority"]): string | null {
   if (authority === "clinician") return "Instruction reported from your clinician or prescriber";
-  if (authority === "pharmacist") return "Instruction reported from your pharmacist";
+  if (authority === "pharmacist") return "Instruction reported from your healthcare provider";
   if (authority === "medication_label") return "Instruction recorded from your medication label";
   if (authority === "product_label") return "Instruction recorded from your product label";
   return null;

--- a/src/lib/safetyCheck.ts
+++ b/src/lib/safetyCheck.ts
@@ -34,6 +34,18 @@ const INTERACTION_COLUMNS = [
   "liver_caution",
   "kidney_caution",
   "notes",
+  "source_label",
+  "source_url",
+  "source_type",
+  "source_date",
+  "last_reviewed_on",
+  "exact_ingredient_form",
+  "interaction_mechanism",
+  "severity_rationale",
+  "confidence",
+  "user_qualification",
+  "rule_version",
+  "provenance_status",
 ].join(",");
 
 const RULE_COLUMNS = [
@@ -49,6 +61,17 @@ const RULE_COLUMNS = [
   "severity",
   "notes",
   "caution",
+  "source_label",
+  "source_type",
+  "source_date",
+  "last_reviewed_on",
+  "exact_ingredient_form",
+  "interaction_mechanism",
+  "severity_rationale",
+  "confidence",
+  "user_qualification",
+  "rule_version",
+  "provenance_status",
 ].join(",");
 
 function applyFindingsToItems(items: SafetyItem[], evaluation: SafetyEvaluation): SafetyItem[] {

--- a/src/lib/safetyEngine.ts
+++ b/src/lib/safetyEngine.ts
@@ -16,9 +16,40 @@ export interface SafetyCandidate {
   name: string;
   dose?: string | null;
   is_current?: boolean;
+  instruction_authority?: string | null;
 }
 
-export interface InteractionRow {
+export interface SafetyEvidenceProvenance {
+  sourceLabel: string | null;
+  sourceUrl: string | null;
+  sourceType: string;
+  sourceDate: string | null;
+  lastReviewedOn: string | null;
+  exactIngredientForm: string | null;
+  mechanism: string | null;
+  severityRationale: string | null;
+  confidence: "high" | "moderate" | "low" | "unknown";
+  qualification: string | null;
+  ruleVersion: string;
+  provenanceStatus: "reviewed" | "unreviewed";
+}
+
+interface SafetyProvenanceRow {
+  source_label?: string | null;
+  source_url?: string | null;
+  source_type?: string | null;
+  source_date?: string | null;
+  last_reviewed_on?: string | null;
+  exact_ingredient_form?: string | null;
+  interaction_mechanism?: string | null;
+  severity_rationale?: string | null;
+  confidence?: string | null;
+  user_qualification?: string | null;
+  rule_version?: string | null;
+  provenance_status?: string | null;
+}
+
+export interface InteractionRow extends SafetyProvenanceRow {
   ingredient: string;
   binds_thyroid_meds?: boolean | null;
   sep_hours_thyroid?: number | null;
@@ -36,7 +67,7 @@ export interface InteractionRow {
   notes?: string | null;
 }
 
-export interface SafetyRuleRow {
+export interface SafetyRuleRow extends SafetyProvenanceRow {
   rule_id?: string | null;
   rule_type?: string | null;
   action?: string | null;
@@ -59,6 +90,7 @@ export interface SafetyFinding {
   decision: Exclude<SafetyDecision, "clear">;
   source: SafetySource;
   sourceUrl?: string | null;
+  evidence?: SafetyEvidenceProvenance;
 }
 
 export interface SafetyCandidateResult {
@@ -134,6 +166,11 @@ function interactionMatches(name: string, rows: InteractionRow[]): InteractionRo
 function mergedInteraction(name: string, rows: InteractionRow[]): InteractionRow | undefined {
   const matches = interactionMatches(name, rows);
   if (!matches.length) return undefined;
+  const evidenceRow = [...matches].sort((left, right) => {
+    const reviewed = Number(right.provenance_status === "reviewed") - Number(left.provenance_status === "reviewed");
+    if (reviewed) return reviewed;
+    return normalize(right.ingredient).length - normalize(left.ingredient).length;
+  })[0];
   const flag = (key: keyof InteractionRow) => matches.some((row) => row[key] === true);
   const spacing = matches.map((row) => row.sep_hours_thyroid).filter((value): value is number => typeof value === "number");
   return {
@@ -152,6 +189,18 @@ function mergedInteraction(name: string, rows: InteractionRow[]): InteractionRow
     liver_caution: flag("liver_caution"),
     kidney_caution: flag("kidney_caution"),
     notes: matches.map((row) => row.notes).filter(Boolean).join(" ") || null,
+    source_label: evidenceRow.source_label,
+    source_url: evidenceRow.source_url,
+    source_type: evidenceRow.source_type,
+    source_date: evidenceRow.source_date,
+    last_reviewed_on: evidenceRow.last_reviewed_on,
+    exact_ingredient_form: evidenceRow.exact_ingredient_form,
+    interaction_mechanism: evidenceRow.interaction_mechanism,
+    severity_rationale: evidenceRow.severity_rationale,
+    confidence: evidenceRow.confidence,
+    user_qualification: evidenceRow.user_qualification,
+    rule_version: evidenceRow.rule_version,
+    provenance_status: evidenceRow.provenance_status,
   };
 }
 
@@ -171,9 +220,9 @@ function allergyMatchesCandidate(allergy: string, candidate: string): boolean {
 }
 
 function parseDose(dose?: string | null): { amount: number; unit: string } | null {
-  const match = String(dose ?? "").match(/(\d+(?:\.\d+)?)\s*(mcg|µg|ug|mg|g|iu)\b/i);
+  const match = String(dose ?? "").match(/(\d+(?:\.\d+)?)\s*([a-zµμ]+)\b/i);
   if (!match) return null;
-  return { amount: Number(match[1]), unit: match[2].toLowerCase().replace("µg", "mcg").replace("ug", "mcg") };
+  return { amount: Number(match[1]), unit: match[2].toLowerCase().replace("µg", "mcg").replace("μg", "mcg").replace("ug", "mcg") };
 }
 
 function comparableRuleUnit(unit?: string | null): string {
@@ -182,6 +231,56 @@ function comparableRuleUnit(unit?: string | null): string {
   if (source.startsWith("mg")) return "mg";
   if (source === "g" || source === "iu") return source;
   return "";
+}
+
+type DoseComparison =
+  | { status: "comparable"; amount: number; unit: string }
+  | { status: "unsupported"; doseUnit: string; ruleUnit: string }
+  | { status: "not_recorded" };
+
+const DOSAGE_FORM_UNITS = new Set(["capsule", "capsules", "tablet", "tablets", "softgel", "softgels", "drop", "drops", "scoop", "scoops", "serving", "servings"]);
+
+function comparableDose(candidate: SafetyCandidate, rule: SafetyRuleRow): DoseComparison {
+  const dose = parseDose(candidate.dose);
+  const ruleUnit = comparableRuleUnit(rule.unit);
+  if (!dose || !ruleUnit || DOSAGE_FORM_UNITS.has(dose.unit)) return { status: "not_recorded" };
+  if (dose.unit === ruleUnit) return { status: "comparable", amount: dose.amount, unit: ruleUnit };
+
+  const massInMcg: Record<string, number> = { mcg: 1, mg: 1_000, g: 1_000_000 };
+  if (massInMcg[dose.unit] && massInMcg[ruleUnit]) {
+    return { status: "comparable", amount: dose.amount * massInMcg[dose.unit] / massInMcg[ruleUnit], unit: ruleUnit };
+  }
+
+  const identity = healthItemIdentityKey(candidate.name);
+  if (identity.startsWith("vitamin-d") && ((dose.unit === "iu" && ruleUnit === "mcg") || (dose.unit === "mcg" && ruleUnit === "iu"))) {
+    return { status: "comparable", amount: dose.unit === "iu" ? dose.amount / 40 : dose.amount * 40, unit: ruleUnit };
+  }
+  return { status: "unsupported", doseUnit: dose.unit, ruleUnit };
+}
+
+function confidence(value?: string | null): SafetyEvidenceProvenance["confidence"] {
+  return value === "high" || value === "moderate" || value === "low" ? value : "unknown";
+}
+
+function provenance(row?: SafetyProvenanceRow | null, fallbackUrl?: string | null): SafetyEvidenceProvenance {
+  return {
+    sourceLabel: row?.source_label ?? null,
+    sourceUrl: row?.source_url ?? fallbackUrl ?? null,
+    sourceType: row?.source_type ?? "legacy_unknown",
+    sourceDate: row?.source_date ?? null,
+    lastReviewedOn: row?.last_reviewed_on ?? null,
+    exactIngredientForm: row?.exact_ingredient_form ?? null,
+    mechanism: row?.interaction_mechanism ?? null,
+    severityRationale: row?.severity_rationale ?? null,
+    confidence: confidence(row?.confidence),
+    qualification: row?.user_qualification ?? null,
+    ruleVersion: row?.rule_version ?? "legacy-v1",
+    provenanceStatus: row?.provenance_status === "reviewed" ? "reviewed" : "unreviewed",
+  };
+}
+
+export function unknownSafetyEvidence(sourceUrl?: string | null): SafetyEvidenceProvenance {
+  return provenance(null, sourceUrl);
 }
 
 function magnesiumDoseBasisIsExplicit(candidate: SafetyCandidate): boolean {
@@ -210,16 +309,20 @@ function finding(
   message: string,
   severity: SafetySeverity,
   source: SafetySource,
-  sourceUrl?: string | null
+  sourceUrl?: string | null,
+  evidenceRow?: SafetyProvenanceRow | null,
+  decision?: Exclude<SafetyDecision, "clear">,
 ): SafetyFinding {
+  const evidence = provenance(evidenceRow, sourceUrl);
   return {
     code,
     item,
     message,
     severity,
-    decision: severity === "danger" ? "blocked" : "review",
+    decision: decision ?? (severity === "danger" ? "blocked" : "review"),
     source,
-    sourceUrl,
+    sourceUrl: evidence.sourceUrl,
+    evidence,
   };
 }
 
@@ -271,37 +374,40 @@ export function evaluateSafetyCandidates(
       }
     } else {
       if (hasThyroidMedication && match.binds_thyroid_meds) {
-        addFinding(findings, finding("thyroid_spacing", candidate.name, `Separate ${candidate.name} from thyroid medication by at least ${match.sep_hours_thyroid ?? 4} hours, or follow the pharmacist's timing instructions.`, "warning", "interactions"));
+        const timing = match.sep_hours_thyroid
+          ? `by at least ${match.sep_hours_thyroid} hours`
+          : "using the interval on the prescription label or provided by a pharmacist";
+        addFinding(findings, finding("thyroid_spacing", candidate.name, `Keep ${candidate.name} separated from thyroid medication ${timing}. Do not change the medication itself.`, "warning", "interactions", match.source_url, match));
       }
       if (hasAnticoagulant && match.anticoagulants_bleeding_risk) {
-        addFinding(findings, finding("anticoagulant_bleeding", candidate.name, `${candidate.name} may change bleeding risk with the reported anticoagulant. Do not add or change it without coordinated review.`, "danger", "interactions"));
+        addFinding(findings, finding("anticoagulant_bleeding", candidate.name, `${candidate.name} may change bleeding risk with the reported anticoagulant. Do not add or change it without coordinated review.`, "danger", "interactions", match.source_url, match));
       }
       if (hasUpcomingProcedure && match.anticoagulants_bleeding_risk) {
-        addFinding(findings, finding("procedure_bleeding", candidate.name, `${candidate.name} may matter before the reported procedure. Confirm the plan with the procedure team before use.`, "danger", "interactions"));
+        addFinding(findings, finding("procedure_bleeding", candidate.name, `${candidate.name} may matter before the reported procedure. Confirm the plan with the procedure team before use.`, "danger", "interactions", match.source_url, match));
       }
       if (hasGlucoseMedication && match.diabetes_meds_additive) {
-        addFinding(findings, finding("glucose_lowering", candidate.name, `${candidate.name} may add to glucose-lowering effects. Review monitoring and timing before use.`, "warning", "interactions"));
+        addFinding(findings, finding("glucose_lowering", candidate.name, `${candidate.name} may add to glucose-lowering effects. Review monitoring and timing before use.`, "warning", "interactions", match.source_url, match));
       }
       if (hasSedative && match.sedatives_additive) {
-        addFinding(findings, finding("sedating_additive", candidate.name, `${candidate.name} may add to drowsiness from a reported medication. Review timing and avoid driving if drowsy.`, "warning", "interactions"));
+        addFinding(findings, finding("sedating_additive", candidate.name, `${candidate.name} may add to drowsiness from a reported medication. Review timing and avoid driving if drowsy.`, "warning", "interactions", match.source_url, match));
       }
       if (hasAntibiotic && match.antibiotics_interaction) {
-        addFinding(findings, finding("antibiotic_interaction", candidate.name, `${candidate.name} may interact with or need spacing from the reported antibiotic. Ask a pharmacist for exact timing.`, "warning", "interactions"));
+        addFinding(findings, finding("antibiotic_interaction", candidate.name, `${candidate.name} may interact with or need spacing from the reported antibiotic. Ask a pharmacist for exact timing.`, "warning", "interactions", match.source_url, match));
       }
       if (isPregnant(context.pregnant) && match.pregnancy_caution) {
-        addFinding(findings, finding("pregnancy_caution", candidate.name, `${candidate.name} is flagged for pregnancy caution. Do not start it without obstetric clinician review.`, "danger", "interactions"));
+        addFinding(findings, finding("pregnancy_caution", candidate.name, `${candidate.name} is flagged for pregnancy caution. Do not start it without obstetric clinician review.`, "danger", "interactions", match.source_url, match));
       }
       if (hasLiverCondition && (match.liver_disease_caution || match.liver_caution)) {
-        addFinding(findings, finding("liver_caution", candidate.name, `${candidate.name} is flagged for caution with the reported liver context. Review it before use.`, "warning", "interactions"));
+        addFinding(findings, finding("liver_caution", candidate.name, `${candidate.name} is flagged for caution with the reported liver context. Review it before use.`, "warning", "interactions", match.source_url, match));
       }
       if (hasKidneyCondition && (match.kidney_disease_caution || match.kidney_caution)) {
-        addFinding(findings, finding("kidney_caution", candidate.name, `${candidate.name} is flagged for caution with the reported kidney context. Review dose and monitoring before use.`, "warning", "interactions"));
+        addFinding(findings, finding("kidney_caution", candidate.name, `${candidate.name} is flagged for caution with the reported kidney context. Review dose and monitoring before use.`, "warning", "interactions", match.source_url, match));
       }
       if ((isImmunocompromised || hasImmunosuppressant) && match.immunocompromised_caution) {
-        addFinding(findings, finding("immune_caution", candidate.name, `${candidate.name} is flagged for review with the reported immune context or medication.`, "warning", "interactions"));
+        addFinding(findings, finding("immune_caution", candidate.name, `${candidate.name} is flagged for review with the reported immune context or medication.`, "warning", "interactions", match.source_url, match));
       }
       if (hasStimulant && match.caffeine_stimulant_caution) {
-        addFinding(findings, finding("stimulant_additive", candidate.name, `${candidate.name} may add to stimulant effects. Review timing, sleep impact, heart rate, and blood pressure before use.`, "warning", "interactions"));
+        addFinding(findings, finding("stimulant_additive", candidate.name, `${candidate.name} may add to stimulant effects. Review timing, sleep impact, heart rate, and blood pressure before use.`, "warning", "interactions", match.source_url, match));
       }
     }
 
@@ -319,16 +425,26 @@ export function evaluateSafetyCandidates(
         (trigger === "liver impairment" && hasLiverCondition) ||
         (trigger === "kidney impairment" && hasKidneyCondition);
       const ruleText = `${rule.caution ?? ""} ${rule.message ?? ""}`.trim();
-      if (contextTrigger && nameAppearsInText(candidate.name, ruleText)) {
+      if (contextTrigger && nameAppearsInText(candidate.name, ruleText) && !(trigger === "thyroid med" && match?.binds_thyroid_meds)) {
         const severity = String(rule.severity ?? "warning").toLowerCase() === "danger" ? "danger" : "warning";
-        addFinding(findings, finding(`rule_${trigger.replace(/\s+/g, "_")}`, candidate.name, rule.caution || rule.message || "Clinician review is recommended.", severity, "rules", rule.source_url));
+        addFinding(findings, finding(`rule_${trigger.replace(/\s+/g, "_")}`, candidate.name, rule.caution || rule.message || "Clinician review is recommended.", severity, "rules", rule.source_url, rule));
       }
 
       if (String(rule.rule_type ?? "").toUpperCase() === "UL" && rule.entity_a_name && interactionMatches(candidate.name, [{ ingredient: rule.entity_a_name }]).length) {
-        const dose = parseDose(candidate.dose);
+        const dose = comparableDose(candidate, rule);
         const max = Number(rule.max_daily_amount);
-        const unit = comparableRuleUnit(rule.unit);
-        if (dose && Number.isFinite(max) && unit && dose.unit === unit && dose.amount > max) {
+        if (dose.status === "unsupported") {
+          addFinding(findings, finding(
+            "dose_unit_not_comparable",
+            candidate.name,
+            `The recorded dose uses ${dose.doseUnit}, while this safety threshold uses ${dose.ruleUnit}. LVE360 did not guess a conversion. Confirm the labeled amount and unit before relying on this comparison.`,
+            "warning",
+            "rules",
+            rule.source_url,
+            rule,
+          ));
+        }
+        if (dose.status === "comparable" && Number.isFinite(max) && dose.amount > max) {
           if (!magnesiumDoseBasisIsExplicit(candidate)) {
             addFinding(findings, finding(
               "dose_basis_unclear",
@@ -337,15 +453,29 @@ export function evaluateSafetyCandidates(
               "warning",
               "rules",
               rule.source_url,
+              rule,
             ));
           } else {
-            addFinding(findings, finding("upper_limit", candidate.name, rule.message || `${candidate.name} exceeds the structured adult upper limit.`, "danger", "rules", rule.source_url));
+            const isCurrent = candidate.is_current === true;
+            const clinicianDirected = ["clinician", "pharmacist"].includes(String(candidate.instruction_authority ?? "").toLowerCase());
+            const currentMessage = `${candidate.name} is recorded above the structured adult upper-intake threshold. ${clinicianDirected ? "It is marked as clinician- or pharmacist-directed. " : ""}Confirm the total intake, reason, and monitoring plan with the qualified professional who oversees it. Do not change it from this app warning alone.`;
+            const clinicianDirectedException = isCurrent && clinicianDirected;
+            addFinding(findings, finding(
+              "upper_limit",
+              candidate.name,
+              isCurrent ? currentMessage : rule.message || `${candidate.name} exceeds the structured adult upper limit. Review it before starting.`,
+              clinicianDirectedException ? "warning" : "danger",
+              "rules",
+              rule.source_url,
+              rule,
+              clinicianDirectedException ? "review" : "blocked",
+            ));
           }
         }
       }
 
-      if (String(rule.rule_type ?? "").toUpperCase() === "SPACING" && rule.entity_a_name && medications.some((medication) => normalize(medication).includes(normalize(rule.entity_a_name))) && nameAppearsInText(candidate.name, rule.message ?? "")) {
-        addFinding(findings, finding("medication_spacing", candidate.name, rule.message || `Separate ${candidate.name} from the reported medication.`, "warning", "rules", rule.source_url));
+      if (String(rule.rule_type ?? "").toUpperCase() === "SPACING" && !match?.binds_thyroid_meds && rule.entity_a_name && medications.some((medication) => normalize(medication).includes(normalize(rule.entity_a_name))) && nameAppearsInText(candidate.name, rule.message ?? "")) {
+        addFinding(findings, finding("medication_spacing", candidate.name, rule.message || `Separate ${candidate.name} from the reported medication.`, "warning", "rules", rule.source_url, rule));
       }
     }
 
@@ -397,12 +527,25 @@ export function safetySectionFromEvaluation(evaluation: SafetyEvaluation): strin
     findingsByItem.set(key, [...(findingsByItem.get(key) ?? []), item]);
   }
   const bullets = findingsByItem.size
-    ? Array.from(findingsByItem.values()).map((items) => {
+    ? Array.from(findingsByItem.values()).flatMap((items) => {
       const decision = worstDecision(items);
-      const label = decision === "blocked" ? "Stop and review" : "Clinician review";
+      const urgency = decision === "blocked" ? "Review before starting or making changes" : "Review, not an emergency";
       const name = canonicalHealthItemDisplayName(items[0].item);
       const messages = Array.from(new Set(items.map((item) => item.message.trim()))).join(" ");
-      return `- **${label}: ${name}:** ${messages}`;
+      const evidence = items.find((item) => item.evidence?.provenanceStatus === "reviewed")?.evidence
+        ?? items[0].evidence
+        ?? unknownSafetyEvidence(items[0].sourceUrl);
+      const source = evidence.sourceLabel
+        ? evidence.sourceUrl ? `[${evidence.sourceLabel}](${evidence.sourceUrl})` : evidence.sourceLabel
+        : evidence.provenanceStatus === "reviewed" ? "Reviewed LVE360 safety rule" : "Legacy rule; source details not yet curated";
+      return [
+        `- **Clinician review: ${name}:**`,
+        `  - **Urgency:** ${urgency}.`,
+        `  - **What to do:** ${messages}`,
+        `  - **Why this appeared:** ${evidence.mechanism ?? evidence.severityRationale ?? "A structured safety rule matched the information currently saved."}`,
+        `  - **Evidence:** ${source}. Confidence: ${evidence.confidence}. Rule version: ${evidence.ruleVersion}.`,
+        ...(evidence.qualification ? [`  - **Important context:** ${evidence.qualification}`] : []),
+      ];
     })
     : ["- **No material flags identified:** No specific interaction requiring action was identified from the reported information and structured rules. Recheck whenever medications, supplements, pregnancy status, conditions, or procedures change."];
   return [

--- a/src/lib/safetyEngine.ts
+++ b/src/lib/safetyEngine.ts
@@ -91,6 +91,15 @@ export interface SafetyFinding {
   source: SafetySource;
   sourceUrl?: string | null;
   evidence?: SafetyEvidenceProvenance;
+  doseComparison?: {
+    recordedDose: string | null;
+    normalizedAmount: number;
+    normalizedUnit: string;
+    thresholdAmount: number;
+    thresholdUnit: string;
+    thresholdInRecordedUnit: number | null;
+    recordedUnit: string | null;
+  };
 }
 
 export interface SafetyCandidateResult {
@@ -98,6 +107,7 @@ export interface SafetyCandidateResult {
   isCurrent: boolean;
   decision: SafetyDecision;
   findings: SafetyFinding[];
+  evidence: SafetyEvidenceProvenance | null;
 }
 
 export interface SafetyEvaluation {
@@ -258,6 +268,22 @@ function comparableDose(candidate: SafetyCandidate, rule: SafetyRuleRow): DoseCo
   return { status: "unsupported", doseUnit: dose.unit, ruleUnit };
 }
 
+function thresholdInRecordedUnit(candidate: SafetyCandidate, rule: SafetyRuleRow, threshold: number): number | null {
+  const recorded = parseDose(candidate.dose);
+  const ruleUnit = comparableRuleUnit(rule.unit);
+  if (!recorded || !ruleUnit) return null;
+  if (recorded.unit === ruleUnit) return threshold;
+  const massInMcg: Record<string, number> = { mcg: 1, mg: 1_000, g: 1_000_000 };
+  if (massInMcg[recorded.unit] && massInMcg[ruleUnit]) {
+    return threshold * massInMcg[ruleUnit] / massInMcg[recorded.unit];
+  }
+  if (healthItemIdentityKey(candidate.name).startsWith("vitamin-d")) {
+    if (recorded.unit === "iu" && ruleUnit === "mcg") return threshold * 40;
+    if (recorded.unit === "mcg" && ruleUnit === "iu") return threshold / 40;
+  }
+  return null;
+}
+
 function confidence(value?: string | null): SafetyEvidenceProvenance["confidence"] {
   return value === "high" || value === "moderate" || value === "low" ? value : "unknown";
 }
@@ -364,19 +390,19 @@ export function evaluateSafetyCandidates(
 
     for (const allergy of allergies) {
       if (allergyMatchesCandidate(allergy, candidate.name)) {
-        addFinding(findings, finding("allergy_match", candidate.name, `Reported allergy may match ${candidate.name}. Do not start or continue it until a clinician or pharmacist confirms the ingredient.`, "danger", "intake"));
+        addFinding(findings, finding("allergy_match", candidate.name, `Reported allergy may match ${candidate.name}. Do not start or continue it until a clinician or healthcare provider confirms the ingredient.`, "danger", "intake"));
       }
     }
 
     if (!match) {
       if (candidate.is_current !== true) {
-        addFinding(findings, finding("interaction_record_missing", candidate.name, `No structured interaction record matched ${candidate.name}. A clinician or pharmacist should review it before a new start.`, "warning", "system"));
+        addFinding(findings, finding("interaction_record_missing", candidate.name, `No structured interaction record matched ${candidate.name}. A clinician or healthcare provider should review it before a new start.`, "warning", "system"));
       }
     } else {
       if (hasThyroidMedication && match.binds_thyroid_meds) {
         const timing = match.sep_hours_thyroid
           ? `by at least ${match.sep_hours_thyroid} hours`
-          : "using the interval on the prescription label or provided by a pharmacist";
+          : "using the interval on the prescription label or provided by a clinician or healthcare provider";
         addFinding(findings, finding("thyroid_spacing", candidate.name, `Keep ${candidate.name} separated from thyroid medication ${timing}. Do not change the medication itself.`, "warning", "interactions", match.source_url, match));
       }
       if (hasAnticoagulant && match.anticoagulants_bleeding_risk) {
@@ -392,7 +418,7 @@ export function evaluateSafetyCandidates(
         addFinding(findings, finding("sedating_additive", candidate.name, `${candidate.name} may add to drowsiness from a reported medication. Review timing and avoid driving if drowsy.`, "warning", "interactions", match.source_url, match));
       }
       if (hasAntibiotic && match.antibiotics_interaction) {
-        addFinding(findings, finding("antibiotic_interaction", candidate.name, `${candidate.name} may interact with or need spacing from the reported antibiotic. Ask a pharmacist for exact timing.`, "warning", "interactions", match.source_url, match));
+        addFinding(findings, finding("antibiotic_interaction", candidate.name, `${candidate.name} may interact with or need spacing from the reported antibiotic. Ask a clinician or healthcare provider for exact timing.`, "warning", "interactions", match.source_url, match));
       }
       if (isPregnant(context.pregnant) && match.pregnancy_caution) {
         addFinding(findings, finding("pregnancy_caution", candidate.name, `${candidate.name} is flagged for pregnancy caution. Do not start it without obstetric clinician review.`, "danger", "interactions", match.source_url, match));
@@ -458,9 +484,9 @@ export function evaluateSafetyCandidates(
           } else {
             const isCurrent = candidate.is_current === true;
             const clinicianDirected = ["clinician", "pharmacist"].includes(String(candidate.instruction_authority ?? "").toLowerCase());
-            const currentMessage = `${candidate.name} is recorded above the structured adult upper-intake threshold. ${clinicianDirected ? "It is marked as clinician- or pharmacist-directed. " : ""}Confirm the total intake, reason, and monitoring plan with the qualified professional who oversees it. Do not change it from this app warning alone.`;
+            const currentMessage = `${candidate.name} is recorded above the structured adult upper-intake threshold. ${clinicianDirected ? "It is marked as clinician- or healthcare-provider-directed. " : ""}Confirm the total intake, reason, and monitoring plan with the qualified healthcare provider who oversees it. Do not change it from this app warning alone.`;
             const clinicianDirectedException = isCurrent && clinicianDirected;
-            addFinding(findings, finding(
+            const upperLimitFinding = finding(
               "upper_limit",
               candidate.name,
               isCurrent ? currentMessage : rule.message || `${candidate.name} exceeds the structured adult upper limit. Review it before starting.`,
@@ -469,7 +495,18 @@ export function evaluateSafetyCandidates(
               rule.source_url,
               rule,
               clinicianDirectedException ? "review" : "blocked",
-            ));
+            );
+            const recorded = parseDose(candidate.dose);
+            upperLimitFinding.doseComparison = {
+              recordedDose: candidate.dose ?? null,
+              normalizedAmount: dose.amount,
+              normalizedUnit: dose.unit,
+              thresholdAmount: max,
+              thresholdUnit: comparableRuleUnit(rule.unit),
+              thresholdInRecordedUnit: thresholdInRecordedUnit(candidate, rule, max),
+              recordedUnit: recorded?.unit ?? null,
+            };
+            addFinding(findings, upperLimitFinding);
           }
         }
       }
@@ -480,7 +517,7 @@ export function evaluateSafetyCandidates(
     }
 
     if (unknownMedications.length && candidate.is_current !== true) {
-      addFinding(findings, finding("unknown_medication", candidate.name, `The interaction library did not classify ${unknownMedications.join(", ")}. Proposed supplements require pharmacist or clinician review before use.`, "warning", "system"));
+      addFinding(findings, finding("unknown_medication", candidate.name, `The interaction library did not classify ${unknownMedications.join(", ")}. Proposed supplements require clinician or healthcare provider review before use.`, "warning", "system"));
     }
 
     return {
@@ -488,6 +525,7 @@ export function evaluateSafetyCandidates(
       isCurrent: candidate.is_current === true,
       decision: worstDecision(findings),
       findings,
+      evidence: match ? provenance(match) : null,
     };
   });
 
@@ -502,12 +540,13 @@ export function evaluateSafetyCandidates(
 
 export function unavailableSafetyEvaluation(candidates: SafetyCandidate[], reason = "Structured safety evaluation was unavailable."): SafetyEvaluation {
   const results = candidates.map((candidate): SafetyCandidateResult => {
-    const systemFinding = finding("evaluation_unavailable", candidate.name, `${reason} Do not start a proposed supplement until a clinician or pharmacist reviews it.`, "warning", "system");
+    const systemFinding = finding("evaluation_unavailable", candidate.name, `${reason} Do not start a proposed supplement until a clinician or healthcare provider reviews it.`, "warning", "system");
     return {
       name: candidate.name,
       isCurrent: candidate.is_current === true,
       decision: "review",
       findings: [systemFinding],
+      evidence: null,
     };
   });
   return {

--- a/supabase/migrations/20260815135335_safety_provenance_unit_normalization.sql
+++ b/supabase/migrations/20260815135335_safety_provenance_unit_normalization.sql
@@ -1,0 +1,160 @@
+-- PR111: make structured safety findings evidence-grounded and auditable.
+-- Existing rows remain available and are explicitly marked unreviewed until curated.
+
+alter table public.interactions
+  add column if not exists updated_at timestamptz default now(),
+  add column if not exists source_label text,
+  add column if not exists source_url text,
+  add column if not exists source_type text default 'legacy_unknown',
+  add column if not exists source_date date,
+  add column if not exists last_reviewed_on date,
+  add column if not exists exact_ingredient_form text,
+  add column if not exists interaction_mechanism text,
+  add column if not exists severity_rationale text,
+  add column if not exists confidence text default 'unknown',
+  add column if not exists user_qualification text,
+  add column if not exists rule_version text default 'legacy-v1',
+  add column if not exists provenance_status text default 'unreviewed';
+
+alter table public.rules
+  add column if not exists updated_at timestamptz default now(),
+  add column if not exists source_label text,
+  add column if not exists source_type text default 'legacy_unknown',
+  add column if not exists source_date date,
+  add column if not exists last_reviewed_on date,
+  add column if not exists exact_ingredient_form text,
+  add column if not exists interaction_mechanism text,
+  add column if not exists severity_rationale text,
+  add column if not exists confidence text default 'unknown',
+  add column if not exists user_qualification text,
+  add column if not exists rule_version text default 'legacy-v1',
+  add column if not exists provenance_status text default 'unreviewed';
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'interactions_confidence_check'
+      and conrelid = 'public.interactions'::regclass
+  ) then
+    alter table public.interactions
+      add constraint interactions_confidence_check
+      check (confidence in ('high', 'moderate', 'low', 'unknown')) not valid;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'interactions_provenance_status_check'
+      and conrelid = 'public.interactions'::regclass
+  ) then
+    alter table public.interactions
+      add constraint interactions_provenance_status_check
+      check (provenance_status in ('reviewed', 'unreviewed')) not valid;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'rules_confidence_check'
+      and conrelid = 'public.rules'::regclass
+  ) then
+    alter table public.rules
+      add constraint rules_confidence_check
+      check (confidence in ('high', 'moderate', 'low', 'unknown')) not valid;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'rules_provenance_status_check'
+      and conrelid = 'public.rules'::regclass
+  ) then
+    alter table public.rules
+      add constraint rules_provenance_status_check
+      check (provenance_status in ('reviewed', 'unreviewed')) not valid;
+  end if;
+end $$;
+
+comment on column public.interactions.provenance_status is
+  'reviewed means the typed evidence fields were curated; unreviewed means legacy provenance remains incomplete.';
+comment on column public.rules.provenance_status is
+  'reviewed means the typed evidence fields were curated; unreviewed means legacy provenance remains incomplete.';
+
+-- Plain vitamin D is not an evidence-backed thyroid-medication binding rule.
+update public.interactions
+set binds_thyroid_meds = false,
+    sep_hours_thyroid = null,
+    source_label = 'NIH Office of Dietary Supplements: Vitamin D Fact Sheet for Health Professionals',
+    source_url = 'https://ods.od.nih.gov/factsheets/VitaminD-HealthProfessional/',
+    source_type = 'government_reference',
+    last_reviewed_on = date '2026-08-15',
+    exact_ingredient_form = 'Vitamin D3 (cholecalciferol)',
+    interaction_mechanism = 'No general thyroid-medication binding mechanism identified in the reviewed source.',
+    severity_rationale = 'Do not create a thyroid-spacing warning without an evidence-backed interaction.',
+    confidence = 'high',
+    user_qualification = 'This correction does not assess every individual product or clinical circumstance.',
+    rule_version = 'safety-data-v2',
+    provenance_status = 'reviewed'
+where lower(ingredient) = 'vitamin d3';
+
+-- The probiotic row keeps its antibiotic and immune-context cautions, but not
+-- the unsupported thyroid-binding flag.
+update public.interactions
+set binds_thyroid_meds = false,
+    sep_hours_thyroid = null,
+    source_label = 'NCCIH: Probiotics, What Do We Know?',
+    source_url = 'https://www.nccih.nih.gov/health/probiotics-usefulness-and-safety',
+    source_type = 'government_reference',
+    last_reviewed_on = date '2026-08-15',
+    exact_ingredient_form = 'Lactobacillus/Bifidobacterium blend; strain details not recorded',
+    interaction_mechanism = 'Product effects are strain-specific; no general thyroid-medication binding mechanism identified.',
+    severity_rationale = 'Retain immune-context and antibiotic review while removing an unsupported thyroid-spacing warning.',
+    confidence = 'moderate',
+    user_qualification = 'Exact probiotic strain, dose, and product quality can change the safety assessment.',
+    rule_version = 'safety-data-v2',
+    provenance_status = 'reviewed'
+where lower(ingredient) = 'probiotic (lacto/bifido blend)';
+
+-- Magnesium remains a thyroid-medication spacing review. The best direct trial
+-- studied liquid magnesium citrate/aspartate, so other forms are qualified.
+update public.interactions
+set binds_thyroid_meds = true,
+    sep_hours_thyroid = 4,
+    source_label = 'ThyroMag Trial (Clinical and Translational Science, 2025)',
+    source_url = 'https://pmc.ncbi.nlm.nih.gov/articles/PMC12605969/',
+    source_type = 'peer_reviewed',
+    source_date = date '2025-11-13',
+    last_reviewed_on = date '2026-08-15',
+    exact_ingredient_form = ingredient,
+    interaction_mechanism = 'Concurrent magnesium can reduce levothyroxine absorption through complexing; evidence varies by formulation.',
+    severity_rationale = 'Reduced thyroid-medication absorption can affect treatment consistency, so timing should be reviewed.',
+    confidence = 'moderate',
+    user_qualification = 'The direct trial studied liquid magnesium citrate and aspartate. Follow the prescription label or pharmacist for the exact product and interval.',
+    rule_version = 'safety-data-v2',
+    provenance_status = 'reviewed'
+where lower(ingredient) in ('magnesium', 'magnesium (glycinate)');
+
+update public.rules
+set source_label = 'NIH Office of Dietary Supplements: Vitamin D Fact Sheet for Health Professionals',
+    source_url = 'https://ods.od.nih.gov/factsheets/VitaminD-HealthProfessional/',
+    source_type = 'government_reference',
+    last_reviewed_on = date '2026-08-15',
+    exact_ingredient_form = 'Vitamin D from all sources',
+    interaction_mechanism = 'Adult tolerable upper intake level; 1 mcg vitamin D equals 40 IU.',
+    severity_rationale = 'Amounts above the adult UL require review; clinician-directed treatment can use higher amounts with monitoring.',
+    confidence = 'high',
+    user_qualification = 'The UL is a review threshold, not an instruction to stop a clinician-directed regimen.',
+    rule_version = 'safety-data-v2',
+    provenance_status = 'reviewed'
+where upper(coalesce(rule_type, '')) = 'UL'
+  and lower(coalesce(entity_a_name, '')) = 'vitamin d3';
+
+update public.rules
+set source_label = 'FDA Synthroid prescribing information (2024)',
+    source_url = 'https://www.accessdata.fda.gov/drugsatfda_docs/label/2024/021402s038lbl.pdf',
+    source_type = 'prescription_label',
+    source_date = date '2024-06-01',
+    last_reviewed_on = date '2026-08-15',
+    exact_ingredient_form = 'Levothyroxine with calcium, iron, or identified magnesium-containing products',
+    interaction_mechanism = 'Some co-administered products reduce levothyroxine absorption.',
+    severity_rationale = 'Timing inconsistency can alter medication absorption and should be reviewed.',
+    confidence = 'high',
+    user_qualification = 'This rule does not apply to Vitamin D3 or probiotics. Use the prescription label or pharmacist instructions for the exact product.',
+    rule_version = 'safety-data-v2',
+    provenance_status = 'reviewed'
+where lower(coalesce(trigger_name, '')) = 'thyroid_med';


### PR DESCRIPTION
## What changed

- added typed evidence provenance to structured interaction and safety-rule records
- normalized comparable dose units, including the authoritative Vitamin D conversion of 1 mcg = 40 IU
- removed unsupported thyroid-spacing flags from plain Vitamin D3 and the Lactobacillus/Bifidobacterium probiotic blend
- retained a qualified magnesium timing review without inventing a spacing interval when none is recorded
- suppressed duplicate generic spacing findings when a specific interaction finding already exists
- propagated evidence, confidence, qualification, and clinician-directed instruction authority into Blueprint safety sections and Ask LVE360
- added deterministic PR111 regression coverage and safety-integrity documentation

## QA corrections after member testing

- routed named dose-threshold, thyroid-spacing, and interaction questions through deterministic safety evaluation instead of unconstrained model generation
- made dose comparisons available as structured data so 5,000 IU cannot be described as below a 4,000 IU threshold
- scoped answer validation to the Routine items named in the question
- prevented generic name matching such as "vitamin" from pulling unrelated regimen items into an answer
- added provenance for reviewed no-general-spacing findings, including Vitamin D and the recorded probiotic blend
- overlaid the latest Blueprint with the current deterministic safety evaluation so corrected rules replace stale false warnings without rewriting historical Blueprint versions
- changed member-facing terminology from "pharmacist" to "clinician or healthcare provider"; legacy stored values and language-recognition patterns remain compatible

## Why

The prior engine compared upper limits only when units were identical, silently skipped unsupported conversions, and trusted two incorrect thyroid-binding flags. Named current-Routine safety questions could also be sent to general AI generation without the corresponding structured safety result. This caused the impossible Vitamin D comparison, irrelevant magnesium framing, an unhelpful combined-question fallback, and stale Blueprint warnings shown during QA.

## Member impact

Safety findings now explain urgency, action, mechanism, evidence, confidence, uncertainty, and rule version. Current clinician- or healthcare-provider-directed regimens above a general threshold prompt confirmation and monitoring review; LVE360 does not tell the member to change the regimen from the app warning alone.

## Database migration

Applied successfully to the connected Supabase project and verified:

- legacy safety rows remain explicit as unreviewed/unknown
- audited Vitamin D, probiotic, magnesium, Vitamin D UL, and thyroid-medication rows are versioned as safety-data-v2
- the pre-existing update-trigger/schema mismatch was repaired by adding the expected updated_at columns
- no RLS policies or grants changed

## Validation

Passed locally:

- npm.cmd run typecheck
- npm.cmd run qa:safety-engine
- npm.cmd run qa:blueprint-safety
- npm.cmd run qa:routine
- npm.cmd run qa:pr91
- npm.cmd run qa:pr93
- npm.cmd run qa:pr105
- npm.cmd run qa:pr107
- npm.cmd run qa:pr108
- npm.cmd run qa:pr109
- npm.cmd run qa:pr110
- npm.cmd run qa:pr111

The local production build compiled successfully, then stopped during login-page prerender because this worktree does not contain the public Supabase build variables. GitHub/Vercel environment-backed checks provide the authoritative build result.