### PR TITLE
PR112: Recenter Today on one focused action

### DIFF
--- a/app/(app)/today/TodayClient.tsx
+++ b/app/(app)/today/TodayClient.tsx
@@ -49,14 +49,6 @@ export default function TodayClient({
           <>
             <ReminderArrivalFeedback deliveryId={reminderDeliveryId} />
 
-            <AiTodayBrief
-              date={checkinDate}
-              onPracticeCompleted={() => {
-                setFirstActionComplete(true);
-                setPracticeRefreshKey((value) => value + 1);
-              }}
-            />
-
             <TodayExperience
               key={`${experiment?.id ?? "none"}:${practiceRefreshKey}`}
               initialExperiment={experiment}
@@ -64,6 +56,14 @@ export default function TodayClient({
               experimentBlueprint={experimentBlueprint}
               initialCompletionDate={checkinDate}
               onCompletionStateChange={setFirstActionComplete}
+            />
+
+            <AiTodayBrief
+              date={checkinDate}
+              onPracticeCompleted={() => {
+                setFirstActionComplete(true);
+                setPracticeRefreshKey((value) => value + 1);
+              }}
             />
 
             <TodayRoutineAgenda />

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "qa:pr109": "node --experimental-strip-types src/_tests_/pr109IntentRouting.assert.ts && node src/_tests_/pr109Architecture.assert.mjs",
     "qa:pr110": "node --experimental-strip-types src/_tests_/pr110TaskSuccess.assert.ts && node src/_tests_/pr110Architecture.assert.mjs",
     "qa:pr111": "node --experimental-strip-types src/_tests_/pr111SafetyIntegrity.assert.ts && node src/_tests_/pr111Architecture.assert.mjs",
+    "qa:pr112": "node --experimental-strip-types src/_tests_/pr112TodaySurface.assert.ts && node src/_tests_/pr112Page.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr100TodayBrief.assert.ts
+++ b/src/_tests_/pr100TodayBrief.assert.ts
@@ -55,8 +55,15 @@ const safetyContext: TodayBriefContext = {
   ...active,
   blueprint: { ...active.blueprint!, safetyNeedsAttention: true },
 };
-assert.equal(shouldGenerateTodayBrief(safetyContext), false, "Safety review must remain deterministic.");
-assert.equal(deterministicTodayBrief(safetyContext).primaryAction, "open_blueprint");
+assert.equal(shouldGenerateTodayBrief(safetyContext), true, "A normal acknowledged-or-reviewable warning must not suppress the useful lifestyle brief.");
+assert.equal(deterministicTodayBrief(safetyContext).primaryAction, "mark_complete");
+
+const urgentSafetyContext: TodayBriefContext = {
+  ...safetyContext,
+  blueprint: { ...safetyContext.blueprint!, urgentSafetyInterruption: true },
+};
+assert.equal(shouldGenerateTodayBrief(urgentSafetyContext), false, "An unavailable safety evaluation must remain deterministic.");
+assert.equal(deterministicTodayBrief(urgentSafetyContext).primaryAction, "open_blueprint");
 
 const completeContext: TodayBriefContext = {
   ...active,

--- a/src/_tests_/pr112Page.assert.mjs
+++ b/src/_tests_/pr112Page.assert.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const client = readFileSync("app/(app)/today/TodayClient.tsx", "utf8");
+const today = readFileSync("src/components/dashboard/TodayExperience.tsx", "utf8");
+const surface = readFileSync("src/lib/todaySurface.ts", "utf8");
+const brief = readFileSync("src/lib/todayBrief.ts", "utf8");
+
+assert.ok(client.indexOf("<TodayExperience") < client.indexOf("<AiTodayBrief"), "The saved focused action must appear before supporting AI coaching.");
+assert.match(today, /deriveTodayBlueprintNotice/, "Today must derive one canonical Blueprint notice.");
+assert.equal((today.match(/<TodayBlueprintNoticeBanner/g) ?? []).length, 2, "One renderer may be placed by urgency, without rendering duplicate notices in the same state.");
+assert.doesNotMatch(today, /function CurrentBlueprintPanel/, "The large duplicated Blueprint summary must leave Today.");
+assert.match(today, /<details[\s\S]*Blueprint connection/, "Blueprint context must remain available as a collapsed secondary disclosure.");
+assert.doesNotMatch(today, /Your Blueprint changed after this practice was chosen/, "A second standalone Blueprint warning strip must not remain.");
+assert.doesNotMatch(today, /Your weekly review is ready\.<\/strong>/, "The focused-action card must not duplicate the AI weekly-review prompt.");
+assert.match(surface, /safety_status === "error"[\s\S]*!blueprint\.safety_acknowledged/, "Urgent safety interruption must be explicit and narrow.");
+assert.match(brief, /!context\.blueprint\?\.urgentSafetyInterruption/, "Normal stale state must not suppress the useful daily brief.");
+assert.doesNotMatch(brief, /&& !context\.blueprint\?\.needsRefresh/, "Blueprint maintenance must not block lifestyle coaching.");
+
+console.log("PR112 Today action hierarchy architecture checks passed.");

--- a/src/_tests_/pr112TodaySurface.assert.ts
+++ b/src/_tests_/pr112TodaySurface.assert.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+
+import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "../lib/blueprintContext.ts";
+import { deterministicTodayBrief, shouldGenerateTodayBrief, type TodayBriefContext } from "../lib/todayBrief.ts";
+import { deriveTodayBlueprintNotice, isUrgentBlueprintSafety } from "../lib/todaySurface.ts";
+
+const blueprint = (overrides: Partial<CurrentBlueprintContext> = {}): CurrentBlueprintContext => ({
+  stack_id: "22222222-2222-4222-8222-222222222222",
+  created_at: "2026-08-15T12:00:00.000Z",
+  safety_status: "safe",
+  safety_acknowledged: false,
+  needs_refresh: false,
+  priorities: [],
+  ...overrides,
+});
+
+const experimentBlueprint = (overrides: Partial<ExperimentBlueprintContext> = {}): ExperimentBlueprintContext => ({
+  source_stack_id: blueprint().stack_id,
+  source_action_id: "walk-after-lunch",
+  priority_label: "Take a short walk after lunch",
+  priority_category: "lifestyle",
+  priority_kind: "lifestyle",
+  blueprint_created_at: "2026-08-10T12:00:00.000Z",
+  is_current_blueprint: true,
+  needs_review: false,
+  ...overrides,
+});
+
+assert.equal(deriveTodayBlueprintNotice(blueprint(), experimentBlueprint()), null, "A current, reviewed state must not render a zero-value notice.");
+
+const staleNotice = deriveTodayBlueprintNotice(blueprint({ needs_refresh: true }), experimentBlueprint());
+assert.equal(staleNotice?.tone, "maintenance");
+assert.match(staleNotice?.detail ?? "", /focused lifestyle action is unchanged/i);
+
+const combinedNotice = deriveTodayBlueprintNotice(
+  blueprint({ needs_refresh: true, safety_status: "warning" }),
+  experimentBlueprint({ needs_review: true }),
+);
+assert.equal(combinedNotice?.tone, "maintenance", "Ordinary stale and warning states must collapse into one maintenance notice.");
+assert.match(combinedNotice?.detail ?? "", /saved health information/i);
+assert.match(combinedNotice?.detail ?? "", /earlier Blueprint/i);
+
+const unavailableSafety = blueprint({ safety_status: "error" });
+assert.equal(isUrgentBlueprintSafety(unavailableSafety), true, "Only an unacknowledged unavailable safety section interrupts the brief.");
+assert.equal(deriveTodayBlueprintNotice(unavailableSafety, experimentBlueprint())?.tone, "urgent");
+assert.equal(isUrgentBlueprintSafety(blueprint({ safety_status: "warning" })), false, "A reviewable warning is maintenance, not an urgent interruption.");
+assert.equal(isUrgentBlueprintSafety(blueprint({ safety_status: "error", safety_acknowledged: true })), false, "An acknowledged safety state must not keep interrupting Today.");
+
+const briefContext = (blueprintContext: TodayBriefContext["blueprint"]): TodayBriefContext => ({
+  localDate: "2026-08-15",
+  experiment: {
+    id: "11111111-1111-4111-8111-111111111111",
+    identity: "Someone who moves consistently",
+    actionLabel: "Walk for ten minutes after lunch",
+    cue: "finish lunch",
+    minimumVersion: "Walk for two minutes",
+    target: 4,
+    completed: 2,
+    completedToday: false,
+  },
+  blueprint: blueprintContext,
+  reviewDue: false,
+});
+
+const staleBrief = briefContext({
+  stackId: blueprint().stack_id,
+  needsRefresh: true,
+  safetyNeedsAttention: false,
+  urgentSafetyInterruption: false,
+});
+assert.equal(shouldGenerateTodayBrief(staleBrief), true, "Normal Blueprint maintenance must not suppress the daily lifestyle brief.");
+assert.equal(deterministicTodayBrief(staleBrief).primaryAction, "mark_complete");
+
+const urgentBrief = briefContext({
+  ...staleBrief.blueprint!,
+  urgentSafetyInterruption: true,
+});
+assert.equal(shouldGenerateTodayBrief(urgentBrief), false);
+assert.equal(deterministicTodayBrief(urgentBrief).primaryAction, "open_blueprint");
+
+console.log("PR112 Today notice and action-priority scenarios passed.");

--- a/src/_tests_/pr83Page.assert.mjs
+++ b/src/_tests_/pr83Page.assert.mjs
@@ -6,6 +6,7 @@ const today = read("app/(app)/routine/TodayDoses.tsx");
 const summary = read("src/components/dashboard/TodaysPlan.tsx");
 const workspace = read("app/(app)/blueprints/[stackId]/BlueprintWorkspaceClient.tsx");
 const context = read("src/components/dashboard/TodayExperience.tsx");
+const todaySurface = read("src/lib/todaySurface.ts");
 const migration = read("supabase/migrations/20260808212539_pr83_safety_acknowledgement.sql");
 
 assert.match(today, /groupByDaypart/);
@@ -14,8 +15,8 @@ assert.match(today, /onEditSchedule\(item\)/);
 assert.match(summary, /href="\/routine#routine-ideas"/);
 assert.match(summary, /href="\/routine#schedule-review"/);
 assert.match(workspace, /I have reviewed these safety notes/);
-assert.match(workspace, /id=\{isSafety \? "safety-notes"/);
-assert.match(context, /!blueprint\.safety_acknowledged/);
+assert.match(workspace, /const sectionId = isSafety[\s\S]*\? "safety-notes"/);
+assert.match(todaySurface, /!blueprint\.safety_acknowledged/);
 assert.match(migration, /safety_acknowledged_at timestamptz/);
 
 console.log("PR83 page assertions passed.");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -6,6 +6,7 @@ import {
   ArrowRight,
   Check,
   CheckCircle2,
+  ChevronDown,
   Circle,
   Goal,
   Loader2,
@@ -15,12 +16,12 @@ import {
 
 import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
 import { returnedAfterGap, weeklyMomentum, type CompletionKind, type DailyPracticeCompletion } from "@/lib/today";
-import { isReviewDue, reviewDueDate } from "@/lib/weeklyReview";
+import { reviewDueDate } from "@/lib/weeklyReview";
 import {
-  blueprintSafetyLabel,
   type CurrentBlueprintContext,
   type ExperimentBlueprintContext,
 } from "@/lib/blueprintContext";
+import { deriveTodayBlueprintNotice, type TodayBlueprintNotice } from "@/lib/todaySurface";
 
 type TodayResponse = {
   ok: boolean;
@@ -153,9 +154,9 @@ export default function TodayExperience({
   const progressPercent = Math.min(100, Math.round((completedCount / target) * 100));
   const momentum = weeklyMomentum(completedCount, target);
   const returnWin = !!localDate && returnedAfterGap(localDate, completions);
-  const reviewDue = !!localDate && isReviewDue(experiment.week_start, localDate);
   const weekEnded = !!localDate && localDate > reviewDueDate(experiment.week_start);
   const weekNotStarted = !!localDate && localDate < experiment.week_start;
+  const blueprintNotice = deriveTodayBlueprintNotice(blueprint, experimentBlueprint);
 
   return (
     <section id="focused-practice" className="overflow-hidden rounded-3xl border border-[#9DCFC3] bg-white shadow-sm" aria-labelledby="today-heading">
@@ -169,32 +170,7 @@ export default function TodayExperience({
         </div>
       </div>
 
-      {blueprint && (blueprint.needs_refresh || (blueprint.safety_status !== "safe" && !blueprint.safety_acknowledged)) ? (
-        <a href={`/blueprints/${blueprint.stack_id}#safety-notes`} className="flex items-start gap-3 border-b border-amber-200 bg-amber-50 px-6 py-4 text-amber-950 hover:bg-amber-100 sm:px-8">
-          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" />
-          <span className="text-sm leading-6">
-            <strong>{blueprintSafetyLabel(blueprint)}.</strong>{" "}
-            Open the exact current Blueprint before acting on safety-sensitive items.
-          </span>
-          <ArrowRight className="ml-auto mt-1 h-4 w-4 shrink-0" />
-        </a>
-      ) : null}
-
-      {experimentBlueprint?.needs_review ? (
-        <a href={`/blueprints/${blueprint?.stack_id ?? experimentBlueprint.source_stack_id}`} className="flex items-start gap-3 border-b border-violet-200 bg-violet-50 px-6 py-4 text-violet-950 hover:bg-violet-100 sm:px-8">
-          <RotateCcw className="mt-0.5 h-5 w-5 shrink-0 text-violet-700" />
-          <span className="text-sm leading-6"><strong>Your Blueprint changed after this practice was chosen.</strong> Review the current priorities. Your active practice has not been overwritten.</span>
-          <ArrowRight className="ml-auto mt-1 h-4 w-4 shrink-0" />
-        </a>
-      ) : null}
-
-      {reviewDue ? (
-        <a href={`/review?experiment=${encodeURIComponent(experiment.id)}`} className="flex items-start gap-3 border-b border-[#9DCFC3] bg-[#EAFBF8] px-6 py-4 text-[#041B2D] hover:bg-[#DDF7F1] sm:px-8">
-          <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#087F72]" />
-          <span className="text-sm leading-6"><strong>Your weekly review is ready.</strong> Notice what worked and shape your next focused week.</span>
-          <ArrowRight className="ml-auto mt-1 h-4 w-4 shrink-0" />
-        </a>
-      ) : null}
+      {blueprintNotice?.tone === "urgent" ? <TodayBlueprintNoticeBanner notice={blueprintNotice} /> : null}
 
       <div className="p-6 sm:p-8">
         {recordingPastDate ? (
@@ -202,7 +178,6 @@ export default function TodayExperience({
             <strong>Phone-free check-in:</strong> Record whether the practice happened on {formatCheckinDate(localDate)}. You did not need to reopen LVE360 after the habit.
           </div>
         ) : null}
-        {blueprint ? <CurrentBlueprintPanel blueprint={blueprint} experimentBlueprint={experimentBlueprint} /> : null}
         <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-2xl">
             <p className="flex items-center gap-2 text-sm font-semibold text-[#087F72]">
@@ -275,6 +250,8 @@ export default function TodayExperience({
           {error ? <p className="mt-3 text-sm font-medium text-rose-700">{error}</p> : null}
         </div>
 
+        {blueprintNotice?.tone === "maintenance" ? <TodayBlueprintNoticeBanner notice={blueprintNotice} /> : null}
+
         <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-5 sm:p-6" aria-live="polite">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
@@ -306,38 +283,55 @@ export default function TodayExperience({
           </div>
           {loadingState ? <p className="mt-3 text-xs text-slate-500">Loading this week's progress...</p> : null}
         </div>
+
+        {blueprint ? <BlueprintConnectionDetails blueprint={blueprint} experimentBlueprint={experimentBlueprint} /> : null}
       </div>
     </section>
   );
 }
 
-function CurrentBlueprintPanel({
+function TodayBlueprintNoticeBanner({ notice }: { notice: TodayBlueprintNotice }) {
+  const urgent = notice.tone === "urgent";
+  return (
+    <aside className={`${urgent ? "border-rose-200 bg-rose-50 text-rose-950" : "border-amber-200 bg-amber-50 text-amber-950"} ${urgent ? "border-b px-6 py-4 sm:px-8" : "mt-7 rounded-2xl border p-4 sm:p-5"}`} aria-label={urgent ? "Urgent Blueprint safety notice" : "Blueprint maintenance notice"}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className={`mt-0.5 h-5 w-5 shrink-0 ${urgent ? "text-rose-700" : "text-amber-700"}`} aria-hidden="true" />
+          <div>
+            <p className="font-bold">{notice.title}</p>
+            <p className="mt-1 text-sm leading-6 opacity-80">{notice.detail}</p>
+          </div>
+        </div>
+        <a href={notice.href} className={`inline-flex min-h-11 shrink-0 items-center justify-center rounded-xl border bg-white px-4 py-2 text-sm font-bold hover:bg-white/70 ${urgent ? "border-rose-300 text-rose-800" : "border-amber-300 text-amber-900"}`}>
+          {notice.actionLabel} <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+        </a>
+      </div>
+    </aside>
+  );
+}
+
+function BlueprintConnectionDetails({
   blueprint,
   experimentBlueprint,
 }: {
   blueprint: CurrentBlueprintContext;
   experimentBlueprint: ExperimentBlueprintContext | null;
 }) {
+  if (!experimentBlueprint?.priority_label && !blueprint.priorities.length) return null;
   return (
-    <aside className="mb-7 rounded-2xl border border-[#BCE3DA] bg-[#F4FAF8] p-4 sm:p-5" aria-label="Current Blueprint context">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">Current Blueprint</p>
-          <p className="mt-1 text-sm font-semibold text-[#041B2D]">Refreshed {formatBlueprintDate(blueprint.created_at)}</p>
-          <p className={`mt-1 text-sm ${blueprint.needs_refresh || (blueprint.safety_status !== "safe" && !blueprint.safety_acknowledged) ? "font-semibold text-amber-800" : "text-slate-600"}`}>
-            {blueprintSafetyLabel(blueprint)}
-          </p>
-        </div>
-        <a href={`/blueprints/${blueprint.stack_id}`} className="inline-flex min-h-11 items-center justify-center rounded-xl border border-[#9DCFC3] bg-white px-4 py-2 text-sm font-bold text-[#06695F] hover:bg-[#EAFBF8]">
-          Open Blueprint <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
-        </a>
-      </div>
+    <details className="mt-5 rounded-2xl border border-slate-200 bg-white">
+      <summary className="flex min-h-12 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-bold text-[#06695F] marker:content-none">
+        <span>Blueprint connection</span>
+        <ChevronDown className="h-4 w-4 shrink-0" aria-hidden="true" />
+      </summary>
+      <div className="border-t border-slate-100 px-4 py-4 text-sm text-slate-700">
       {experimentBlueprint?.priority_label ? (
-        <p className="mt-4 rounded-xl bg-white p-3 text-sm leading-6 text-slate-700">
+        <p className="rounded-xl bg-[#F4FAF8] p-3 leading-6">
           <strong className="text-[#041B2D]">This focused week came from:</strong> {experimentBlueprint.priority_label}
         </p>
       ) : null}
-      <div className="mt-4">
+      {experimentBlueprint?.needs_review ? <p className="mt-3 text-amber-900">Your active practice has not been overwritten.</p> : null}
+      {blueprint.priorities.length ? <div className="mt-4">
         <p className="text-xs font-bold uppercase tracking-[0.12em] text-slate-500">Current priorities</p>
         <ul className="mt-2 space-y-2 text-sm text-slate-700">
           {blueprint.priorities.slice(0, 3).map((priority) => (
@@ -353,8 +347,12 @@ function CurrentBlueprintPanel({
             </li>
           ))}
         </ul>
+      </div> : null}
+      <a href={`/blueprints/${blueprint.stack_id}`} className="mt-4 inline-flex min-h-11 items-center font-bold text-[#087F72] hover:underline">
+        Open current Blueprint <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+      </a>
       </div>
-    </aside>
+    </details>
   );
 }
 
@@ -363,10 +361,6 @@ function toLocalDate(date: Date): string {
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-}
-
-function formatBlueprintDate(value: string): string {
-  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
 }
 
 function formatCheckinDate(value: string): string {

--- a/src/lib/ai/todayBriefData.ts
+++ b/src/lib/ai/todayBriefData.ts
@@ -16,6 +16,7 @@ import {
   type TodayBriefContext,
 } from "@/lib/todayBrief";
 import { isReviewDue } from "@/lib/weeklyReview";
+import { isUrgentBlueprintSafety } from "@/lib/todaySurface";
 
 type TodayBriefRow = {
   id: string;
@@ -118,6 +119,7 @@ export async function buildTodayBriefContext(userId: string, localDate: string):
       stackId: blueprint.stack_id,
       needsRefresh: blueprint.needs_refresh,
       safetyNeedsAttention: blueprint.safety_status !== "safe" && !blueprint.safety_acknowledged,
+      urgentSafetyInterruption: isUrgentBlueprintSafety(blueprint),
     } : null,
     reviewDue: Boolean(experiment && isReviewDue(experiment.week_start, localDate)),
   };

--- a/src/lib/todayBrief.ts
+++ b/src/lib/todayBrief.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const TODAY_BRIEF_PROMPT_VERSION = "today-brief-v2";
+export const TODAY_BRIEF_PROMPT_VERSION = "today-brief-v3";
 
 export type TodayBriefPrimaryAction =
   | "mark_complete"
@@ -24,6 +24,7 @@ export type TodayBriefContext = {
     stackId: string;
     needsRefresh: boolean;
     safetyNeedsAttention: boolean;
+    urgentSafetyInterruption?: boolean;
   } | null;
   reviewDue: boolean;
 };
@@ -90,22 +91,19 @@ export function shouldGenerateTodayBrief(context: TodayBriefContext): boolean {
     context.experiment
     && !context.experiment.completedToday
     && !context.reviewDue
-    && !context.blueprint?.needsRefresh
-    && !context.blueprint?.safetyNeedsAttention,
+    && !context.blueprint?.urgentSafetyInterruption,
   );
 }
 
 export function deterministicTodayBrief(context: TodayBriefContext): TodayBriefContent {
-  if (context.blueprint?.needsRefresh || context.blueprint?.safetyNeedsAttention) {
+  if (context.blueprint?.urgentSafetyInterruption) {
     return {
-      noticed: context.blueprint.needsRefresh
-        ? "Your health information changed after this Blueprint was created."
-        : "Your current Blueprint has safety notes awaiting review.",
-      whyItMatters: "Review the current source before acting on health-sensitive guidance.",
-      nextAction: "Open your current Blueprint and review the highlighted changes or safety notes.",
-      minimumVersion: "Open the Blueprint and read the first highlighted item.",
+      noticed: "LVE360 could not confirm the current Blueprint safety section.",
+      whyItMatters: "Review the current source before using health-sensitive guidance.",
+      nextAction: "Open your current Blueprint and review the safety section.",
+      minimumVersion: "Open the Blueprint and read the first safety item.",
       primaryAction: "open_blueprint",
-      primaryHref: `/blueprints/${context.blueprint.stackId}`,
+      primaryHref: `/blueprints/${context.blueprint.stackId}#safety-notes`,
     };
   }
 

--- a/src/lib/todaySurface.ts
+++ b/src/lib/todaySurface.ts
@@ -1,0 +1,87 @@
+import type { CurrentBlueprintContext, ExperimentBlueprintContext } from "./blueprintContext.ts";
+
+export type TodayBlueprintNotice = {
+  tone: "maintenance" | "urgent";
+  title: string;
+  detail: string;
+  href: string;
+  actionLabel: string;
+};
+
+/**
+ * An ordinary stale Blueprint is maintenance, not an emergency. Today only
+ * treats a missing or unreadable safety section as an urgent interruption.
+ */
+export function isUrgentBlueprintSafety(blueprint: CurrentBlueprintContext | null): boolean {
+  return Boolean(
+    blueprint
+    && blueprint.safety_status === "error"
+    && !blueprint.safety_acknowledged,
+  );
+}
+
+export function deriveTodayBlueprintNotice(
+  blueprint: CurrentBlueprintContext | null,
+  experimentBlueprint: ExperimentBlueprintContext | null,
+): TodayBlueprintNotice | null {
+  if (!blueprint) return null;
+
+  if (isUrgentBlueprintSafety(blueprint)) {
+    return {
+      tone: "urgent",
+      title: "The current Blueprint safety review needs attention",
+      detail: "LVE360 could not confirm the current safety section. Review the Blueprint before using health-sensitive guidance. Your lifestyle practice remains available below.",
+      href: `/blueprints/${blueprint.stack_id}#safety-notes`,
+      actionLabel: "Review safety section",
+    };
+  }
+
+  const safetyWaiting = blueprint.safety_status === "warning" && !blueprint.safety_acknowledged;
+  const sourceChanged = Boolean(experimentBlueprint?.needs_review);
+
+  if (safetyWaiting) {
+    const additionalContext = [
+      blueprint.needs_refresh ? "Your saved health information also differs from this report." : null,
+      sourceChanged ? "This weekly practice came from an earlier Blueprint." : null,
+    ].filter(Boolean).join(" ");
+    return {
+      tone: "maintenance",
+      title: "Review your current Blueprint safety notes",
+      detail: `${additionalContext ? `${additionalContext} ` : ""}Your focused lifestyle action is unchanged.`,
+      href: `/blueprints/${blueprint.stack_id}#safety-notes`,
+      actionLabel: "Open Blueprint",
+    };
+  }
+
+  if (blueprint.needs_refresh && sourceChanged) {
+    return {
+      tone: "maintenance",
+      title: "Your Blueprint has updates to review",
+      detail: "Your saved health information changed, and this weekly practice came from an earlier Blueprint. Refresh when convenient. Your focused action is unchanged.",
+      href: `/blueprints/${blueprint.stack_id}`,
+      actionLabel: "Review updates",
+    };
+  }
+
+  if (blueprint.needs_refresh) {
+    return {
+      tone: "maintenance",
+      title: "Your saved changes are ready for Blueprint review",
+      detail: "Refresh the Blueprint when convenient. Today’s focused lifestyle action is unchanged.",
+      href: `/blueprints/${blueprint.stack_id}`,
+      actionLabel: "Review changes",
+    };
+  }
+
+  if (sourceChanged) {
+    return {
+      tone: "maintenance",
+      title: "This practice came from an earlier Blueprint",
+      detail: "Review the current priorities when convenient. Your active practice has not been overwritten.",
+      href: `/blueprints/${blueprint.stack_id}`,
+      actionLabel: "Compare priorities",
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Purpose

Restore Today as a rewarding daily action surface instead of a maintenance-warning surface.

## What changed

- moved the saved focused weekly action ahead of the supporting AI brief
- replaced separate stale Blueprint, safety, and source-change strips with one canonical derived notice
- defined an urgent safety interruption narrowly as an unacknowledged missing or unreadable Blueprint safety section
- kept ordinary Blueprint staleness and reviewable safety notes as secondary maintenance that does not suppress the lifestyle brief
- replaced the large duplicated Blueprint panel with a collapsed Blueprint connection disclosure
- removed the duplicate weekly-review strip from the focused-action card
- bumped the Today Brief prompt version so previously cached maintenance-first briefs do not survive the behavior change
- added PR112 regression tests and updated affected historical assertions

## Member impact

Members see the action they chose first. Routine and Blueprint maintenance remain available, but ordinary saved changes no longer take over Today or replace the daily lifestyle prompt. A truly unavailable safety review is clearly distinguished and links directly to the safety section.

## Files changed

- Today page composition and focused-action UI
- deterministic Today notice policy
- Today Brief context and fallback behavior
- PR112 and affected regression tests
- package QA command

## Verification

Passed locally:

- npm.cmd run typecheck
- npm.cmd run qa:pr74
- npm.cmd run qa:pr83
- npm.cmd run qa:pr85
- npm.cmd run qa:pr85-1
- npm.cmd run qa:pr94
- npm.cmd run qa:pr96
- npm.cmd run qa:pr97
- npm.cmd run qa:pr100
- npm.cmd run qa:pr101
- npm.cmd run qa:pr112
- git diff --check

## Not verified locally

The optimized build compiled successfully, then stopped while prerendering /login because this worktree does not contain the required public Supabase variables. The local environment audit likewise reports launch variables as absent. GitHub CI and Vercel Preview are the authoritative environment-backed checks.

## Risks and rollback

- no database migration, RLS change, environment variable, payment, or medication-management change
- ordinary safety warnings still link to the exact current Blueprint and remain visible as one compact notice
- urgent safety state is limited to safety_status=error with no acknowledgement
- rollback is the single PR112 commit; Today Brief v2 rows remain intact and harmless because v3 uses a new prompt version