### PR TITLE
PR113 — Connect goals, Blueprint priorities, and weekly practices

### DIFF
--- a/app/(app)/today/TodayClient.tsx
+++ b/app/(app)/today/TodayClient.tsx
@@ -10,11 +10,13 @@ import type { PremiumActivationProgress } from "@/lib/premiumActivation";
 import PremiumActivationChecklist from "@/components/activation/PremiumActivationChecklist";
 import AiTodayBrief from "@/components/dashboard/AiTodayBrief";
 import ReminderArrivalFeedback from "@/components/dashboard/ReminderArrivalFeedback";
+import type { PracticeConnectionContext } from "@/lib/practiceConnection";
 
 export default function TodayClient({
   experiment,
   blueprint,
   experimentBlueprint,
+  practiceConnection,
   checkinDate,
   reminderDeliveryId,
   activationProgress,
@@ -22,6 +24,7 @@ export default function TodayClient({
   experiment: WeeklyExperiment | null;
   blueprint: CurrentBlueprintContext | null;
   experimentBlueprint: ExperimentBlueprintContext | null;
+  practiceConnection: PracticeConnectionContext | null;
   checkinDate: string | null;
   reminderDeliveryId: string | null;
   activationProgress: PremiumActivationProgress;
@@ -54,6 +57,7 @@ export default function TodayClient({
               initialExperiment={experiment}
               blueprint={blueprint}
               experimentBlueprint={experimentBlueprint}
+              practiceConnection={practiceConnection}
               initialCompletionDate={checkinDate}
               onCompletionStateChange={setFirstActionComplete}
             />

--- a/app/(app)/today/page.tsx
+++ b/app/(app)/today/page.tsx
@@ -8,6 +8,7 @@ import type { WeeklyExperiment } from "@/lib/activation";
 import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
 import { parseLocalDate } from "@/lib/today";
 import { getPremiumActivationProgress } from "@/lib/premiumActivation";
+import { practiceGoalOptions, resolvePracticeConnection, type PracticeGoalRow } from "@/lib/practiceConnection";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -64,6 +65,10 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
   const experimentBlueprints = activeExperiment
     ? await getExperimentBlueprintContexts(user.id, [activeExperiment], blueprint)
     : {};
+  const experimentBlueprint = activeExperiment ? experimentBlueprints[activeExperiment.id] ?? null : null;
+  const practiceConnection = activeExperiment
+    ? resolvePracticeConnection(activeExperiment, practiceGoalOptions((goals as PracticeGoalRow | null) ?? null), experimentBlueprint)
+    : null;
 
   const targetWeight = goals?.target_weight ?? null;
   const targetSleep = goals?.target_sleep ?? null;
@@ -74,7 +79,8 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
       <TodayClient
         experiment={activeExperiment}
         blueprint={blueprint}
-        experimentBlueprint={activeExperiment ? experimentBlueprints[activeExperiment.id] ?? null : null}
+        experimentBlueprint={experimentBlueprint}
+        practiceConnection={practiceConnection}
         checkinDate={checkinDate}
         reminderDeliveryId={unratedReminderDeliveryId}
         activationProgress={activationProgress}

--- a/app/api/activation/route.ts
+++ b/app/api/activation/route.ts
@@ -15,6 +15,12 @@ import { isHour, isIanaTimeZone } from "@/lib/accountSettings";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
 import { isQuietHour, isReminderTiming } from "@/lib/reminderSchedule";
+import {
+  connectionType,
+  practiceGoalOptions,
+  type PracticeGoalOption,
+  type PracticeGoalRow,
+} from "@/lib/practiceConnection";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -32,6 +38,7 @@ type ActivationBody = {
   reminder_hour?: unknown;
   timezone?: unknown;
   cue_hour?: unknown;
+  goal_key?: unknown;
 };
 
 function identityFromCategory(category: string): IdentityDirection {
@@ -79,6 +86,7 @@ async function createDraft(req: NextRequest, userId: string): Promise<WeeklyExpe
     user_id: userId,
     source_stack_id: hasSpecificAction ? handoff?.pointer.stackId ?? null : null,
     source_action_id: hasSpecificAction ? handoff?.pointer.actionId ?? null : null,
+    connection_type: hasSpecificAction ? "blueprint" : "independent",
     identity_direction: selected ? identityFromCategory(selected.category) : null,
     action_label: hasSpecificAction ? selected?.label ?? null : null,
     onboarding_step: 0,
@@ -105,6 +113,17 @@ async function createDraft(req: NextRequest, userId: string): Promise<WeeklyExpe
   return data as WeeklyExperiment;
 }
 
+async function loadGoalOptions(userId: string): Promise<{ row: PracticeGoalRow | null; options: PracticeGoalOption[] }> {
+  const { data, error } = await getSupabaseAdmin()
+    .from("goals")
+    .select("id,goals,custom_goal,target_weight,target_sleep,target_energy")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw error;
+  const row = (data as PracticeGoalRow | null) ?? null;
+  return { row, options: practiceGoalOptions(row) };
+}
+
 async function getOrCreateExperiment(req: NextRequest, userId: string): Promise<WeeklyExperiment> {
   const current = await currentExperiment(userId);
   if (current) return current;
@@ -125,13 +144,14 @@ export async function GET(req: NextRequest) {
   try {
     const auth = await requirePaidUser();
     if (auth.error || !auth.user) return responseForAuthError(auth.error ?? "unauthorized");
-    const [experiment, { data: preferences, error: preferencesError }] = await Promise.all([
+    const [experiment, { data: preferences, error: preferencesError }, goals] = await Promise.all([
       getOrCreateExperiment(req, auth.user.id),
       getSupabaseAdmin()
         .from("user_preferences")
         .select("timezone, quiet_start_hour, quiet_end_hour")
         .eq("user_id", auth.user.id)
         .maybeSingle(),
+      loadGoalOptions(auth.user.id),
     ]);
     if (preferencesError) throw preferencesError;
     return NextResponse.json({
@@ -142,6 +162,7 @@ export async function GET(req: NextRequest) {
         quiet_start_hour: preferences?.quiet_start_hour ?? 21,
         quiet_end_hour: preferences?.quiet_end_hour ?? 7,
       },
+      goal_options: goals.options,
     });
   } catch (error) {
     console.error("[activation] load failed", error);
@@ -182,10 +203,22 @@ export async function PUT(req: NextRequest) {
         return NextResponse.json({ ok: false, error: "choose_safe_lifestyle_action" }, { status: 400 });
       }
       changes.action_label = action;
-      if (action !== experiment.action_label) {
+      const actionChanged = action !== experiment.action_label;
+      const keepsBlueprint = !actionChanged && Boolean(experiment.source_stack_id && experiment.source_action_id);
+      if (actionChanged) {
         changes.source_stack_id = null;
         changes.source_action_id = null;
       }
+      const goals = await loadGoalOptions(auth.user.id);
+      const goalKey = typeof body?.goal_key === "string" ? cleanText(body.goal_key, 120) : null;
+      const selectedGoal = goalKey ? goals.options.find((option) => option.key === goalKey) ?? null : null;
+      if (goalKey && (!goals.row || !selectedGoal)) {
+        return NextResponse.json({ ok: false, error: "choose_current_goal" }, { status: 400 });
+      }
+      changes.goal_id = selectedGoal ? goals.row?.id ?? null : null;
+      changes.goal_key = selectedGoal?.key ?? null;
+      changes.goal_label_snapshot = selectedGoal?.label ?? null;
+      changes.connection_type = connectionType(Boolean(selectedGoal), keepsBlueprint);
     }
 
     if (step === 3) {

--- a/app/api/journey/route.ts
+++ b/app/api/journey/route.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/journey";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
+import { practiceGoalOptions, resolvePracticeConnection, type PracticeGoalRow } from "@/lib/practiceConnection";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -44,10 +45,10 @@ export async function GET() {
 
     const admin = getSupabaseAdmin();
     const blueprintPromise = getCurrentBlueprintContext(auth.user.id);
-    const [{ data: experiments, error: experimentError }, { data: reviews, error: reviewError }, { data: checkIns, error: checkInError }, { data: syntheses, error: synthesisError }] = await Promise.all([
+    const [{ data: experiments, error: experimentError }, { data: reviews, error: reviewError }, { data: checkIns, error: checkInError }, { data: syntheses, error: synthesisError }, { data: goals, error: goalsError }] = await Promise.all([
       admin
         .from("weekly_experiments")
-        .select("id, source_stack_id, source_action_id, identity_direction, action_label, cue, frequency_per_week, minimum_version, status, week_start, activated_at, completed_at")
+        .select("id, source_stack_id, source_action_id, connection_type, goal_id, goal_key, goal_label_snapshot, identity_direction, action_label, cue, frequency_per_week, minimum_version, status, week_start, activated_at, completed_at")
         .eq("user_id", auth.user.id)
         .order("week_start", { ascending: false })
         .limit(52),
@@ -70,9 +71,10 @@ export async function GET() {
         .in("generation_status", ["succeeded", "failed", "skipped"])
         .order("created_at", { ascending: false })
         .limit(52),
+      admin.from("goals").select("id,goals,custom_goal,target_weight,target_sleep,target_energy").eq("user_id", auth.user.id).maybeSingle(),
     ]);
-    if (experimentError || reviewError || checkInError || synthesisError) {
-      throw experimentError ?? reviewError ?? checkInError ?? synthesisError;
+    if (experimentError || reviewError || checkInError || synthesisError || goalsError) {
+      throw experimentError ?? reviewError ?? checkInError ?? synthesisError ?? goalsError;
     }
 
     const experimentRows = (experiments ?? []) as JourneyExperiment[];
@@ -95,6 +97,11 @@ export async function GET() {
       experimentRows,
       blueprint,
     );
+    const goalOptions = practiceGoalOptions((goals as PracticeGoalRow | null) ?? null);
+    const practiceConnections = Object.fromEntries(experimentRows.map((experiment) => [
+      experiment.id,
+      resolvePracticeConnection(experiment, goalOptions, experimentBlueprints[experiment.id] ?? null),
+    ]));
 
     return NextResponse.json({
       ok: true,
@@ -105,6 +112,7 @@ export async function GET() {
       syntheses: (syntheses ?? []) as JourneySynthesis[],
       blueprint,
       experiment_blueprints: experimentBlueprints,
+      practice_connections: practiceConnections,
     });
   } catch (error) {
     console.error("[journey] load failed", error);

--- a/app/api/weekly-review/route.ts
+++ b/app/api/weekly-review/route.ts
@@ -7,6 +7,8 @@ import { isReviewDecision, isReviewDue, validateNextPlan, type NextWeekPlan } fr
 import { synthesisResponseState, type WeeklySynthesisContent } from "@/lib/weeklySynthesis";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { recordProductEventSafely } from "@/lib/productAnalytics";
+import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
+import { practiceGoalOptions, resolvePracticeConnection, type PracticeGoalRow } from "@/lib/practiceConnection";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -60,7 +62,18 @@ export async function GET(req: NextRequest) {
     if (!isReviewDue(experiment.week_start, todayUtc())) {
       return NextResponse.json({ ok: false, error: "review_not_due" }, { status: 409 });
     }
-    const completed = await countCompletions(auth.user.id, experiment);
+    const [completed, blueprint, { data: goals, error: goalsError }] = await Promise.all([
+      countCompletions(auth.user.id, experiment),
+      getCurrentBlueprintContext(auth.user.id),
+      getSupabaseAdmin().from("goals").select("id,goals,custom_goal,target_weight,target_sleep,target_energy").eq("user_id", auth.user.id).maybeSingle(),
+    ]);
+    if (goalsError) throw goalsError;
+    const blueprintContexts = await getExperimentBlueprintContexts(auth.user.id, [experiment], blueprint);
+    const practiceConnection = resolvePracticeConnection(
+      experiment,
+      practiceGoalOptions((goals as PracticeGoalRow | null) ?? null),
+      blueprintContexts[experiment.id] ?? null,
+    );
     const admin = getSupabaseAdmin();
     const { error } = await admin.from("weekly_experiment_reviews").upsert({
       user_id: auth.user.id,
@@ -78,7 +91,7 @@ export async function GET(req: NextRequest) {
       experiment_id: experiment.id,
       event_key: `review:opened:${experiment.id}`,
     });
-    return NextResponse.json({ ok: true, experiment, completed, target: experiment.frequency_per_week ?? 1 });
+    return NextResponse.json({ ok: true, experiment, completed, target: experiment.frequency_per_week ?? 1, practice_connection: practiceConnection });
   } catch (error) {
     console.error("[weekly-review] load failed", error);
     return NextResponse.json({ ok: false, error: "review_unavailable" }, { status: 500 });

--- a/app/onboarding/OnboardingHandoffClient.tsx
+++ b/app/onboarding/OnboardingHandoffClient.tsx
@@ -13,6 +13,7 @@ import {
   type WeeklyExperiment,
 } from "@/lib/activation";
 import { isQuietHour, type ReminderTiming } from "@/lib/reminderSchedule";
+import type { PracticeGoalOption } from "@/lib/practiceConnection";
 
 type FormState = {
   identity_direction: IdentityDirection | null;
@@ -24,6 +25,7 @@ type FormState = {
   reminder_timing: ReminderTiming;
   reminder_hour: number;
   timezone: string;
+  goal_key: string | null;
 };
 
 type ReminderContext = {
@@ -42,6 +44,7 @@ const EMPTY_FORM: FormState = {
   reminder_timing: "at_cue",
   reminder_hour: 18,
   timezone: "UTC",
+  goal_key: null,
 };
 
 export default function OnboardingHandoffClient() {
@@ -56,6 +59,7 @@ export default function OnboardingHandoffClient() {
     quiet_start_hour: 21,
     quiet_end_hour: 7,
   });
+  const [goalOptions, setGoalOptions] = useState<PracticeGoalOption[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,14 +67,15 @@ export default function OnboardingHandoffClient() {
       .then(async (response) => {
         const json = await response.json().catch(() => null);
         if (!response.ok || !json?.experiment) throw new Error("We could not load your weekly setup.");
-        return json as { experiment: WeeklyExperiment; reminder_context?: ReminderContext };
+        return json as { experiment: WeeklyExperiment; reminder_context?: ReminderContext; goal_options?: PracticeGoalOption[] };
       })
-      .then(({ experiment: loaded, reminder_context }) => {
+      .then(({ experiment: loaded, reminder_context, goal_options }) => {
         if (cancelled) return;
         setExperiment(loaded);
         const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         const context = reminder_context ?? { timezone: detectedTimezone || "UTC", quiet_start_hour: 21, quiet_end_hour: 7 };
         setReminderContext(context);
+        setGoalOptions(goal_options ?? []);
         setForm({ ...formFromExperiment(loaded), timezone: context.timezone || detectedTimezone || "UTC" });
         setStep(nextOnboardingStep(loaded));
       })
@@ -130,7 +135,7 @@ export default function OnboardingHandoffClient() {
       </div>
 
       {step === 1 && <IdentityStep value={form.identity_direction} onChange={(value) => setForm({ ...form, identity_direction: value })} />}
-      {step === 2 && <ActionStep form={form} starterActions={starterActions} fromBlueprint={!!experiment.source_action_id} onChange={(action_label) => setForm({ ...form, action_label })} />}
+      {step === 2 && <ActionStep form={form} starterActions={starterActions} goalOptions={goalOptions} fromBlueprint={!!experiment.source_action_id && form.action_label === experiment.action_label} onChange={(changes) => setForm({ ...form, ...changes })} />}
       {step === 3 && <CueStep form={form} onChange={(changes) => setForm({ ...form, ...changes })} />}
       {step === 4 && <MinimumStep value={form.minimum_version} action={form.action_label} onChange={(minimum_version) => setForm({ ...form, minimum_version })} />}
       {step === 5 && (
@@ -144,7 +149,7 @@ export default function OnboardingHandoffClient() {
           onChange={(changes) => setForm({ ...form, ...changes })}
         />
       )}
-      {step === 6 && <ConfirmationStep form={form} active={active} onEditPlan={() => setStep(1)} onEditReminders={() => setStep(5)} />}
+      {step === 6 && <ConfirmationStep form={form} active={active} goalOptions={goalOptions} fromBlueprint={!!experiment.source_action_id} onEditPlan={() => setStep(1)} onEditReminders={() => setStep(5)} />}
 
       {error && <p className="mt-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">{error}</p>}
 
@@ -179,8 +184,12 @@ function IdentityStep({ value, onChange }: { value: IdentityDirection | null; on
   return <section><Sparkles className="h-8 w-8 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">Who are you becoming?</h1><p className="mt-3 leading-7 text-slate-600">Choose the identity you want this week&apos;s practice to reinforce.</p><div className="mt-6 grid gap-3 sm:grid-cols-2">{IDENTITY_OPTIONS.map((option) => <button key={option.value} type="button" onClick={() => onChange(option.value)} aria-pressed={value === option.value} className={`flex min-h-16 items-center justify-between rounded-2xl border px-4 py-3 text-left font-semibold transition ${value === option.value ? "border-[#08A88A] bg-[#EAFBF8] text-[#041B2D] ring-2 ring-[#08A88A]/20" : "border-slate-200 text-slate-700 hover:border-[#9DCFC3]"}`}><span>{option.label}</span>{value === option.value ? <Check className="h-5 w-5 text-[#087F72]" /> : null}</button>)}</div></section>;
 }
 
-function ActionStep({ form, starterActions, fromBlueprint, onChange }: { form: FormState; starterActions: string[]; fromBlueprint: boolean; onChange: (value: string) => void }) {
-  return <section><h1 className="text-3xl font-extrabold tracking-tight text-[#041B2D]">Choose one practice for this week</h1><p className="mt-3 leading-7 text-slate-600">Small enough to repeat. Specific enough to know when you did it.</p>{fromBlueprint && form.action_label ? <div className="mt-6 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-4"><p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">Selected from your Blueprint</p><p className="mt-2 font-semibold text-[#041B2D]">{form.action_label}</p></div> : null}<div className="mt-5 grid gap-3">{starterActions.map((action) => <button key={action} type="button" onClick={() => onChange(action)} aria-pressed={form.action_label === action} className={`flex items-center justify-between rounded-2xl border p-4 text-left font-semibold ${form.action_label === action ? "border-[#08A88A] bg-[#EAFBF8]" : "border-slate-200 hover:border-[#9DCFC3]"}`}><span>{action}</span>{form.action_label === action ? <Check className="h-5 w-5 text-[#087F72]" /> : null}</button>)}</div><label className="mt-5 block text-sm font-bold text-[#041B2D]" htmlFor="weekly-action">Or write your own lifestyle practice</label><textarea id="weekly-action" rows={3} maxLength={240} value={form.action_label} onChange={(event) => onChange(event.target.value)} placeholder="Take a 10-minute walk after lunch" className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3 outline-none focus:border-[#08A88A] focus:ring-2 focus:ring-[#08A88A]/20" /></section>;
+function ActionStep({ form, starterActions, goalOptions, fromBlueprint, onChange }: { form: FormState; starterActions: string[]; goalOptions: PracticeGoalOption[]; fromBlueprint: boolean; onChange: (changes: Partial<FormState>) => void }) {
+  return <section><h1 className="text-3xl font-extrabold tracking-tight text-[#041B2D]">Choose one practice for this week</h1><p className="mt-3 leading-7 text-slate-600">Small enough to repeat. Specific enough to know when you did it.</p>{fromBlueprint && form.action_label ? <div className="mt-6 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-4"><p className="text-xs font-bold uppercase tracking-[0.14em] text-[#087F72]">Selected from your Blueprint</p><p className="mt-2 font-semibold text-[#041B2D]">{form.action_label}</p></div> : null}<div className="mt-5 grid gap-3">{starterActions.map((action) => <button key={action} type="button" onClick={() => onChange({ action_label: action })} aria-pressed={form.action_label === action} className={`flex items-center justify-between rounded-2xl border p-4 text-left font-semibold ${form.action_label === action ? "border-[#08A88A] bg-[#EAFBF8]" : "border-slate-200 hover:border-[#9DCFC3]"}`}><span>{action}</span>{form.action_label === action ? <Check className="h-5 w-5 text-[#087F72]" /> : null}</button>)}</div><label className="mt-5 block text-sm font-bold text-[#041B2D]" htmlFor="weekly-action">Or write your own lifestyle practice</label><textarea id="weekly-action" rows={3} maxLength={240} value={form.action_label} onChange={(event) => onChange({ action_label: event.target.value })} placeholder="Take a 10-minute walk after lunch" className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3 outline-none focus:border-[#08A88A] focus:ring-2 focus:ring-[#08A88A]/20" /><fieldset className="mt-7 border-t border-slate-200 pt-6"><legend className="text-lg font-bold text-[#041B2D]">Why does this practice matter this week?</legend><p className="mt-2 text-sm leading-6 text-slate-600">Choose a saved goal when there is a real connection. Otherwise, keep it as an independent choice.</p><div className="mt-4 grid gap-3"><ConnectionChoice selected={form.goal_key === null} title="Independent choice for this week" onClick={() => onChange({ goal_key: null })} />{goalOptions.map((goal) => <ConnectionChoice key={goal.key} selected={form.goal_key === goal.key} title={goal.label} eyebrow="Supports saved goal" onClick={() => onChange({ goal_key: goal.key })} />)}</div>{!goalOptions.length ? <p className="mt-3 rounded-xl bg-slate-50 p-3 text-sm text-slate-600">No saved goals are available yet. This practice will remain an independent choice.</p> : null}</fieldset></section>;
+}
+
+function ConnectionChoice({ selected, title, eyebrow, onClick }: { selected: boolean; title: string; eyebrow?: string; onClick: () => void }) {
+  return <button type="button" onClick={onClick} aria-pressed={selected} className={`flex items-center justify-between rounded-2xl border p-4 text-left ${selected ? "border-[#08A88A] bg-[#EAFBF8]" : "border-slate-200 hover:border-[#9DCFC3]"}`}><span>{eyebrow ? <span className="block text-xs font-bold uppercase tracking-[0.12em] text-[#087F72]">{eyebrow}</span> : null}<span className={`${eyebrow ? "mt-1 " : ""}block font-semibold text-[#041B2D]`}>{title}</span></span>{selected ? <Check className="h-5 w-5 shrink-0 text-[#087F72]" /> : null}</button>;
 }
 
 function CueStep({ form, onChange }: { form: FormState; onChange: (changes: Partial<FormState>) => void }) {
@@ -251,8 +260,10 @@ function ReminderStep({
   );
 }
 
-function ConfirmationStep({ form, active, onEditPlan, onEditReminders }: { form: FormState; active: boolean; onEditPlan: () => void; onEditReminders: () => void }) {
-  return <section><CheckCircle2 className="h-10 w-10 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">{active ? "Your week is active" : "Your first week is ready"}</h1><p className="mt-3 leading-7 text-slate-600">Use this plan while it fits your life. You can change it when your schedule or priorities change.</p><div className="mt-6 space-y-4 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5"><Summary label="This week's direction" value={identityLabel(form.identity_direction)} /><Summary label="This week I will" value={form.action_label} /><Summary label="My cue" value={`After I ${form.cue}`} /><Summary label="Target" value={`${form.frequency_per_week} ${form.frequency_per_week === 1 ? "day" : "days"} this week`} /><Summary label="On a hard day" value={form.minimum_version} /><Summary label="Reminder plan" value={reminderSummary(form)} /></div>{active ? <div className="mt-5 flex flex-wrap gap-3"><button type="button" onClick={onEditPlan} className="min-h-11 rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F]">Edit weekly plan</button><button type="button" onClick={onEditReminders} className="min-h-11 rounded-xl border border-[#9DCFC3] px-4 py-2 font-bold text-[#087F72] hover:bg-[#EAFBF8]">Change reminder plan</button></div> : null}</section>;
+function ConfirmationStep({ form, active, goalOptions, fromBlueprint, onEditPlan, onEditReminders }: { form: FormState; active: boolean; goalOptions: PracticeGoalOption[]; fromBlueprint: boolean; onEditPlan: () => void; onEditReminders: () => void }) {
+  const goal = goalOptions.find((option) => option.key === form.goal_key) ?? null;
+  const connection = [goal ? `Supports saved goal: ${goal.label}` : null, fromBlueprint ? "Supports a selected Blueprint priority" : null].filter(Boolean).join(" · ") || "Independently chosen for this week";
+  return <section><CheckCircle2 className="h-10 w-10 text-[#08A88A]" /><h1 className="mt-4 text-3xl font-extrabold tracking-tight text-[#041B2D]">{active ? "Your week is active" : "Your first week is ready"}</h1><p className="mt-3 leading-7 text-slate-600">Use this plan while it fits your life. You can change it when your schedule or priorities change.</p><div className="mt-6 space-y-4 rounded-2xl border border-[#9DCFC3] bg-[#EAFBF8] p-5"><Summary label="This week's direction" value={identityLabel(form.identity_direction)} /><Summary label="This week I will" value={form.action_label} /><Summary label="Why it matters" value={connection} /><Summary label="My cue" value={`After I ${form.cue}`} /><Summary label="Target" value={`${form.frequency_per_week} ${form.frequency_per_week === 1 ? "day" : "days"} this week`} /><Summary label="On a hard day" value={form.minimum_version} /><Summary label="Reminder plan" value={reminderSummary(form)} /></div>{active ? <div className="mt-5 flex flex-wrap gap-3"><button type="button" onClick={onEditPlan} className="min-h-11 rounded-xl bg-[#087F72] px-4 py-2 font-bold text-white hover:bg-[#06695F]">Edit weekly plan</button><button type="button" onClick={onEditReminders} className="min-h-11 rounded-xl border border-[#9DCFC3] px-4 py-2 font-bold text-[#087F72] hover:bg-[#EAFBF8]">Change reminder plan</button></div> : null}</section>;
 }
 
 function Summary({ label, value }: { label: string; value: string }) {
@@ -270,12 +281,13 @@ function formFromExperiment(experiment: WeeklyExperiment): FormState {
     reminder_timing: experiment.reminder_timing ?? "account_default",
     reminder_hour: experiment.reminder_hour ?? 18,
     timezone: "UTC",
+    goal_key: experiment.goal_key ?? null,
   };
 }
 
 function payloadForStep(step: number, form: FormState) {
   if (step === 1) return { step, identity_direction: form.identity_direction };
-  if (step === 2) return { step, action_label: form.action_label };
+  if (step === 2) return { step, action_label: form.action_label, goal_key: form.goal_key };
   if (step === 3) return { step, cue: form.cue, frequency_per_week: form.frequency_per_week };
   if (step === 4) return { step, minimum_version: form.minimum_version };
   if (step === 5) return {
@@ -291,6 +303,7 @@ function payloadForStep(step: number, form: FormState) {
 function errorMessage(code: string | undefined) {
   if (code === "choose_identity") return "Choose the identity you want to reinforce.";
   if (code === "choose_safe_lifestyle_action") return "Choose a lifestyle action. Supplement and medication changes stay in your Blueprint for professional review.";
+  if (code === "choose_current_goal") return "That saved goal is no longer available. Choose another goal or keep this as an independent weekly choice.";
   if (code === "add_cue_and_frequency") return "Add a clear cue and choose how many days you want to practice.";
   if (code === "add_safe_minimum_version") return "Add a small lifestyle version that can count on a hard day.";
   if (code === "choose_reminder_timing") return "Choose when reminder support would be useful for this practice.";

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "qa:pr110": "node --experimental-strip-types src/_tests_/pr110TaskSuccess.assert.ts && node src/_tests_/pr110Architecture.assert.mjs",
     "qa:pr111": "node --experimental-strip-types src/_tests_/pr111SafetyIntegrity.assert.ts && node src/_tests_/pr111Architecture.assert.mjs",
     "qa:pr112": "node --experimental-strip-types src/_tests_/pr112TodaySurface.assert.ts && node src/_tests_/pr112Page.assert.mjs",
+    "qa:pr113": "node --experimental-strip-types src/_tests_/pr113PracticeConnection.assert.ts && node src/_tests_/pr113Architecture.assert.mjs",
     "qa:blueprint-safety": "node --experimental-strip-types src/_tests_/blueprintSafetyStatus.assert.ts",
     "qa:safety-engine": "node --experimental-strip-types src/_tests_/safetyEngine.assert.ts",
     "qa:all": "npm run qa:env && npm run qa:build"

--- a/src/_tests_/pr113Architecture.assert.mjs
+++ b/src/_tests_/pr113Architecture.assert.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(path, "utf8");
+const migration = read("supabase/migrations/20260816000245_pr113_practice_connections.sql");
+const activation = read("app/api/activation/route.ts");
+const onboarding = read("app/onboarding/OnboardingHandoffClient.tsx");
+const today = read("src/components/dashboard/TodayExperience.tsx");
+const journey = read("src/components/journey/JourneyDashboard.tsx");
+const review = read("src/components/review/WeeklyReviewClient.tsx");
+const brief = read("src/lib/ai/todayBriefData.ts");
+const member = read("src/lib/memberContext.ts");
+
+for (const column of ["connection_type", "goal_id", "goal_key", "goal_label_snapshot"]) {
+  assert.match(migration, new RegExp(`add column ${column}`), `Migration must add ${column}.`);
+}
+assert.match(migration, /on delete set null/i, "Deleting a saved goal must preserve the weekly record through its snapshot.");
+assert.match(migration, /preserves_practice.*keep.*shrink.*advance/s, "Same-practice rollovers must preserve explicit connections.");
+assert.match(migration, /case when preserves_practice then current_experiment\.connection_type else 'independent'/, "Swapped practices must not inherit old links.");
+assert.match(migration, /Rollback:/, "Migration must document rollback behavior.");
+
+assert.match(activation, /practiceGoalOptions/, "Activation must load deterministic saved-goal options.");
+assert.match(activation, /choose_current_goal/, "Activation must reject stale or invented goal keys.");
+assert.match(activation, /connectionType\(Boolean\(selectedGoal\), keepsBlueprint\)/, "Activation must derive linkage only from explicit selections and stored Blueprint provenance.");
+assert.match(onboarding, /Why does this practice matter this week\?/, "Weekly setup must ask for the connection explicitly.");
+assert.match(onboarding, /Independent choice for this week/, "Members must be able to choose no goal link.");
+
+for (const [surface, source] of [["Today", today], ["Journey", journey], ["weekly review", review]]) {
+  assert.match(source, /Why (?:this matters|it mattered)/, `${surface} must explain the same explicit connection.`);
+}
+assert.match(brief, /explicit_practice_connection/, "The daily AI brief must receive the deterministic connection.");
+assert.match(member, /explicitly linked to a current saved goal/, "Canonical member context must expose current goal linkage.");
+assert.doesNotMatch(journey, /was your chosen focus/, "Journey must not infer why a practice mattered from identity text.");
+
+console.log("PR113 practice-connection architecture checks passed.");

--- a/src/_tests_/pr113PracticeConnection.assert.ts
+++ b/src/_tests_/pr113PracticeConnection.assert.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+
+import type { WeeklyExperiment } from "../lib/activation.ts";
+import type { ExperimentBlueprintContext } from "../lib/blueprintContext.ts";
+import {
+  connectionType,
+  practiceGoalOptions,
+  resolvePracticeConnection,
+} from "../lib/practiceConnection.ts";
+
+const goals = practiceGoalOptions({
+  id: "goal-row-1",
+  goals: ["Improve sleep", "Improve sleep", "Move consistently"],
+  custom_goal: null,
+  target_weight: 185,
+  target_sleep: null,
+  target_energy: 8,
+});
+
+assert.deepEqual(goals.map((goal) => goal.key), [
+  "named:improve-sleep",
+  "named:move-consistently",
+  "target:weight",
+  "target:energy",
+]);
+assert.equal(connectionType(false, false), "independent");
+assert.equal(connectionType(true, false), "goal");
+assert.equal(connectionType(false, true), "blueprint");
+assert.equal(connectionType(true, true), "both");
+
+const experiment = (overrides: Partial<WeeklyExperiment> = {}): WeeklyExperiment => ({
+  id: "experiment-1",
+  user_id: "member-1",
+  source_stack_id: null,
+  source_action_id: null,
+  connection_type: "independent",
+  goal_id: null,
+  goal_key: null,
+  goal_label_snapshot: null,
+  identity_direction: "sleep",
+  action_label: "Keep a consistent wake time",
+  cue: "turn off my alarm",
+  frequency_per_week: 5,
+  minimum_version: "Get out of bed",
+  reminder_preference: "none",
+  reminder_timing: "at_cue",
+  reminder_hour: null,
+  onboarding_step: 6,
+  status: "active",
+  week_start: "2026-08-10",
+  activated_at: "2026-08-10T12:00:00.000Z",
+  created_at: "2026-08-10T12:00:00.000Z",
+  updated_at: "2026-08-10T12:00:00.000Z",
+  ...overrides,
+});
+
+const blueprint: ExperimentBlueprintContext = {
+  source_stack_id: "stack-1",
+  source_action_id: "priority-1",
+  priority_label: "Keep a consistent wake time",
+  priority_category: "sleep",
+  priority_kind: "lifestyle",
+  blueprint_created_at: "2026-08-09T12:00:00.000Z",
+  is_current_blueprint: true,
+  needs_review: false,
+};
+
+const currentGoal = resolvePracticeConnection(experiment({
+  connection_type: "goal",
+  goal_id: "goal-row-1",
+  goal_key: "named:improve-sleep",
+  goal_label_snapshot: "Improve sleep",
+}), goals, null);
+assert.equal(currentGoal.goal?.status, "current");
+assert.equal(currentGoal.summary, "Supports saved goal: Improve sleep");
+
+const both = resolvePracticeConnection(experiment({
+  connection_type: "both",
+  source_stack_id: "stack-1",
+  source_action_id: "priority-1",
+  goal_id: "goal-row-1",
+  goal_key: "named:improve-sleep",
+  goal_label_snapshot: "Improve sleep",
+}), goals, blueprint);
+assert.equal(both.type, "both");
+assert.match(both.summary, /Supports saved goal: Improve sleep/);
+assert.match(both.summary, /Supports Blueprint priority: Keep a consistent wake time/);
+
+const removedGoal = resolvePracticeConnection(experiment({
+  connection_type: "goal",
+  goal_id: null,
+  goal_key: "named:old-goal",
+  goal_label_snapshot: "An earlier saved goal",
+}), goals, null);
+assert.equal(removedGoal.goal?.status, "historical");
+assert.match(removedGoal.summary, /An earlier saved goal/);
+
+const independent = resolvePracticeConnection(experiment({ action_label: "Improve sleep" }), goals, blueprint);
+assert.equal(independent.type, "independent");
+assert.equal(independent.goal, null, "Matching words must never create a goal link.");
+assert.equal(independent.blueprint, null, "Available Blueprint context must never create a link without stored provenance.");
+assert.equal(independent.summary, "Independently chosen for this week");
+
+console.log("PR113 explicit practice-connection scenarios passed.");

--- a/src/components/dashboard/TodayExperience.tsx
+++ b/src/components/dashboard/TodayExperience.tsx
@@ -22,6 +22,7 @@ import {
   type ExperimentBlueprintContext,
 } from "@/lib/blueprintContext";
 import { deriveTodayBlueprintNotice, type TodayBlueprintNotice } from "@/lib/todaySurface";
+import type { PracticeConnectionContext } from "@/lib/practiceConnection";
 
 type TodayResponse = {
   ok: boolean;
@@ -36,12 +37,14 @@ export default function TodayExperience({
   initialExperiment,
   blueprint,
   experimentBlueprint,
+  practiceConnection,
   initialCompletionDate,
   onCompletionStateChange,
 }: {
   initialExperiment: WeeklyExperiment | null;
   blueprint: CurrentBlueprintContext | null;
   experimentBlueprint: ExperimentBlueprintContext | null;
+  practiceConnection: PracticeConnectionContext | null;
   initialCompletionDate: string | null;
   onCompletionStateChange?: (complete: boolean) => void;
 }) {
@@ -184,6 +187,7 @@ export default function TodayExperience({
               <Sparkles className="h-4 w-4" /> This week&apos;s direction: {identityLabel(experiment.identity_direction)}
             </p>
             <h2 className="mt-3 text-3xl font-bold leading-tight text-[#041B2D] sm:text-4xl">{experiment.action_label}</h2>
+            {practiceConnection ? <p className="mt-3 rounded-xl bg-slate-50 px-3 py-2 text-sm font-semibold leading-6 text-slate-700 ring-1 ring-slate-200"><span className="text-[#087F72]">Why this matters:</span> {practiceConnection.summary}</p> : null}
             <p className="mt-4 text-base leading-7 text-slate-600">
               <strong className="text-[#041B2D]">Your cue:</strong> After I {experiment.cue}
             </p>

--- a/src/components/journey/JourneyDashboard.tsx
+++ b/src/components/journey/JourneyDashboard.tsx
@@ -28,6 +28,7 @@ import {
   type JourneySynthesis,
 } from "@/lib/journey";
 import { blueprintSafetyLabel, type CurrentBlueprintContext, type ExperimentBlueprintContext } from "@/lib/blueprintContext";
+import type { PracticeConnectionContext } from "@/lib/practiceConnection";
 
 type MetricKey = "sleep" | "energy" | "weight";
 
@@ -129,7 +130,7 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
 
       {data.blueprint ? <BlueprintJourneyContext blueprint={data.blueprint} /> : null}
 
-      {activeExperiment ? <CurrentChapter experiment={activeExperiment} blueprintContext={data.experiment_blueprints[activeExperiment.id] ?? null} completed={data.completions.filter((item) => item.experiment_id === activeExperiment.id).length} /> : (
+      {activeExperiment ? <CurrentChapter experiment={activeExperiment} connection={data.practice_connections[activeExperiment.id]} blueprintContext={data.experiment_blueprints[activeExperiment.id] ?? null} completed={data.completions.filter((item) => item.experiment_id === activeExperiment.id).length} /> : (
         <EmptyState
           title="Ready for a new focused week?"
           body="Your past weeks are saved below. Start another small experiment when you are ready."
@@ -162,6 +163,7 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
               key={experiment.id}
               experiment={experiment}
               blueprintContext={data.experiment_blueprints[experiment.id] ?? null}
+              connection={data.practice_connections[experiment.id]}
               review={data.reviews.find((item) => item.experiment_id === experiment.id) ?? null}
               completed={data.completions.filter((item) => item.experiment_id === experiment.id).length}
             />
@@ -206,7 +208,7 @@ function JourneyContent({ data }: { data: JourneyResponse }) {
         <LearningLoop
           reviews={completedReviews}
           experiments={data.experiments}
-          experimentBlueprints={data.experiment_blueprints}
+          practiceConnections={data.practice_connections}
           syntheses={data.syntheses}
         />
       </div>
@@ -309,14 +311,12 @@ function BlueprintJourneyContext({ blueprint }: { blueprint: CurrentBlueprintCon
   );
 }
 
-function BlueprintPracticeLink({ context, compact = false }: { context: ExperimentBlueprintContext | null; compact?: boolean }) {
-  if (!context?.priority_label) {
-    return <p className={`${compact ? "mt-2" : "mt-3"} text-xs font-semibold text-slate-500`}>Self-chosen practice. No Blueprint priority link recorded.</p>;
-  }
+function PracticeConnectionLabel({ connection, blueprintContext, compact = false }: { connection: PracticeConnectionContext | undefined; blueprintContext: ExperimentBlueprintContext | null; compact?: boolean }) {
+  if (!connection) return <p className={`${compact ? "mt-2" : "mt-3"} text-xs font-semibold text-slate-500`}>Practice connection unavailable.</p>;
   return (
-    <div className={`${compact ? "mt-2" : "mt-3"} rounded-xl ${context.needs_review ? "bg-amber-50 text-amber-900" : "bg-white text-slate-700"} p-3 text-xs leading-5`}>
-      <strong>{context.needs_review ? "Review against the current Blueprint:" : "Supports Blueprint priority:"}</strong> {context.priority_label}
-      {context.needs_review ? <span className="block mt-1">The practice was preserved and was not automatically changed.</span> : null}
+    <div className={`${compact ? "mt-2" : "mt-3"} rounded-xl ${blueprintContext?.needs_review ? "bg-amber-50 text-amber-900" : "bg-white text-slate-700"} p-3 text-xs leading-5`}>
+      <strong>Why it matters:</strong> {connection.summary}
+      {blueprintContext?.needs_review ? <span className="mt-1 block">The practice was preserved and was not automatically changed.</span> : null}
     </div>
   );
 }
@@ -330,7 +330,7 @@ function SummaryStat({ label, value }: { label: string; value: string }) {
   );
 }
 
-function CurrentChapter({ experiment, blueprintContext, completed }: { experiment: JourneyExperiment; blueprintContext: ExperimentBlueprintContext | null; completed: number }) {
+function CurrentChapter({ experiment, connection, blueprintContext, completed }: { experiment: JourneyExperiment; connection: PracticeConnectionContext | undefined; blueprintContext: ExperimentBlueprintContext | null; completed: number }) {
   const target = experiment.frequency_per_week ?? 1;
   return (
     <section aria-labelledby="current-chapter-title" className="rounded-3xl border border-[#BCE3DA] bg-[#F4FAF8] p-6 sm:p-8">
@@ -341,7 +341,7 @@ function CurrentChapter({ experiment, blueprintContext, completed }: { experimen
           <p className="mt-2 text-sm leading-6 text-slate-600">
             After: {experiment.cue || "your chosen cue"}. Minimum: {experiment.minimum_version || "your smallest version"}.
           </p>
-          <BlueprintPracticeLink context={blueprintContext} />
+          <PracticeConnectionLabel connection={connection} blueprintContext={blueprintContext} />
         </div>
         <div className="min-w-48">
           <p className="text-sm font-bold text-[#041B2D]">{completed} of {target} planned reps</p>
@@ -364,7 +364,7 @@ function CurrentChapter({ experiment, blueprintContext, completed }: { experimen
   );
 }
 
-function ExperimentCard({ experiment, blueprintContext, review, completed }: { experiment: JourneyExperiment; blueprintContext: ExperimentBlueprintContext | null; review: JourneyReview | null; completed: number }) {
+function ExperimentCard({ experiment, connection, blueprintContext, review, completed }: { experiment: JourneyExperiment; connection: PracticeConnectionContext | undefined; blueprintContext: ExperimentBlueprintContext | null; review: JourneyReview | null; completed: number }) {
   const target = review?.target_count ?? experiment.frequency_per_week ?? 1;
   return (
     <li className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
@@ -374,7 +374,7 @@ function ExperimentCard({ experiment, blueprintContext, review, completed }: { e
             Week of {formatDate(experiment.week_start)}. {domainLabel(experiment.identity_direction)}
           </p>
           <h3 className="mt-2 font-bold text-[#041B2D]">{experiment.action_label || "Focused weekly practice"}</h3>
-          <BlueprintPracticeLink context={blueprintContext} compact />
+          <PracticeConnectionLabel connection={connection} blueprintContext={blueprintContext} compact />
         </div>
         <span className={`w-fit rounded-full px-3 py-1 text-xs font-bold ${experiment.status === "active" ? "bg-[#DDF7F1] text-[#087F72]" : "bg-slate-200 text-slate-700"}`}>
           {experiment.status === "active" ? "In progress" : experiment.status === "completed" ? "Reviewed" : "Closed"}
@@ -479,7 +479,7 @@ function WinsTimeline({ reviews, completionTotal }: { reviews: JourneyReview[]; 
   );
 }
 
-function LearningLoop({ reviews, experiments, experimentBlueprints, syntheses }: { reviews: JourneyReview[]; experiments: JourneyExperiment[]; experimentBlueprints: Record<string, ExperimentBlueprintContext>; syntheses: JourneySynthesis[] }) {
+function LearningLoop({ reviews, experiments, practiceConnections, syntheses }: { reviews: JourneyReview[]; experiments: JourneyExperiment[]; practiceConnections: Record<string, PracticeConnectionContext>; syntheses: JourneySynthesis[] }) {
   const synthesisByExperiment = new Map(syntheses.map((item) => [item.experiment_id, item]));
   return (
     <section aria-labelledby="review-history-title" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -488,12 +488,12 @@ function LearningLoop({ reviews, experiments, experimentBlueprints, syntheses }:
         <ul className="mt-5 space-y-4">{reviews.map((review) => {
           const experiment = experiments.find((item) => item.id === review.experiment_id);
           const nextExperiment = experiments.find((item) => item.id === review.next_experiment_id) ?? null;
-          const context = experiment ? experimentBlueprints[experiment.id] ?? null : null;
+          const connection = experiment ? practiceConnections[experiment.id] : null;
           const synthesis = synthesisByExperiment.get(review.experiment_id) ?? null;
           return <li key={review.experiment_id} className="rounded-2xl bg-slate-50 p-4">
             <dl className="space-y-3 text-sm leading-6">
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Tried</dt><dd className="font-semibold text-[#041B2D]">{experiment?.action_label || "Weekly practice"}</dd></div>
-              <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Why it mattered</dt><dd className="text-slate-600">{context?.priority_label || `${domainLabel(experiment?.identity_direction ?? null)} was your chosen focus.`}</dd></div>
+              <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Why it mattered</dt><dd className="text-slate-600">{connection?.summary ?? "No explicit connection was recorded for this week."}</dd></div>
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Noticed</dt><dd className="text-slate-600">You reported usefulness {review.value_rating}/5 and difficulty {review.difficulty}/5 after {review.completion_count} of {review.target_count} planned reps.</dd></div>
               {synthesis ? <><div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Recorded observation</dt><dd className="text-slate-600">{synthesis.observation}</dd></div><div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Working hypothesis</dt><dd className="text-slate-600">{synthesis.hypothesis} <span className="font-semibold">This is a {synthesis.confidence}-confidence idea to test, not proof.</span></dd></div></> : null}
               <div><dt className="text-xs font-bold uppercase tracking-wide text-[#087F72]">Chose next</dt><dd className="text-slate-600">{review.decision ? DECISION_LABELS[review.decision] : "Reviewed"}{nextExperiment?.action_label ? `: ${nextExperiment.action_label}` : "."}</dd></div>

--- a/src/components/review/WeeklyReviewClient.tsx
+++ b/src/components/review/WeeklyReviewClient.tsx
@@ -6,12 +6,14 @@ import { ArrowLeft, ArrowRight, Check, Loader2, Pause, RefreshCw, Repeat2, Spark
 import type { WeeklyExperiment } from "@/lib/activation";
 import { suggestedNextPlan, type NextWeekPlan, type ReviewDecision } from "@/lib/weeklyReview";
 import type { WeeklySynthesis } from "@/lib/weeklySynthesis";
+import type { PracticeConnectionContext } from "@/lib/practiceConnection";
 
 type ReviewResponse = {
   ok: boolean;
   experiment?: WeeklyExperiment;
   completed?: number;
   target?: number;
+  practice_connection?: PracticeConnectionContext;
   error?: string;
 };
 
@@ -27,6 +29,7 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
   const [experiment, setExperiment] = useState<WeeklyExperiment | null>(null);
   const [completed, setCompleted] = useState(0);
   const [target, setTarget] = useState(1);
+  const [practiceConnection, setPracticeConnection] = useState<PracticeConnectionContext | null>(null);
   const [difficulty, setDifficulty] = useState(0);
   const [valueRating, setValueRating] = useState(0);
   const [decision, setDecision] = useState<ReviewDecision | null>(null);
@@ -50,6 +53,7 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
         setExperiment(json.experiment ?? null);
         setCompleted(json.completed ?? 0);
         setTarget(json.target ?? 1);
+        setPracticeConnection(json.practice_connection ?? null);
       })
       .catch((loadError: Error) => { if (!cancelled) setError(loadError.message); })
       .finally(() => { if (!cancelled) setLoading(false); });
@@ -121,6 +125,7 @@ export default function WeeklyReviewClient({ experimentId }: { experimentId: str
       <section className="mt-8 rounded-3xl bg-[#041B2D] p-6 text-white sm:p-8">
         <p className="text-sm font-semibold text-[#8DE5D5]">This week</p>
         <h2 className="mt-2 text-2xl font-bold">{experiment.action_label}</h2>
+        {practiceConnection ? <p className="mt-3 rounded-xl bg-white/10 px-4 py-3 text-sm leading-6 text-white/85"><strong className="text-white">Why it mattered:</strong> {practiceConnection.summary}</p> : null}
         <p className="mt-5 text-4xl font-bold">{completed} <span className="text-lg font-medium text-white/70">of {target} planned reps</span></p>
         <p className="mt-2 text-sm text-white/70">Every completed repetition counts, including the minimum version.</p>
       </section>
@@ -197,6 +202,7 @@ function NextPlanEditor({ plan, onChange, swap }: { plan: NextWeekPlan; onChange
   return (
     <section className="mt-8 rounded-3xl border border-[#BCE3DA] bg-[#F4FAF8] p-6 sm:p-8">
       <h2 className="text-xl font-bold text-[#041B2D]">{swap ? "Choose next week's practice" : "Your next week"}</h2>
+      {swap ? <p className="mt-2 text-sm leading-6 text-slate-600">A different practice starts as an independent choice. After this review, use Review practice in Today if you want to connect it to a saved goal.</p> : null}
       <label className="mt-5 block text-sm font-bold text-[#041B2D]">Practice<input value={plan.action_label} onChange={(event) => onChange({ ...plan, action_label: event.target.value })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal" /></label>
       <label className="mt-4 block text-sm font-bold text-[#041B2D]">After I...<input value={plan.cue} onChange={(event) => onChange({ ...plan, cue: event.target.value })} className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-4 py-3 font-normal" /></label>
       <div className="mt-4 grid gap-4 sm:grid-cols-[160px_1fr]">

--- a/src/lib/activation.ts
+++ b/src/lib/activation.ts
@@ -16,12 +16,17 @@ export const IDENTITY_OPTIONS = [
 export type IdentityDirection = (typeof IDENTITY_OPTIONS)[number]["value"];
 export type ReminderPreference = "none" | "email";
 export type ExperimentStatus = "draft" | "active" | "completed" | "archived";
+export type PracticeConnectionType = "independent" | "goal" | "blueprint" | "both";
 
 export type WeeklyExperiment = {
   id: string;
   user_id: string;
   source_stack_id: string | null;
   source_action_id: string | null;
+  connection_type: PracticeConnectionType;
+  goal_id: string | null;
+  goal_key: string | null;
+  goal_label_snapshot: string | null;
   identity_direction: IdentityDirection | null;
   action_label: string | null;
   cue: string | null;

--- a/src/lib/ai/todayBriefData.ts
+++ b/src/lib/ai/todayBriefData.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 
 import { identityLabel, type WeeklyExperiment } from "@/lib/activation";
 import { generateAI } from "@/lib/ai/gateway";
-import { getCurrentBlueprintContext } from "@/lib/currentBlueprintContext";
+import { getCurrentBlueprintContext, getExperimentBlueprintContexts } from "@/lib/currentBlueprintContext";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import { completionCount, weekBounds, type DailyPracticeCompletion } from "@/lib/today";
 import {
@@ -17,6 +17,7 @@ import {
 } from "@/lib/todayBrief";
 import { isReviewDue } from "@/lib/weeklyReview";
 import { isUrgentBlueprintSafety } from "@/lib/todaySurface";
+import { practiceGoalOptions, resolvePracticeConnection, type PracticeGoalRow } from "@/lib/practiceConnection";
 
 type TodayBriefRow = {
   id: string;
@@ -83,10 +84,16 @@ async function activeExperiment(userId: string): Promise<WeeklyExperiment | null
 }
 
 export async function buildTodayBriefContext(userId: string, localDate: string): Promise<TodayBriefContext> {
-  const [experiment, blueprint] = await Promise.all([
+  const [experiment, blueprint, { data: goals, error: goalsError }] = await Promise.all([
     activeExperiment(userId),
     getCurrentBlueprintContext(userId),
+    getSupabaseAdmin().from("goals").select("id,goals,custom_goal,target_weight,target_sleep,target_energy").eq("user_id", userId).maybeSingle(),
   ]);
+  if (goalsError) throw goalsError;
+  const blueprintContexts = experiment ? await getExperimentBlueprintContexts(userId, [experiment], blueprint) : {};
+  const connection = experiment
+    ? resolvePracticeConnection(experiment, practiceGoalOptions((goals as PracticeGoalRow | null) ?? null), blueprintContexts[experiment.id] ?? null)
+    : null;
 
   let completions: DailyPracticeCompletion[] = [];
   if (experiment) {
@@ -114,6 +121,7 @@ export async function buildTodayBriefContext(userId: string, localDate: string):
       target: experiment.frequency_per_week ?? 1,
       completed: completionCount(completions),
       completedToday: completions.some((item) => item.completion_date === localDate),
+      connectionSummary: connection?.summary ?? "Independently chosen for this week",
     } : null,
     blueprint: blueprint ? {
       stackId: blueprint.stack_id,
@@ -138,7 +146,7 @@ function generatedPrompt(context: TodayBriefContext) {
         "Return only valid JSON with exactly these string fields: noticed and why_it_matters.",
         "noticed must describe the supplied progress neutrally. Never use despite, failed, missed, behind, haven't, or should have.",
         "The weekly target counts completed days or repetitions. It is never the number of pushups, minutes, meals, or other units inside the saved practice.",
-        "why_it_matters must connect this repetition to consistency or the supplied identity direction. Do not invent a physiological, clinical, or performance benefit.",
+        "why_it_matters must explain the supplied explicit practice connection. Do not invent another goal, Blueprint link, or physiological, clinical, or performance benefit.",
       ].join(" "),
     },
     {
@@ -152,6 +160,7 @@ function generatedPrompt(context: TodayBriefContext) {
         weekly_target_repetitions: experiment.target,
         weekly_completed_repetitions: experiment.completed,
         metric_definition: "These numbers count completed practice repetitions this week, not units inside the practice.",
+        explicit_practice_connection: experiment.connectionSummary,
       }),
     },
   ];

--- a/src/lib/journey.ts
+++ b/src/lib/journey.ts
@@ -2,6 +2,10 @@ export type JourneyExperiment = {
   id: string;
   source_stack_id: string | null;
   source_action_id: string | null;
+  connection_type: import("@/lib/activation").PracticeConnectionType;
+  goal_id: string | null;
+  goal_key: string | null;
+  goal_label_snapshot: string | null;
   identity_direction: string | null;
   action_label: string | null;
   cue: string | null;
@@ -66,6 +70,7 @@ export type JourneyResponse = {
   syntheses: JourneySynthesis[];
   blueprint: import("@/lib/blueprintContext").CurrentBlueprintContext | null;
   experiment_blueprints: Record<string, import("@/lib/blueprintContext").ExperimentBlueprintContext>;
+  practice_connections: Record<string, import("@/lib/practiceConnection").PracticeConnectionContext>;
   error?: string;
 };
 

--- a/src/lib/memberContext.ts
+++ b/src/lib/memberContext.ts
@@ -64,6 +64,7 @@ export type MemberPreferencesContext = {
 };
 
 export type MemberGoalContext = {
+  key?: string;
   label: string;
   kind: "named" | "weight_target" | "sleep_target" | "energy_target";
   targetValue: number | null;
@@ -100,7 +101,7 @@ export type MemberRegimenContext = {
 };
 
 export type PracticeGoalLink = {
-  status: "linked" | "not_recorded";
+  status: "linked" | "historical" | "unresolved" | "not_recorded";
   goalLabel: string | null;
   explanation: string;
 };
@@ -186,6 +187,10 @@ export type MemberContextExperimentInput = {
   id: string;
   source_stack_id: string | null;
   source_action_id: string | null;
+  connection_type: "independent" | "goal" | "blueprint" | "both";
+  goal_id: string | null;
+  goal_key: string | null;
+  goal_label_snapshot: string | null;
   identity_direction: string | null;
   action_label: string | null;
   cue: string | null;
@@ -310,10 +315,20 @@ function practiceContext(
   reviews: MemberContextReviewInput[],
   completions: MemberContextCompletionInput[],
   blueprintContexts: Record<string, ExperimentBlueprintContext>,
+  savedGoals: MemberGoalContext[],
 ): MemberPracticeContext {
   const review = reviews.find((item) => item.experiment_id === experiment.id) ?? null;
   const recorded = completions.filter((item) => item.experiment_id === experiment.id);
   const blueprint = blueprintContexts[experiment.id] ?? null;
+  const currentGoal = experiment.goal_key ? savedGoals.find((goal) => goal.key === experiment.goal_key) ?? null : null;
+  const hasGoalLink = experiment.connection_type === "goal" || experiment.connection_type === "both";
+  const goalLink: PracticeGoalLink = hasGoalLink
+    ? currentGoal
+      ? { status: "linked", goalLabel: currentGoal.label, explanation: "This practice is explicitly linked to a current saved goal." }
+      : experiment.goal_label_snapshot
+        ? { status: "historical", goalLabel: experiment.goal_label_snapshot, explanation: "This practice retains the saved goal label recorded when the week was created." }
+        : { status: "unresolved", goalLabel: null, explanation: "A saved goal link is recorded, but its label could not be resolved." }
+    : { status: "not_recorded", goalLabel: null, explanation: "The member chose this practice independently of a saved goal." };
   let blueprintLink: PracticeBlueprintLink;
   if (!experiment.source_stack_id && !experiment.source_action_id) {
     blueprintLink = {
@@ -367,11 +382,7 @@ function practiceContext(
       status: review.status,
       completedAt: review.completed_at,
     } : null,
-    goalLink: {
-      status: "not_recorded",
-      goalLabel: null,
-      explanation: "The current schema does not store an explicit practice-to-saved-goal relation.",
-    },
+    goalLink,
     blueprintLink,
     provenance,
   };
@@ -446,7 +457,7 @@ export function buildMemberIntelligenceContext(input: MemberIntelligenceContextI
 
   const practices = [...input.experiments]
     .sort((left, right) => right.week_start.localeCompare(left.week_start) || right.updated_at.localeCompare(left.updated_at))
-    .map((experiment) => practiceContext(experiment, input.reviews, input.completions, input.practiceBlueprintContexts));
+    .map((experiment) => practiceContext(experiment, input.reviews, input.completions, input.practiceBlueprintContexts, input.savedGoals));
   const active = practices.find((practice) => practice.status === "active") ?? null;
   const activePractice = active
     ? section<MemberPracticeContext>(active, "present", latestTimestamp(active.provenance.map((item) => item.updatedAt)), active.provenance)

--- a/src/lib/memberContextData.ts
+++ b/src/lib/memberContextData.ts
@@ -14,6 +14,7 @@ import {
   type MemberIntelligenceContext,
   type MemberPreferencesContext,
 } from "@/lib/memberContext";
+import { practiceGoalOptions } from "@/lib/practiceConnection";
 import type { SafetyContext } from "@/lib/safetyEngine";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
@@ -121,16 +122,19 @@ function healthProfile(row: SubmissionRow | null, now: Date): (MemberHealthProfi
 function savedGoals(row: GoalsRow | null): MemberGoalContext[] {
   if (!row) return [];
   const provenance = { source: "goals" as const, recordId: row.id, updatedAt: row.updated_at };
-  const named = [...new Set([...readableValues(row.goals), ...readableValues(row.custom_goal)])]
-    .map((label): MemberGoalContext => ({ label, kind: "named", targetValue: null, provenance }));
-  const targets: MemberGoalContext[] = [];
-  const weight = numberOrNull(row.target_weight);
-  const sleep = numberOrNull(row.target_sleep);
-  const energy = numberOrNull(row.target_energy);
-  if (weight != null) targets.push({ label: "Target weight", kind: "weight_target", targetValue: weight, provenance });
-  if (sleep != null) targets.push({ label: "Target sleep", kind: "sleep_target", targetValue: sleep, provenance });
-  if (energy != null) targets.push({ label: "Target energy", kind: "energy_target", targetValue: energy, provenance });
-  return [...named, ...targets];
+  const values: Record<string, number | null> = {
+    weight_target: numberOrNull(row.target_weight),
+    sleep_target: numberOrNull(row.target_sleep),
+    energy_target: numberOrNull(row.target_energy),
+    named: null,
+  };
+  return practiceGoalOptions(row).map((goal): MemberGoalContext => ({
+    key: goal.key,
+    label: goal.label,
+    kind: goal.kind,
+    targetValue: values[goal.kind],
+    provenance,
+  }));
 }
 
 function preferences(row: PreferencesRow | null): (MemberPreferencesContext & { updatedAt: string | null }) | null {
@@ -173,7 +177,7 @@ export async function getMemberIntelligenceContext(userId: string): Promise<Memb
     getCurrentBlueprintContext(userId),
     getCurrentRegimen(userId),
     admin.from("weekly_experiments")
-      .select("id,source_stack_id,source_action_id,identity_direction,action_label,cue,frequency_per_week,minimum_version,status,week_start,created_at,updated_at")
+      .select("id,source_stack_id,source_action_id,connection_type,goal_id,goal_key,goal_label_snapshot,identity_direction,action_label,cue,frequency_per_week,minimum_version,status,week_start,created_at,updated_at")
       .eq("user_id", userId).order("week_start", { ascending: false }).limit(12),
     admin.from("logs").select("id,log_date,weight,sleep,energy,updated_at")
       .eq("user_id", userId).order("log_date", { ascending: false }).limit(30),

--- a/src/lib/practiceConnection.ts
+++ b/src/lib/practiceConnection.ts
@@ -1,0 +1,118 @@
+import type { WeeklyExperiment } from "./activation";
+import type { ExperimentBlueprintContext } from "./blueprintContext";
+
+export type PracticeGoalRow = {
+  id: string;
+  goals: unknown;
+  custom_goal: string | null;
+  target_weight: number | string | null;
+  target_sleep: number | string | null;
+  target_energy: number | string | null;
+};
+
+export type PracticeGoalOption = {
+  key: string;
+  label: string;
+  kind: "named" | "weight_target" | "sleep_target" | "energy_target";
+};
+
+export type PracticeConnectionContext = {
+  type: WeeklyExperiment["connection_type"];
+  goal: {
+    key: string | null;
+    label: string | null;
+    status: "current" | "historical" | "unresolved";
+  } | null;
+  blueprint: {
+    label: string | null;
+    status: "current" | "historical" | "unresolved";
+  } | null;
+  summary: string;
+};
+
+function cleanLabel(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return value.replace(/\s+/g, " ").trim().slice(0, 160) || null;
+}
+
+function readableValues(value: unknown): string[] {
+  if (value == null) return [];
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).split(/[,;|\n]/).map(cleanLabel).filter((item): item is string => Boolean(item));
+  }
+  if (Array.isArray(value)) return [...new Set(value.flatMap(readableValues))];
+  if (typeof value === "object") return [...new Set(Object.values(value as Record<string, unknown>).flatMap(readableValues))];
+  return [];
+}
+
+function goalKey(label: string): string {
+  const normalized = label.toLowerCase().normalize("NFKD").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 100);
+  return `named:${normalized || "goal"}`;
+}
+
+function numberOrNull(value: number | string | null): number | null {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function practiceGoalOptions(row: PracticeGoalRow | null): PracticeGoalOption[] {
+  if (!row) return [];
+  const result: PracticeGoalOption[] = [];
+  const seen = new Set<string>();
+  for (const label of [...readableValues(row.goals), ...readableValues(row.custom_goal)]) {
+    const key = goalKey(label);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ key, label, kind: "named" });
+  }
+  const weight = numberOrNull(row.target_weight);
+  const sleep = numberOrNull(row.target_sleep);
+  const energy = numberOrNull(row.target_energy);
+  if (weight != null) result.push({ key: "target:weight", label: "Reach target weight", kind: "weight_target" });
+  if (sleep != null) result.push({ key: "target:sleep", label: "Reach target sleep", kind: "sleep_target" });
+  if (energy != null) result.push({ key: "target:energy", label: "Reach target energy", kind: "energy_target" });
+  return result;
+}
+
+export function connectionType(hasGoal: boolean, hasBlueprint: boolean): WeeklyExperiment["connection_type"] {
+  if (hasGoal && hasBlueprint) return "both";
+  if (hasGoal) return "goal";
+  if (hasBlueprint) return "blueprint";
+  return "independent";
+}
+
+export function resolvePracticeConnection(
+  experiment: Pick<WeeklyExperiment, "connection_type" | "goal_key" | "goal_label_snapshot" | "source_stack_id" | "source_action_id">,
+  goals: PracticeGoalOption[],
+  blueprint: ExperimentBlueprintContext | null,
+): PracticeConnectionContext {
+  const hasStoredGoal = experiment.connection_type === "goal" || experiment.connection_type === "both";
+  const currentGoal = hasStoredGoal && experiment.goal_key
+    ? goals.find((option) => option.key === experiment.goal_key) ?? null
+    : null;
+  const goal = hasStoredGoal ? {
+    key: experiment.goal_key,
+    label: currentGoal?.label ?? experiment.goal_label_snapshot,
+    status: currentGoal ? "current" as const : experiment.goal_label_snapshot ? "historical" as const : "unresolved" as const,
+  } : null;
+  const hasStoredBlueprint = experiment.connection_type === "blueprint" || experiment.connection_type === "both";
+  const blueprintLink = hasStoredBlueprint ? {
+    label: blueprint?.priority_label ?? null,
+    status: blueprint?.priority_label
+      ? blueprint.is_current_blueprint ? "current" as const : "historical" as const
+      : "unresolved" as const,
+  } : null;
+
+  const reasons = [
+    goal?.label ? `Supports saved goal: ${goal.label}` : goal ? "Saved goal link needs review" : null,
+    blueprintLink?.label ? `Supports Blueprint priority: ${blueprintLink.label}` : blueprintLink ? "Blueprint priority link needs review" : null,
+  ].filter((item): item is string => Boolean(item));
+
+  return {
+    type: experiment.connection_type,
+    goal,
+    blueprint: blueprintLink,
+    summary: reasons.length ? reasons.join(" · ") : "Independently chosen for this week",
+  };
+}

--- a/src/lib/todayBrief.ts
+++ b/src/lib/todayBrief.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const TODAY_BRIEF_PROMPT_VERSION = "today-brief-v3";
+export const TODAY_BRIEF_PROMPT_VERSION = "today-brief-v4";
 
 export type TodayBriefPrimaryAction =
   | "mark_complete"
@@ -19,6 +19,7 @@ export type TodayBriefContext = {
     target: number;
     completed: number;
     completedToday: boolean;
+    connectionSummary: string;
   } | null;
   blueprint: {
     stackId: string;
@@ -145,7 +146,7 @@ export function deterministicTodayBrief(context: TodayBriefContext): TodayBriefC
     noticed: remaining === 1
       ? "One more repetition will keep your promise for this week."
       : `You have completed ${context.experiment.completed} of ${context.experiment.target} planned repetitions this week.`,
-    whyItMatters: `This is one vote for ${context.experiment.identity.toLowerCase()}.`,
+    whyItMatters: context.experiment.connectionSummary,
     nextAction: context.experiment.actionLabel,
     minimumVersion: context.experiment.minimumVersion,
     primaryAction: "mark_complete",

--- a/supabase/migrations/20260816000245_pr113_practice_connections.sql
+++ b/supabase/migrations/20260816000245_pr113_practice_connections.sql
@@ -1,0 +1,151 @@
+alter table public.weekly_experiments
+  add column connection_type text not null default 'independent',
+  add column goal_id uuid references public.goals(id) on delete set null,
+  add column goal_key text,
+  add column goal_label_snapshot text;
+
+update public.weekly_experiments
+set
+  connection_type = case
+    when source_stack_id is not null and source_action_id is not null then 'blueprint'
+    else 'independent'
+  end,
+  source_stack_id = case when source_stack_id is not null and source_action_id is not null then source_stack_id else null end,
+  source_action_id = case when source_stack_id is not null and source_action_id is not null then source_action_id else null end;
+
+alter table public.weekly_experiments
+  add constraint weekly_experiments_connection_type_check
+    check (connection_type in ('independent', 'goal', 'blueprint', 'both')),
+  add constraint weekly_experiments_goal_connection_check
+    check (
+      (connection_type in ('goal', 'both') and goal_key is not null and goal_label_snapshot is not null)
+      or (connection_type in ('independent', 'blueprint') and goal_id is null and goal_key is null and goal_label_snapshot is null)
+    ),
+  add constraint weekly_experiments_blueprint_connection_check
+    check (
+      (connection_type in ('blueprint', 'both') and source_stack_id is not null and source_action_id is not null)
+      or (connection_type in ('independent', 'goal') and source_stack_id is null and source_action_id is null)
+    ),
+  add constraint weekly_experiments_goal_key_length check (goal_key is null or char_length(goal_key) between 1 and 120),
+  add constraint weekly_experiments_goal_label_length check (goal_label_snapshot is null or char_length(goal_label_snapshot) between 1 and 160);
+
+create index weekly_experiments_goal_id_idx
+  on public.weekly_experiments(goal_id)
+  where goal_id is not null;
+
+create or replace function public.complete_weekly_review(
+  p_user_id uuid,
+  p_experiment_id uuid,
+  p_difficulty smallint,
+  p_value_rating smallint,
+  p_decision text,
+  p_action_label text default null,
+  p_cue text default null,
+  p_frequency_per_week smallint default null,
+  p_minimum_version text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  current_experiment public.weekly_experiments%rowtype;
+  next_id uuid;
+  completed_reps smallint;
+  next_week_start date;
+  preserves_practice boolean;
+begin
+  if p_difficulty not between 1 and 5
+    or p_value_rating not between 1 and 5
+    or p_decision not in ('keep', 'shrink', 'swap', 'pause', 'advance') then
+    raise exception 'invalid_review';
+  end if;
+
+  select * into current_experiment
+  from public.weekly_experiments
+  where id = p_experiment_id and user_id = p_user_id and status = 'active'
+  for update;
+
+  if not found then raise exception 'active_experiment_not_found'; end if;
+  if current_date < current_experiment.week_start + 6 then raise exception 'review_not_due'; end if;
+  if exists (
+    select 1 from public.weekly_experiment_reviews
+    where experiment_id = p_experiment_id and status = 'completed'
+  ) then raise exception 'review_already_completed'; end if;
+
+  select count(distinct completion_date)::smallint into completed_reps
+  from public.daily_practice_completions
+  where user_id = p_user_id
+    and experiment_id = p_experiment_id
+    and completion_date between current_experiment.week_start and current_experiment.week_start + 6;
+
+  update public.weekly_experiments
+  set status = 'completed', completed_at = now(), updated_at = now()
+  where id = p_experiment_id;
+
+  if p_decision <> 'pause' then
+    if p_action_label is null or char_length(btrim(p_action_label)) not between 4 and 240
+      or p_cue is null or char_length(btrim(p_cue)) not between 2 and 160
+      or p_frequency_per_week not between 1 and 7
+      or p_minimum_version is null or char_length(btrim(p_minimum_version)) not between 2 and 160 then
+      raise exception 'invalid_next_experiment';
+    end if;
+
+    next_week_start := greatest(current_experiment.week_start + 7, date_trunc('week', current_date)::date);
+    preserves_practice := p_decision in ('keep', 'shrink', 'advance');
+
+    insert into public.weekly_experiments (
+      user_id, source_stack_id, source_action_id,
+      connection_type, goal_id, goal_key, goal_label_snapshot,
+      identity_direction, action_label, cue, frequency_per_week, minimum_version,
+      reminder_preference, reminder_timing, reminder_hour,
+      onboarding_step, status, week_start, activated_at
+    ) values (
+      p_user_id,
+      case when preserves_practice then current_experiment.source_stack_id else null end,
+      case when preserves_practice then current_experiment.source_action_id else null end,
+      case when preserves_practice then current_experiment.connection_type else 'independent' end,
+      case when preserves_practice then current_experiment.goal_id else null end,
+      case when preserves_practice then current_experiment.goal_key else null end,
+      case when preserves_practice then current_experiment.goal_label_snapshot else null end,
+      current_experiment.identity_direction,
+      btrim(p_action_label), btrim(p_cue), p_frequency_per_week, btrim(p_minimum_version),
+      current_experiment.reminder_preference, current_experiment.reminder_timing,
+      current_experiment.reminder_hour, 6, 'active', next_week_start, now()
+    ) returning id into next_id;
+  end if;
+
+  insert into public.weekly_experiment_reviews (
+    user_id, experiment_id, completion_count, target_count, difficulty,
+    value_rating, decision, status, next_experiment_id, completed_at, updated_at
+  ) values (
+    p_user_id, p_experiment_id, completed_reps, current_experiment.frequency_per_week,
+    p_difficulty, p_value_rating, p_decision, 'completed', next_id, now(), now()
+  ) on conflict (experiment_id) do update set
+    completion_count = excluded.completion_count,
+    target_count = excluded.target_count,
+    difficulty = excluded.difficulty,
+    value_rating = excluded.value_rating,
+    decision = excluded.decision,
+    status = 'completed',
+    next_experiment_id = excluded.next_experiment_id,
+    completed_at = excluded.completed_at,
+    updated_at = excluded.updated_at;
+
+  return next_id;
+end;
+$$;
+
+revoke all on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  from public, anon, authenticated;
+grant execute on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text)
+  to service_role;
+
+comment on function public.complete_weekly_review(uuid, uuid, smallint, smallint, text, text, text, smallint, text) is
+  'Completes a weekly review and preserves explicit goal and Blueprint connections only when the member keeps, shrinks, or advances the same practice.';
+
+-- Rollback: restore the complete_weekly_review definition from
+-- 20260801233949_preserve_blueprint_journey_rollover.sql, then drop
+-- weekly_experiments_goal_id_idx, the five PR113 constraints, and the four
+-- PR113 columns. Rolling back removes explicit practice-connection history.


### PR DESCRIPTION
## Summary
- add an explicit weekly-practice connection: saved goal, Blueprint priority, both, or independently chosen
- let members choose the saved-goal connection during weekly setup without inferring it from similar wording
- use one deterministic connection across Today, Journey, weekly review, canonical member context, and the AI Today Brief
- preserve connections only when a member keeps, shrinks, or advances the same practice; swaps start independently

## Why
PR113 closes the missing link between what a member says they want, what their Blueprint prioritizes, and what they practice this week. The application can now explain why a practice matters without inventing a relationship.

## Safety boundaries
- no medication, hormone, supplement, diagnosis, treatment, or dose changes
- AI receives the saved deterministic connection and cannot create a new goal or Blueprint link
- deleted or renamed goals remain historical snapshots rather than being silently rematched
- text similarity never creates linkage

## Database migration
- adds four additive columns and constraints to `weekly_experiments`
- backfills existing Blueprint-provenance rows as Blueprint-linked and all other rows as independent
- updates weekly-review rollover to preserve linkage only for the same practice
- includes rollback notes
- **not applied to the shared Supabase project yet; apply before authenticated Preview QA**

## Validation
- `npm.cmd run typecheck`
- `npm.cmd run qa:pr113`
- regression checks passed: PR79, PR80, PR94, PR95, PR96, PR100, PR101, PR108, PR109, PR110, PR112, and Journey
- Next.js compiled successfully; local prerender stopped at `/login` only because this checkout lacks `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. Vercel Preview is the authoritative full build.

## Manual QA after migration
1. Open **Review practice** from Today.
2. Keep the practice independent, save, and confirm Today/Journey/review say it was independently chosen.
3. Edit again, connect a saved goal, and confirm every surface uses the same goal label.
4. Start from a Blueprint lifestyle priority, optionally add a saved goal, and confirm the combined connection.
5. Change the practice text and confirm the old Blueprint connection is removed.
6. Complete a weekly review with Keep and confirm the link carries forward; use Swap and confirm the new week starts independently.